### PR TITLE
sm - add string interpolation

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/StringInterpolator.java
+++ b/implementation/src/main/java/io/smallrye/config/StringInterpolator.java
@@ -1,0 +1,30 @@
+package io.smallrye.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Provide string interpolation of mp-config variables
+ * @author kg6zvp
+ */
+public class StringInterpolator {
+    public static final Pattern configPattern = Pattern.compile("\\$\\{(.*?)\\}");
+
+    public static String interpolate(String value) {
+        Matcher m = configPattern.matcher(value);
+        Map<String, String> vars = new HashMap<>();
+        while(m.find()) {
+            String varName = m.group(1);
+            vars.put(varName, ConfigProvider.getConfig().getValue(varName, String.class));
+        }
+        String outputString = value;
+        for(String key : vars.keySet()) {
+            outputString = outputString.replaceAll(Pattern.quote("${" + key + "}"), vars.get(key));
+        }
+        return outputString;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/StringInterpolatorTestCase.java
+++ b/implementation/src/test/java/io/smallrye/config/StringInterpolatorTestCase.java
@@ -1,0 +1,17 @@
+package io.smallrye.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author kg6zvp
+ */
+public class StringInterpolatorTestCase {
+    @Test
+    public void testInterpolation() {
+        System.setProperty("prop.value", "twinkie");
+        System.setProperty("other_value", "pretzel");
+        assertEquals("twinkie-settings-pretzel", StringInterpolator.interpolate("${prop.value}-settings-${other_value}"));
+    }
+}


### PR DESCRIPTION
I believe there are many use cases for the ability to interpolate strings in configuration files and other places.

This pull request adds the ability to transform this:

`<property name="javax..action" value="${jpa.database.action}"/>`

into this:

`<property name="javax..action" value="none"/>`

### Justification

This belongs in smallrye-config because, even though it isn't directly useful as a part of microprofile-config, it will be useful in other projects utilizing smallrye-config and provides a common place for the code to reside.

If this seems like the wrong place for it, I would be happy to integrate this small change into Thorntail directly.