### PR TITLE
Fixes #11: Consistent ConfigSource order

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -211,6 +211,12 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
                 if ( v1 < v2 ) {
                     return +1;
                 }
+                // if 2 config sources have the same ordinal,
+                // provide consistent order by sorting them
+                // according to their name.
+                if (o2.getName() != null && o1.getName() != null) {
+                    return o2.getName().compareTo(o1.getName());
+                }
                 return 0;
             }
         });


### PR DESCRIPTION
Sort ConfigSource with the same ordinal according to their names.

Issue: https://github.com/smallrye/smallrye-config/issues/11