### PR TITLE
Do not deploy tck and docs module

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -29,6 +29,10 @@
 
   <name>SmallRye: MicroProfile Config Documentation</name>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -29,6 +29,10 @@
 
   <name>SmallRye: MicroProfile Config TCK</name>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Skip the 2 modules when smallrye-config artifacts are deployed in Maven
repository.

This fixes #3.