### PR TITLE
Add HOCON configuration file format support

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -19,6 +19,7 @@ In addition to the features provided by MicroProfile Config, smallrye-config pro
  creates a ConfigSource that will look into a directory where each file corresponds to a property (the file name is the property key and its textual content is the property value).
  This ConfigSource can be used to read configuration from https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap[Kubernetes ConfigMap].
 * https://github.com/smallrye/smallrye-config/tree/master/config-sources/zookeeper[ZkMicroProfileConfig] creates a ConfigSource that is backed by Apache Zookeeper
+* https://github.com/smallrye/smallrye-config/blob/master/sources/hocon[HoconConfigSource] Creates a ConfigSource from configuration files in https://github.com/lightbend/config/blob/master/HOCON.md[HOCON] format.
 
 [[more-resources]]
 == More Resources

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <module>implementation</module>
     <module>testsuite</module>
     <module>docs</module>
+    <module>sources/hocon</module>
     <module>sources/zookeeper</module>
     <module>converters/json</module>
     <module>utils/events</module>

--- a/sources/hocon/Readme.adoc
+++ b/sources/hocon/Readme.adoc
@@ -1,0 +1,26 @@
+= HOCON source config
+
+Implementation of a https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc[MicroProfile ConfigSource] to support https://github.com/lightbend/config/blob/master/HOCON.md[HOCON] file format.
+
+Using the MicroProfile Configuration API is a really convenient way to configure your application.
+The standard MicroProfile Configuration Sources are Environment Variables, System Variables and via a microprofile-config.properties file in the Classpath.
+This project adds an additional source which reads microprofile-config.conf file in HOCON format.
+
+== Usage
+
+To use the HOCON MicroProfile Config source, add the following to your Maven `pom.xml`
+
+```xml
+<dependency>
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-source-hocon</artifactId>
+    <version>1.3.10-SNAPSHOT</version>
+</dependency>
+```
+
+This Configuration Source will be looking for the following files in this order of priority:
+
+1. `META-INF/microprofile-config.conf`
+2. `WEB-INF/classes/META-INF/microprofile-config.conf`
+
+These configuration files have a lower priority than the default sources.

--- a/sources/hocon/pom.xml
+++ b/sources/hocon/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>smallrye-config-parent</artifactId>
+        <groupId>io.smallrye</groupId>
+        <version>1.3.10-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-source-hocon</artifactId>
+    <name>SmallRye: HOCON ConfigSource</name>
+
+    <properties>
+        <lightbend-config.version>1.3.4</lightbend-config.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>${lightbend-config.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <argLine>@{jacocoArgLine}</argLine>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/sources/hocon/src/main/java/io/smallrye/configsource/HoconConfigSource.java
+++ b/sources/hocon/src/main/java/io/smallrye/configsource/HoconConfigSource.java
@@ -1,0 +1,54 @@
+package io.smallrye.configsource;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import com.typesafe.config.Config;
+
+import io.smallrye.config.PropertiesConfigSource;
+
+public class HoconConfigSource implements ConfigSource, Serializable {
+    private final String source;
+    private final PropertiesConfigSource delegate;
+
+    public HoconConfigSource(Config config, String source, int ordinal) {
+        this.source = source;
+        this.delegate = new PropertiesConfigSource(Collections.unmodifiableMap(config.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> config.getString(entry.getKey())))), source, ordinal);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return this.delegate.getProperties();
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return this.delegate.getPropertyNames();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return delegate.getOrdinal();
+    }
+
+    @Override
+    public String getValue(String s) {
+        return delegate.getValue(s);
+    }
+
+    @Override
+    public String getName() {
+        return "HoconConfigSource[source=" + source + "]";
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/sources/hocon/src/main/java/io/smallrye/configsource/HoconConfigSourceProvider.java
+++ b/sources/hocon/src/main/java/io/smallrye/configsource/HoconConfigSourceProvider.java
@@ -1,0 +1,31 @@
+package io.smallrye.configsource;
+
+import java.util.*;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigSyntax;
+
+public class HoconConfigSourceProvider implements ConfigSourceProvider {
+
+    private static final String META_INF_MICROPROFILE_CONFIG_RESOURCE = "META-INF/microprofile-config.conf";
+    private static final String WEB_INF_MICROPROFILE_CONFIG_RESOURCE = "WEB-INF/classes/META-INF/microprofile-config.conf";
+
+    static ConfigSource getConfigSource(ClassLoader classLoader, String resource, int ordinal) {
+        final Config config = ConfigFactory.parseResourcesAnySyntax(classLoader, resource,
+                ConfigParseOptions.defaults().setClassLoader(classLoader).setSyntax(ConfigSyntax.CONF));
+        return new HoconConfigSource(config, resource, ordinal);
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
+        final List<ConfigSource> configSources = new ArrayList<>(2);
+        configSources.add(getConfigSource(classLoader, META_INF_MICROPROFILE_CONFIG_RESOURCE, 60));
+        configSources.add(getConfigSource(classLoader, WEB_INF_MICROPROFILE_CONFIG_RESOURCE, 50));
+        return Collections.unmodifiableList(configSources);
+    }
+}

--- a/sources/hocon/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
+++ b/sources/hocon/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
@@ -1,0 +1,1 @@
+io.smallrye.configsource.HoconConfigSourceProvider

--- a/sources/hocon/src/test/java/io/smallrye/configsource/HoconConfigSourceTest.java
+++ b/sources/hocon/src/test/java/io/smallrye/configsource/HoconConfigSourceTest.java
@@ -1,0 +1,23 @@
+package io.smallrye.configsource;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.Test;
+
+public class HoconConfigSourceTest {
+
+    @Test
+    public void testHocon() {
+        final ConfigSource configSource = HoconConfigSourceProvider.getConfigSource(
+                Thread.currentThread().getContextClassLoader(), "hocon/microprofile-config.conf", 100);
+        assertEquals(HoconConfigSource.DEFAULT_ORDINAL, configSource.getOrdinal());
+        assertArrayEquals(new String[] { "hello.world", "hello.foo.bar" }, configSource.getPropertyNames().toArray());
+        assertArrayEquals(new String[] { "hello.world", "hello.foo.bar" }, configSource.getPropertyNames().toArray());
+        assertEquals("1", configSource.getValue("hello.world"));
+        assertEquals("Hell yeah!", configSource.getValue("hello.foo.bar"));
+        assertEquals(2, configSource.getProperties().entrySet().size());
+        assertEquals("1", configSource.getProperties().get("hello.world"));
+        assertEquals("Hell yeah!", configSource.getProperties().get("hello.foo.bar"));
+    }
+}

--- a/sources/hocon/src/test/resources/hocon/microprofile-config.conf
+++ b/sources/hocon/src/test/resources/hocon/microprofile-config.conf
@@ -1,0 +1,6 @@
+hello {
+  world = 1
+  foo {
+    bar = "Hell yeah!"
+  }
+}


### PR DESCRIPTION
Using Lightbend's config library to support HOCON file format. I disabled much of what the lib can do (config file merge...), I limited it to looks at these files only:
- `META-INF/microprofile-config.conf`
- `WEB-INF/classes/META-INF/microprofile-config.conf`

The default ordinal for these files is `60` and `50`, which is lower than their `.properties` counterparts, therefore not overwriting them.

Fixes #160.