### PR TITLE
Reuse smallrye producer implementation

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -42,6 +42,7 @@ class Converters {
                     || "JA".equalsIgnoreCase(value)
                     || "J".equalsIgnoreCase(value)
                     || "SI".equalsIgnoreCase(value)
+                    || "SIM".equalsIgnoreCase(value)
                     || "OUI".equalsIgnoreCase(value);
         }
         return null;

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -33,11 +33,12 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
 
-import io.smallrye.config.StringUtil;
-import io.smallrye.config.SmallRyeConfig;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.StringUtil;
 
 /**
  * CDI producer for {@link Config} bean.
@@ -156,7 +157,7 @@ public class ConfigProducer implements Serializable{
 
     private <T> Class<T> unwrapType(Type type) {
         if (type instanceof ParameterizedType) {
-            type = ((ParameterizedType) type).getRawType();
+            type = ((ParameterizedType) type).getActualTypeArguments()[0];
         }
         return (Class<T>) type;
     }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -16,29 +16,18 @@
 
 package io.smallrye.config.inject;
 
-import static io.smallrye.config.SecuritySupport.getContextClassLoader;
-
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
+import java.io.Serializable;
+import java.util.*;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import io.smallrye.config.SmallRyeConfig;
-import io.smallrye.config.StringUtil;
+import static io.smallrye.config.SecuritySupport.getContextClassLoader;
 
 /**
  * CDI producer for {@link Config} bean.
@@ -57,152 +46,55 @@ public class ConfigProducer implements Serializable{
     @Dependent
     @Produces @ConfigProperty
     String produceStringConfigProperty(InjectionPoint ip) {
-        return getValue(ip, String.class);
+        return ConfigProducerUtil.getValue(ip, String.class, getConfig(ip));
     }
 
     @Dependent
     @Produces @ConfigProperty
     Long getLongValue(InjectionPoint ip) {
-        return getValue(ip, Long.class);
+        return ConfigProducerUtil.getValue(ip, Long.class, getConfig(ip));
     }
 
     @Dependent
     @Produces @ConfigProperty
     Integer getIntegerValue(InjectionPoint ip) {
-        return getValue(ip, Integer.class);
+        return ConfigProducerUtil.getValue(ip, Integer.class, getConfig(ip));
     }
 
     @Dependent
     @Produces @ConfigProperty
     Float produceFloatConfigProperty(InjectionPoint ip) {
-        return getValue(ip, Float.class);
+        return ConfigProducerUtil.getValue(ip, Float.class, getConfig(ip));
     }
 
     @Dependent
     @Produces @ConfigProperty
     Double produceDoubleConfigProperty(InjectionPoint ip) {
-        return getValue(ip, Double.class);
+        return ConfigProducerUtil.getValue(ip, Double.class, getConfig(ip));
     }
 
     @Dependent
     @Produces @ConfigProperty
     Boolean produceBooleanConfigProperty(InjectionPoint ip) {
-        return getValue(ip, Boolean.class);
+        return ConfigProducerUtil.getValue(ip, Boolean.class, getConfig(ip));
     }
 
-    @SuppressWarnings("unchecked")
     @Dependent
     @Produces @ConfigProperty
     <T> Optional<T> produceOptionalConfigValue(InjectionPoint injectionPoint) {
-        Type type = injectionPoint.getAnnotated().getBaseType();
-        final Class<T> valueType;
-        if (type instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-
-            Type[] typeArguments = parameterizedType.getActualTypeArguments();
-            valueType = unwrapType(typeArguments[0]);
-        } else {
-            valueType = (Class<T>) String.class;
-        }
-        return Optional.ofNullable(getValue(injectionPoint, valueType));
+        return ConfigProducerUtil.optionalConfigValue(injectionPoint, getConfig(injectionPoint));
     }
 
     @Dependent
     @Produces @ConfigProperty
     <T> Set<T> producesSetConfigPropery(InjectionPoint ip) {
-        Type type = ip.getAnnotated().getBaseType();
-        final Class<T> valueType;
-        if (type instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-
-            Type[] typeArguments = parameterizedType.getActualTypeArguments();
-            valueType = unwrapType(typeArguments[0]);
-        } else {
-            valueType = (Class<T>) String.class;
-        }
-        HashSet<T> s = new HashSet<>();
-        String stringValue = getValue(ip, String.class);
-        String[] split = StringUtil.split(stringValue);
-        Config config = getConfig(ip);
-        for(int i = 0 ; i < split.length ; i++) {
-            T item = ((SmallRyeConfig) config).convert(split[i], valueType);
-            s.add(item);
-        }
-        return s;
+        return ConfigProducerUtil.setConfigProperty(ip, getConfig(ip));
     }
 
     @Dependent
     @Produces @ConfigProperty
     <T> List<T> producesListConfigPropery(InjectionPoint ip) {
-        Type type = ip.getAnnotated().getBaseType();
-        final Class<T> valueType;
-        if (type instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) type;
-
-            Type[] typeArguments = parameterizedType.getActualTypeArguments();
-            valueType = unwrapType(typeArguments[0]);
-        } else {
-            valueType = (Class<T>) String.class;
-        }
-        ArrayList<T> s = new ArrayList<>();
-        String stringValue = getValue(ip, String.class);
-        String[] split = StringUtil.split(stringValue);
-        Config config = getConfig(ip);
-        for(int i = 0 ; i < split.length ; i++) {
-            T item = ((SmallRyeConfig) config).convert(split[i], valueType);
-            s.add(item);
-        }
-        return s;
-    }
-
-    private <T> Class<T> unwrapType(Type type) {
-        if (type instanceof ParameterizedType) {
-            type = ((ParameterizedType) type).getActualTypeArguments()[0];
-        }
-        return (Class<T>) type;
-    }
-
-    private <T> T getValue
-            (InjectionPoint injectionPoint, Class<T> target) {
-        Config config = getConfig(injectionPoint);
-        String name = getName(injectionPoint);
-        try {
-            if (name == null) {
-                return null;
-            }
-            Optional<T> optionalValue = config.getOptionalValue(name, target);
-            if (optionalValue.isPresent()) {
-                return optionalValue.get();
-            } else {
-                String defaultValue = getDefaultValue(injectionPoint);
-                if (defaultValue != null && !defaultValue.equals(ConfigProperty.UNCONFIGURED_VALUE)) {
-                    return ((SmallRyeConfig)config).convert(defaultValue, target);
-                } else {
-                    return null;
-                }
-            }
-        } catch (RuntimeException e) {
-            return null;
-        }
-    }
-
-    private String getName(InjectionPoint injectionPoint) {
-        for (Annotation qualifier : injectionPoint.getQualifiers()) {
-            if (qualifier.annotationType().equals(ConfigProperty.class)) {
-                ConfigProperty configProperty = ((ConfigProperty)qualifier);
-                return ConfigExtension.getConfigKey(injectionPoint, configProperty);
-            }
-        }
-        return null;
-    }
-
-    private String getDefaultValue(InjectionPoint injectionPoint) {
-        for (Annotation qualifier : injectionPoint.getQualifiers()) {
-            if (qualifier.annotationType().equals(ConfigProperty.class)) {
-                return ((ConfigProperty) qualifier).defaultValue();
-            }
-        }
-        return null;
+        return ConfigProducerUtil.listConfigProperty(ip, getConfig(ip));
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -88,13 +88,13 @@ public class ConfigProducer implements Serializable{
     @Dependent
     @Produces @ConfigProperty
     <T> Set<T> producesSetConfigPropery(InjectionPoint ip) {
-        return ConfigProducerUtil.setConfigProperty(ip, getConfig(ip));
+        return ConfigProducerUtil.collectionConfigProperty(ip, getConfig(ip), new HashSet<>());
     }
 
     @Dependent
     @Produces @ConfigProperty
     <T> List<T> producesListConfigPropery(InjectionPoint ip) {
-        return ConfigProducerUtil.listConfigProperty(ip, getConfig(ip));
+        return ConfigProducerUtil.collectionConfigProperty(ip, getConfig(ip), new ArrayList<T>());
     }
 
 }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -1,0 +1,122 @@
+package io.smallrye.config.inject;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.StringUtil;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+
+/**
+ * Actual implementations for producer method in CDI producer {@link ConfigProducer}.
+ *
+ * @author <a href="https://github.com/guhilling">Gunnar Hilling</a>
+ */
+public class ConfigProducerUtil {
+
+    private ConfigProducerUtil() {
+    }
+
+    public static <T> Optional<T> optionalConfigValue(InjectionPoint injectionPoint, Config config) {
+        Type type = injectionPoint.getAnnotated().getBaseType();
+        final Class<T> valueType;
+        valueType = resolveValueType(type);
+        return Optional.ofNullable(getValue(injectionPoint, valueType, config));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> resolveValueType(Type type) {
+        Class<T> valueType;
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+
+            Type[] typeArguments = parameterizedType.getActualTypeArguments();
+            valueType = unwrapType(typeArguments[0]);
+        } else {
+            valueType = (Class<T>) String.class;
+        }
+        return valueType;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Set<T> setConfigProperty(InjectionPoint injectionPoint, Config config) {
+        Type type = injectionPoint.getAnnotated().getBaseType();
+        final Class<T> valueType = resolveValueType(type);
+        HashSet<T> s = new HashSet<>();
+        String stringValue = getValue(injectionPoint, String.class, config);
+        String[] split = StringUtil.split(stringValue);
+        for (String aSplit : split) {
+            T item = ((SmallRyeConfig) config).convert(aSplit, valueType);
+            s.add(item);
+        }
+        return s;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> listConfigProperty(InjectionPoint injectionPoint, Config config) {
+        Type type = injectionPoint.getAnnotated().getBaseType();
+        final Class<T> valueType = resolveValueType(type);
+        ArrayList<T> s = new ArrayList<>();
+        String stringValue = getValue(injectionPoint, String.class, config);
+        String[] split = StringUtil.split(stringValue);
+        for (String aSplit : split) {
+            T item = ((SmallRyeConfig) config).convert(aSplit, valueType);
+            s.add(item);
+        }
+        return s;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> unwrapType(Type type) {
+        if (type instanceof ParameterizedType) {
+            type = ((ParameterizedType) type).getRawType();
+        }
+        return (Class<T>) type;
+    }
+
+    public static <T> T getValue
+            (InjectionPoint injectionPoint, Class<T> target, Config config) {
+        String name = getName(injectionPoint);
+        try {
+            if (name == null) {
+                return null;
+            }
+            Optional<T> optionalValue = config.getOptionalValue(name, target);
+            if (optionalValue.isPresent()) {
+                return optionalValue.get();
+            } else {
+                String defaultValue = getDefaultValue(injectionPoint);
+                if (defaultValue != null && !defaultValue.equals(ConfigProperty.UNCONFIGURED_VALUE)) {
+                    return ((SmallRyeConfig) config).convert(defaultValue, target);
+                } else {
+                    return null;
+                }
+            }
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    public static String getName(InjectionPoint injectionPoint) {
+        for (Annotation qualifier : injectionPoint.getQualifiers()) {
+            if (qualifier.annotationType().equals(ConfigProperty.class)) {
+                ConfigProperty configProperty = ((ConfigProperty)qualifier);
+                return ConfigExtension.getConfigKey(injectionPoint, configProperty);
+            }
+        }
+        return null;
+    }
+
+    private static String getDefaultValue(InjectionPoint injectionPoint) {
+        for (Annotation qualifier : injectionPoint.getQualifiers()) {
+            if (qualifier.annotationType().equals(ConfigProperty.class)) {
+                return ((ConfigProperty) qualifier).defaultValue();
+            }
+        }
+        return null;
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -57,7 +57,7 @@ public class ConfigProducerUtil {
     @SuppressWarnings("unchecked")
     private static <T> Class<T> unwrapType(Type type) {
         if (type instanceof ParameterizedType) {
-            type = ((ParameterizedType) type).getRawType();
+            type = ((ParameterizedType) type).getActualTypeArguments()[0];
         }
         return (Class<T>) type;
     }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -42,32 +42,16 @@ public class ConfigProducerUtil {
         return valueType;
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T> Set<T> setConfigProperty(InjectionPoint injectionPoint, Config config) {
+    public static <C extends Collection<T>, T> C collectionConfigProperty(InjectionPoint injectionPoint, Config config, C collection) {
         Type type = injectionPoint.getAnnotated().getBaseType();
         final Class<T> valueType = resolveValueType(type);
-        HashSet<T> s = new HashSet<>();
         String stringValue = getValue(injectionPoint, String.class, config);
         String[] split = StringUtil.split(stringValue);
         for (String aSplit : split) {
             T item = ((SmallRyeConfig) config).convert(aSplit, valueType);
-            s.add(item);
+            collection.add(item);
         }
-        return s;
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <T> List<T> listConfigProperty(InjectionPoint injectionPoint, Config config) {
-        Type type = injectionPoint.getAnnotated().getBaseType();
-        final Class<T> valueType = resolveValueType(type);
-        ArrayList<T> s = new ArrayList<>();
-        String stringValue = getValue(injectionPoint, String.class, config);
-        String[] split = StringUtil.split(stringValue);
-        for (String aSplit : split) {
-            T item = ((SmallRyeConfig) config).convert(aSplit, valueType);
-            s.add(item);
-        }
-        return s;
+        return collection;
     }
 
     @SuppressWarnings("unchecked")

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderBeanWithList.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderBeanWithList.java
@@ -1,0 +1,19 @@
+package io.smallrye.config.test.provider;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public class ProviderBeanWithList {
+
+    @Inject
+    @ConfigProperty(name="objectIds", defaultValue="")
+    Provider<List<String>> objectdIds;
+
+    @Inject
+    @ConfigProperty(name="numbers", defaultValue="")
+    Provider<List<Integer>> numbers;
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderWithListTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderWithListTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.config.test.provider;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Test that configuration is injected into Provider.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class ProviderWithListTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "ProviderTest.jar")
+                .addClasses(ProviderWithListTest.class, Email.class, ProviderBeanWithList.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(new StringAsset(
+                        "objectIds=a,b,c\nnumbers=4,5,6"
+                ), "microprofile-config.properties")
+                .as(JavaArchive.class);
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "ProviderTest.war")
+                .addAsLibrary(testJar);
+        return war;
+    }
+
+    @Inject
+    private ProviderBeanWithList bean;
+
+
+    @Test
+    public void testProvider() {
+        Provider<List<String>> provider = bean.objectdIds;
+        assertNotNull(provider);
+        List<String> stuff = provider.get();
+        assertNotNull(stuff);
+        assertEquals(stuff.size(), 3);
+        assertEquals(stuff.get(0), "a");
+        assertEquals(stuff.get(1), "b");
+        assertEquals(stuff.get(2), "c");
+
+        Provider<List<Integer>> numberProvider = bean.numbers;
+        assertNotNull(numberProvider);
+        List<Integer> numbers = numberProvider.get();
+        assertNotNull(numbers);
+        assertEquals(numbers.size(), 3);
+        assertEquals((int)numbers.get(0), 4);
+
+    }
+}


### PR DESCRIPTION
I’m currently working on extending my junit5 testing-framework for cdi (https://github.com/guhilling/cdi-test) for eclipse microprofile.
To accomplish this I’ll provide an annotation to inject config values on a per-test basis as follows:

    @Test
    @ConfigPropertyValue(name = "some.string.property", value = "value method b")
    public void overrideValuesInMethod() {
        Assertions.assertEquals("value method b", controller.getStringProperty());

I think, you get the idea… The code is already working and you can find it at https://github.com/guhilling/cdi-test-microprofile .
As you would have guessed, I’m using smallrye-config behing the scenes. Now I got the problem that I have to duplicate some of the code from the ConfigProducer class because I need to create a new Config Instance for each test case.

The pull request solves my problem and I also removed some duplications...