### PR TITLE
[#27] Encapsulates each deployment problem in a ConfigException

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigException.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.config.inject;
+
+public class ConfigException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    String configPropertyName;
+
+    public ConfigException(String configPropertyName, String message) {
+        super(message);
+        this.configPropertyName = configPropertyName;
+    }
+
+    public ConfigException(String configPropertyName, String message, Throwable cause) {
+        super(message, cause);
+        this.configPropertyName = configPropertyName;
+    }
+
+    public String getConfigPropertyName() {
+        return configPropertyName;
+    }
+
+}

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigException.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigException.java
@@ -16,6 +16,12 @@
 
 package io.smallrye.config.inject;
 
+/**
+ * A relatively generic Exception that encapsulates the configuration
+ * property's name.
+ * 
+ * @author Steve Moyer - The Pennsylvania State University
+ */
 public class ConfigException extends Exception {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
As discussed in #27, this code change collects _all_ exceptions that happen during the CDI validation phase (missing required parameters and ``IllegalArgumentException``s thrown by ``Converter``s and adds them to the CDI container as deployment problems (``Throwable``s).  The CDI container will encapsulate these problems into a ``DeploymentException`` once all ``@Observer``s of the ``AfterDeploymentValidation`` event have processed the environment.