### PR TITLE
Treat empty list values as missing

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -16,20 +16,22 @@
 
 package io.smallrye.config;
 
+import java.util.regex.Pattern;
+
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
 public class StringUtil {
 
     // delimiter is a comma that is not preceded by a \
-    private static final String DELIMITER = "(?<!\\\\),+";
+    private static final Pattern DELIMITER = Pattern.compile("(?<!\\\\),+");
     private static final String[] NO_STRINGS = new String[0];
 
     public static String[] split(String text) {
         if (text == null || text.isEmpty()) {
             return NO_STRINGS;
         }
-        String[] split = text.split(DELIMITER);
+        String[] split = DELIMITER.split(text);
         for (int i = 0 ;i < split.length ; i++) {
             split[i] = split[i].replace("\\,", ",");
         }

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -35,7 +35,7 @@ public class StringUtil {
         }
         text = LEADING_COMMAS.matcher(text).replaceAll("");
         String[] split = DELIMITER.split(text);
-        if (split.length == 0) {
+        if (split.length == 0 || split.length == 1 && split[0].isEmpty()) {
             return NO_STRINGS;
         }
         for (int i = 0 ;i < split.length ; i++) {

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -23,10 +23,11 @@ public class StringUtil {
 
     // delimiter is a comma that is not preceded by a \
     private static final String DELIMITER = "(?<!\\\\),";
+    private static final String[] NO_STRINGS = new String[0];
 
     public static String[] split(String text) {
         if (text == null) {
-            return new String[0];
+            return NO_STRINGS;
         }
         String[] split = text.split(DELIMITER);
         for (int i = 0 ;i < split.length ; i++) {

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -22,7 +22,7 @@ package io.smallrye.config;
 public class StringUtil {
 
     // delimiter is a comma that is not preceded by a \
-    private static final String DELIMITER = "(?<!\\\\),";
+    private static final String DELIMITER = "(?<!\\\\),+";
     private static final String[] NO_STRINGS = new String[0];
 
     public static String[] split(String text) {

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -26,6 +26,7 @@ public class StringUtil {
     // delimiter is a comma that is not preceded by a \
     private static final Pattern DELIMITER = Pattern.compile("(?<!\\\\),+");
     private static final String[] NO_STRINGS = new String[0];
+    private static final Pattern ESCAPED_COMMA = Pattern.compile("\\\\,");
 
     public static String[] split(String text) {
         if (text == null || text.isEmpty()) {
@@ -33,7 +34,7 @@ public class StringUtil {
         }
         String[] split = DELIMITER.split(text);
         for (int i = 0 ;i < split.length ; i++) {
-            split[i] = split[i].replace("\\,", ",");
+            split[i] = ESCAPED_COMMA.matcher(split[i]).replaceAll(",");
         }
         return split;
     }

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -27,12 +27,17 @@ public class StringUtil {
     private static final Pattern DELIMITER = Pattern.compile("(?<!\\\\),+");
     private static final String[] NO_STRINGS = new String[0];
     private static final Pattern ESCAPED_COMMA = Pattern.compile("\\\\,");
+    private static final Pattern LEADING_COMMAS = Pattern.compile("^,+");
 
     public static String[] split(String text) {
         if (text == null || text.isEmpty()) {
             return NO_STRINGS;
         }
+        text = LEADING_COMMAS.matcher(text).replaceAll("");
         String[] split = DELIMITER.split(text);
+        if (split.length == 0) {
+            return NO_STRINGS;
+        }
         for (int i = 0 ;i < split.length ; i++) {
             split[i] = ESCAPED_COMMA.matcher(split[i]).replaceAll(",");
         }

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -16,6 +16,7 @@
 
 package io.smallrye.config;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -38,8 +39,15 @@ public class StringUtil {
         if (split.length == 0 || split.length == 1 && split[0].isEmpty()) {
             return NO_STRINGS;
         }
-        for (int i = 0 ;i < split.length ; i++) {
-            split[i] = ESCAPED_COMMA.matcher(split[i]).replaceAll(",");
+        final Matcher ecMatcher = ESCAPED_COMMA.matcher(split[0]);
+        if (ecMatcher.find()) {
+            split[0] = ecMatcher.replaceAll(",");
+        }
+        for (int i = 1; i < split.length; i++) {
+            ecMatcher.reset(split[i]);
+            if (ecMatcher.find()) {
+                split[i] = ecMatcher.replaceAll(",");
+            }
         }
         return split;
     }

--- a/implementation/src/main/java/io/smallrye/config/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/StringUtil.java
@@ -26,7 +26,7 @@ public class StringUtil {
     private static final String[] NO_STRINGS = new String[0];
 
     public static String[] split(String text) {
-        if (text == null) {
+        if (text == null || text.isEmpty()) {
             return NO_STRINGS;
         }
         String[] split = text.split(DELIMITER);

--- a/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
@@ -34,4 +34,14 @@ public class StringUtilTest {
         assertEquals("medium:chicken", split[1]);
         assertEquals("small:pepperoni", split[2]);
     }
+
+    @Test
+    public void testTrailingSegmentsIgnored() {
+        String text = "foo,bar,baz,,,,,";
+        final String[] split = StringUtil.split(text);
+        assertEquals(3, split.length);
+        assertEquals("foo", split[0]);
+        assertEquals("bar", split[1]);
+        assertEquals("baz", split[2]);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
@@ -64,4 +64,11 @@ public class StringUtilTest {
         assertEquals("bar", split[1]);
         assertEquals("baz", split[2]);
     }
+
+    @Test
+    public void testAllEmptySegments() {
+        String text = ",,,,,";
+        final String[] split = StringUtil.split(text);
+        assertEquals(0, split.length);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
@@ -44,4 +44,14 @@ public class StringUtilTest {
         assertEquals("bar", split[1]);
         assertEquals("baz", split[2]);
     }
+
+    @Test
+    public void testLeadingSegmentsIgnored() {
+        String text = ",,,,,,,,foo,bar,baz";
+        final String[] split = StringUtil.split(text);
+        assertEquals(3, split.length);
+        assertEquals("foo", split[0]);
+        assertEquals("bar", split[1]);
+        assertEquals("baz", split[2]);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
@@ -54,4 +54,14 @@ public class StringUtilTest {
         assertEquals("bar", split[1]);
         assertEquals("baz", split[2]);
     }
+
+    @Test
+    public void testMidSegmentsIgnored() {
+        String text = "foo,,,,bar,,,baz";
+        final String[] split = StringUtil.split(text);
+        assertEquals(3, split.length);
+        assertEquals("foo", split[0]);
+        assertEquals("bar", split[1]);
+        assertEquals("baz", split[2]);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
@@ -71,4 +71,11 @@ public class StringUtilTest {
         final String[] split = StringUtil.split(text);
         assertEquals(0, split.length);
     }
+
+    @Test
+    public void testTwoEmptySegments() {
+        String text = ",";
+        final String[] split = StringUtil.split(text);
+        assertEquals(0, split.length);
+    }
 }

--- a/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/StringUtilTest.java
@@ -78,4 +78,9 @@ public class StringUtilTest {
         final String[] split = StringUtil.split(text);
         assertEquals(0, split.length);
     }
+
+    @Test
+    public void testEmptyString() {
+        assertEquals(0, StringUtil.split("").length);
+    }
 }


### PR DESCRIPTION
Fixes #83, fixes #84.  Makes handling of an empty string and empty list items consistent with the existing equivalency between an empty string and a `null` or missing value.