### PR TITLE
unmodified properties in the ConfigSource and small refactoring

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -35,6 +35,7 @@ import java.util.function.IntFunction;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import io.smallrye.config.utils.StringUtil;
 import org.eclipse.microprofile.config.spi.Converter;
 
 /**

--- a/implementation/src/main/java/io/smallrye/config/PropertiesConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertiesConfigSource.java
@@ -25,41 +25,47 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import io.smallrye.config.utils.ConfigSourceUtil;
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import static io.smallrye.config.utils.ConfigSourceUtil.CONFIG_ORDINAL_KEY;
+import static io.smallrye.config.utils.ConfigSourceUtil.CONFIG_ORDINAL_100;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
 public class PropertiesConfigSource implements ConfigSource, Serializable {
 
-    private static final String CONFIG_ORDINAL_KEY = "config_ordinal";
-    private static final String CONFIG_ORDINAL_DEFAULT_VALUE = "100";
-
     private final Map<String, String> properties;
     private final String source;
     private final int ordinal;
 
+    /**
+     * Construct a new instance
+     *
+     * @param url a property file location
+     * @throws IOException if an error occurred when reading from the input stream
+     */
     public PropertiesConfigSource(URL url) throws IOException {
         this.source = url.toString();
         try (InputStream in = url.openStream()) {
             Properties p = new Properties();
             p.load(in);
-            properties = new HashMap(p);
+            properties = ConfigSourceUtil.propertiesToMap(p);
         }
-        this.ordinal = Integer.valueOf(properties.getOrDefault(CONFIG_ORDINAL_KEY, CONFIG_ORDINAL_DEFAULT_VALUE));
+        this.ordinal = Integer.valueOf(properties.getOrDefault(CONFIG_ORDINAL_KEY, CONFIG_ORDINAL_100));
     }
 
     public PropertiesConfigSource(Properties properties, String source) {
-        this.properties = new HashMap(properties);
+        this.properties = ConfigSourceUtil.propertiesToMap(properties);
         this.source = source;
-        this.ordinal = Integer.valueOf(properties.getProperty(CONFIG_ORDINAL_KEY, CONFIG_ORDINAL_DEFAULT_VALUE));
+        this.ordinal = Integer.valueOf(properties.getProperty(CONFIG_ORDINAL_KEY, CONFIG_ORDINAL_100));
     }
 
     public PropertiesConfigSource(Map<String, String> properties, String source, int ordinal) {
-        this.properties = new HashMap(properties);
+        this.properties = new HashMap<>(properties);
         this.source = source;
         if (properties.containsKey(CONFIG_ORDINAL_KEY)) {
-            this.ordinal = Integer.valueOf(properties.getOrDefault(CONFIG_ORDINAL_KEY, CONFIG_ORDINAL_DEFAULT_VALUE));
+            this.ordinal = Integer.valueOf(properties.getOrDefault(CONFIG_ORDINAL_KEY, CONFIG_ORDINAL_100));
         } else {
             this.ordinal = ordinal;
         }

--- a/implementation/src/main/java/io/smallrye/config/SysPropConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/SysPropConfigSource.java
@@ -16,14 +16,16 @@
 
 package io.smallrye.config;
 
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
 import java.io.Serializable;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
-import org.eclipse.microprofile.config.spi.ConfigSource;
+import static io.smallrye.config.utils.ConfigSourceUtil.propertiesToMap;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
@@ -35,8 +37,9 @@ class SysPropConfigSource implements ConfigSource, Serializable {
 
     @Override
     public Map<String, String> getProperties() {
-        Properties properties = AccessController.doPrivileged((PrivilegedAction<Properties>) System::getProperties);
-        return (Map<String, String>) new HashMap(properties);
+
+        return Collections.unmodifiableMap(
+                propertiesToMap(AccessController.doPrivileged((PrivilegedAction<Properties>) System::getProperties)));
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -11,7 +11,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.smallrye.config.SmallRyeConfig;
-import io.smallrye.config.StringUtil;
+import io.smallrye.config.utils.StringUtil;
 
 /**
  * Actual implementations for producer method in CDI producer {@link ConfigProducer}.

--- a/implementation/src/main/java/io/smallrye/config/utils/ConfigSourceUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/utils/ConfigSourceUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.config.utils;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/**
+ * utilities and constants for {@link ConfigSource} implementations
+ *
+ * @author helloween
+ */
+public class ConfigSourceUtil {
+    public static final String CONFIG_ORDINAL_KEY = "config_ordinal";
+    public static final String CONFIG_ORDINAL_100 = "100";
+
+    private ConfigSourceUtil() {
+    }
+
+    /**
+     * convert {@link Properties} to {@link Map}
+     *
+     * @param properties {@link Properties} object
+     * @return {@link Map} object
+     */
+    public static Map<String, String> propertiesToMap(Properties properties) {
+        return properties.entrySet().stream().collect(Collectors.toMap(e -> String.valueOf(e.getKey()),
+                e -> String.valueOf(e.getValue())));
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/utils/StringUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/utils/StringUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.smallrye.config;
+package io.smallrye.config.utils;
 
 import java.util.ArrayList;
 import java.util.regex.Matcher;
@@ -28,6 +28,9 @@ public class StringUtil {
     private static final String[] NO_STRINGS = new String[0];
 
     private static final Pattern ITEM_PATTERN = Pattern.compile("(,+)|([^\\\\,]+)|\\\\(.)");
+
+    private StringUtil() {
+    }
 
     public static String[] split(String text) {
         if (text == null || text.isEmpty()) {

--- a/implementation/src/test/java/io/smallrye/config/utils/ConfigSourceUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/utils/ConfigSourceUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.config.utils;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
+/**
+ */
+public class ConfigSourceUtilTest {
+
+    @Test
+    public void propertiesToMap() {
+        Properties properties = new Properties();
+        properties.put("my.key1", "my.value1");
+        properties.put("my.key2", "my.value2");
+        properties.put("my.key3", 2);
+
+        Map<String, String> map = ConfigSourceUtil.propertiesToMap(properties);
+        assertEquals("my.value1", map.get("my.key1"));
+        assertEquals("my.value2", map.get("my.key2"));
+        assertEquals("2", map.get("my.key3"));
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/utils/StringUtilTest.java
+++ b/implementation/src/test/java/io/smallrye/config/utils/StringUtilTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package io.smallrye.config;
-
-import static org.junit.Assert.assertEquals;
+package io.smallrye.config.utils;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.


### PR DESCRIPTION
https://github.com/eclipse/microprofile-config/blob/4611c9433675e34ee73bd1eba026e01631582772/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java#L39

> A ConfigSource is always read-only, any potential updates of the configured values must be handled directly inside each ConfigSource.