### PR TITLE
Fixes #16: Remove java.time classes from supported types

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -83,11 +83,7 @@ public class ConfigExtension implements Extension {
                         && ip.getType() != Float.class
                         && ip.getType() != Float.TYPE
                         && ip.getType() != Double.class
-                        && ip.getType() != Double.TYPE
-                        && ip.getType() != Duration.class
-                        && ip.getType() != LocalDate.class
-                        && ip.getType() != LocalTime.class
-                        && ip.getType() != LocalDateTime.class)
+                        && ip.getType() != Double.TYPE)
                 .map(ip -> (Class) ip.getType())
                 .collect(Collectors.toSet());
         types.forEach(type -> abd.addBean(new ConfigInjectionBean(bm, type)));


### PR DESCRIPTION
java.time classes are supported by implicit converters and should no
longer be listed in the types supported by the ConfigProducer.

Issue: https://github.com/smallrye/smallrye-config/issues/16