### PR TITLE
Invalid content in DirConfigSource [#21]

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/implementation/src/main/java/io/smallrye/config/DirConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/DirConfigSource.java
@@ -24,11 +24,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.jboss.logging.Logger;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
 public class DirConfigSource implements ConfigSource {
+
+    private static final Logger LOG = Logger.getLogger(DirConfigSource.class);
 
     private static final int DEFAULT_ORDINAL = 100;
 
@@ -59,9 +62,8 @@ public class DirConfigSource implements ConfigSource {
                 String key = file.getName();
                 String value = readContent(file);
                 props.put(key, value);
-            } catch (IOException e) {
-                e.printStackTrace();
-                // should log some errors...
+            } catch (Throwable t) {
+                LOG.warnf("Unable to read content from file %s", file.getAbsolutePath());
             }
         }
         return props;

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <version.junit>4.11</version.junit>
     <version.org.jboss.arquillian>1.1.13.Final</version.org.jboss.arquillian>
     <version.org.jboss.arquillian.container.weld-embedded>2.0.0.Beta5</version.org.jboss.arquillian.container.weld-embedded>
-    <version.org.jboss.logging>2.0.1.Final</version.org.jboss.logging>
+    <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.weld>2.3.SP2</version.org.jboss.weld>
     <version.org.jboss.weld.core.impl>2.3.5.Final</version.org.jboss.weld.core.impl>
     <version.org.testng>6.9.9</version.org.testng>
@@ -84,13 +84,8 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>
-        <artifactId>jboss-logging-annotations</artifactId>
-        <version>${version.org.jboss.logging}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.logging</groupId>
-        <artifactId>jboss-logging-processor</artifactId>
-        <version>${version.org.jboss.logging}</version>
+        <artifactId>jboss-logging</artifactId>
+        <version>${version.org.jboss.logging.jboss-logging}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
* catch Throwable when file content is read to catch both checked and
  unchecked exceptions
* add dependency to org.jboss.logging:jboss-logging:3.3.1.Final
* log a warning if the file content can not be read

Issue: https://github.com/smallrye/smallrye-config/issues/21