### PR TITLE
Deprecate ConfigFactory

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigFactory.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigFactory.java
@@ -10,7 +10,10 @@ import org.eclipse.microprofile.config.spi.Converter;
 
 /**
  * Created by bob on 6/26/18.
+ *
+ * @deprecated This interface should no longer be used.
  */
+@Deprecated
 public interface ConfigFactory {
     Config newConfig(List<ConfigSource> sources, Map<Type, Converter<?>> configConverters);
 }

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -201,6 +201,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         return newConfig(sources, configConverters);
     }
 
+    @SuppressWarnings("deprecation")
     protected Config newConfig(List<ConfigSource> sources, Map<Type, Converter<?>> configConverters) {
         ServiceLoader<ConfigFactory> factoryLoader = ServiceLoader.load(ConfigFactory.class, this.classLoader);
         Iterator<ConfigFactory> iter = factoryLoader.iterator();


### PR DESCRIPTION
This interface is not really useful anymore.  A custom subclass of `SmallRyeConfig` can be created by subclassing `SmallRyeConfigBuilder`.  A custom implementation of `Config` doesn't need to be created by the SmallRye API.

By ultimately removing this interface, the `io.smallrye.config.SmallRyeConfigBuilder#build` can be made to covariantly return `SmallRyeConfig`.