### PR TITLE
Donation from MicroProfile-ext: Abstract, File, Dynamic and Yaml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,23 @@
     <module>implementation</module>
     <module>testsuite</module>
     <module>docs</module>
-    <module>sources/hocon</module>
-    <module>sources/zookeeper</module>
+    
+    <!-- Config Converters -->
     <module>converters/json</module>
+    
+    <!-- Base Config Sources -->
+    <module>sources/abstract</module>
+    <module>sources/abstract-file</module>
+    
+    <!-- Utils -->
     <module>utils/events</module>
     <module>utils/cdi-provider</module>
+    <module>utils/dynamic</module>
+    
+    <!-- Config sources -->
+    <module>sources/yaml</module>
+    <module>sources/hocon</module>
+    <module>sources/zookeeper</module>
   </modules>
 
   <dependencyManagement>

--- a/sources/abstract-file/pom.xml
+++ b/sources/abstract-file/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-config-parent</artifactId>
+        <version>1.3.10-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-source-abstract-file</artifactId>
+
+    <name>SmallRye: MicroProfile Config Source - Abstract File</name>
+    <description>A config that provides default behavior for file based sources</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-config-source-abstract</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project> 

--- a/sources/abstract-file/src/main/java/io/smallrye/config/source/file/AbstractUrlBasedSource.java
+++ b/sources/abstract-file/src/main/java/io/smallrye/config/source/file/AbstractUrlBasedSource.java
@@ -1,0 +1,143 @@
+package io.smallrye.config.source.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.smallrye.config.source.EnabledConfigSource;
+
+/**
+ * URL Based property files
+ * 
+ * Load some file from a file and convert to properties.
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+public abstract class AbstractUrlBasedSource extends EnabledConfigSource {
+    private static final Logger LOG = Logger.getLogger(AbstractUrlBasedSource.class.getName());
+
+    private final LinkedHashMap<URL, Map<String, String>> propertiesMap = new LinkedHashMap<>();
+    private final Map<String, String> properties = new HashMap<>();
+    private final List<URL> urls;
+    private final String keySeparator;
+
+    public AbstractUrlBasedSource() {
+        LOG.log(Level.INFO, "Loading [{0}] MicroProfile ConfigSource", getClass().getSimpleName());
+        this.keySeparator = loadPropertyKeySeparator();
+        this.urls = loadUrls();
+        super.initOrdinal(500);
+    }
+
+    @Override
+    protected Map<String, String> getPropertiesIfEnabled() {
+        return this.properties;
+    }
+
+    @Override
+    public String getValue(String key) {
+        // in case we are about to configure ourselves we simply ignore that key
+        if (super.isEnabled() && !key.startsWith(getPrefix())) {
+            return this.properties.get(key);
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return getClassKeyPrefix();
+    }
+
+    public List<URL> getUrlList() {
+        return this.urls;
+    }
+
+    public void reload(URL url) {
+        initialLoad(url);
+        mergeProperties();
+    }
+
+    private void initialLoad(URL url) {
+        try (InputStream inputStream = url.openStream()) {
+            if (inputStream != null) {
+                this.propertiesMap.put(url, toMap(inputStream));
+            }
+        } catch (IOException e) {
+            LOG.log(Level.WARNING, "Unable to read URL [{0}] - {1}", new Object[] { url, e.getMessage() });
+        }
+    }
+
+    protected String getKeySeparator() {
+        return this.keySeparator;
+    }
+
+    private List<URL> loadUrls() {
+        String inputConfig = config.getOptionalValue(getPrefixWithKey(URL), String.class).orElse(getDefaultUrl());
+
+        List<URL> listOfValidUrls = new ArrayList<>();
+        String values[] = inputConfig.split(COMMA);
+
+        for (String u : values) {
+            if (u != null && !u.isEmpty()) {
+                URL url = loadUrl(u.trim());
+                if (url != null)
+                    listOfValidUrls.add(url);
+            }
+        }
+        mergeProperties();
+        return listOfValidUrls;
+    }
+
+    private URL loadUrl(String url) {
+        try {
+            URL u = new URL(url);
+            LOG.log(Level.INFO, "Using [{0}] as {1} URL", new Object[] { u.toString(), getFileExtension() });
+            initialLoad(u);
+            return u;
+        } catch (MalformedURLException ex) {
+            LOG.log(Level.WARNING, "Can not load URL [" + url + "]", ex);
+            return null;
+        }
+    }
+
+    private void mergeProperties() {
+        this.properties.clear();
+        Set<Map.Entry<URL, Map<String, String>>> entrySet = propertiesMap.entrySet();
+        for (Map.Entry<URL, Map<String, String>> entry : entrySet) {
+            this.properties.putAll(entry.getValue());
+        }
+    }
+
+    private String loadPropertyKeySeparator() {
+        return config.getOptionalValue(getPrefixWithKey(KEY_SEPARATOR), String.class).orElse(DOT);
+    }
+
+    private String getDefaultUrl() {
+        String path = APPLICATION + DOT + getFileExtension();
+        try {
+            URL u = Paths.get(path).toUri().toURL();
+            return u.toString();
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static final String COMMA = ",";
+    private static final String URL = "url";
+    private static final String KEY_SEPARATOR = "keyseparator";
+
+    private static final String APPLICATION = "application";
+
+    protected abstract String getFileExtension();
+
+    protected abstract Map<String, String> toMap(final InputStream inputStream);
+}

--- a/sources/abstract-file/src/main/resources/META-INF/beans.xml
+++ b/sources/abstract-file/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/sources/abstract/pom.xml
+++ b/sources/abstract/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-config-parent</artifactId>
+        <version>1.3.10-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-source-abstract</artifactId>
+
+    <name>SmallRye: MicroProfile Config Source - Abstract</name>
+    <description>A config that provides default config_ordinal override behavior</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/sources/abstract/src/main/java/io/smallrye/config/source/EnabledConfigSource.java
+++ b/sources/abstract/src/main/java/io/smallrye/config/source/EnabledConfigSource.java
@@ -1,0 +1,58 @@
+package io.smallrye.config.source;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A config source that can be disabled by class or by instance (all vs each).
+ * <p>
+ * Instance keys take precedence over class keys, so individual sources can be
+ * turned back on if all sources have been turned off.
+ * <p>
+ * Config sources are enabled by default.
+ *
+ * @author <a href="mailto:dpmoore@acm.org">Derek P. Moore</a>
+ */
+public abstract class EnabledConfigSource extends SelfConfiguringConfigSource {
+    
+    /**
+     * Called to return the properties in this config source when it is enabled
+     * 
+     * @return the map containing the properties in this config source
+     */
+    abstract protected Map<String, String> getPropertiesIfEnabled();
+
+    /**
+     * Return the properties, unless disabled return empty
+     * 
+     * @return the map containing the properties in this config source or empty
+     *         if disabled
+     */
+    @Override
+    public Map<String, String> getProperties() {
+        return isEnabled() ? getPropertiesIfEnabled() : Collections.emptyMap();
+    }
+
+    protected boolean isEnabled() {
+        boolean isSet = configPropertyIsSet(getPrefixWithKey(ENABLED));
+        if (isSet) {
+            return config.getOptionalValue(getPrefixWithKey(ENABLED), Boolean.class).orElse(true);
+        }
+        return true; // default;
+
+    }
+
+    protected String getClassKeyPrefix() {
+        return getClass().getSimpleName();
+    }
+
+    protected boolean configPropertyIsSet(String key) {
+        for (String name : config.getPropertyNames()) {
+            if (name.equals(key))
+                return true;
+        }
+        return false;
+    }
+
+    private static final String ENABLED = "enabled";
+}

--- a/sources/abstract/src/main/java/io/smallrye/config/source/SelfConfiguringConfigSource.java
+++ b/sources/abstract/src/main/java/io/smallrye/config/source/SelfConfiguringConfigSource.java
@@ -1,0 +1,74 @@
+package io.smallrye.config.source;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Base class for all our ConfigSources (Originally from Geronimo Config)
+ *
+ * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
+ * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
+ * @author <a href="mailto:dpmoore@acm.org">Derek P. Moore</a>
+ */
+public abstract class SelfConfiguringConfigSource implements ConfigSource {
+    private static final Logger LOG = Logger.getLogger(SelfConfiguringConfigSource.class.getName());
+
+    protected final Config config;
+    private int ordinal = 1000; // default
+
+    public SelfConfiguringConfigSource() {
+        super();
+        this.config = createConfig();
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+    /**
+     * Init method e.g. for initializing the ordinal.
+     * This method can be used from a subclass to determine
+     * the ordinal value
+     *
+     * @param defaultOrdinal the default value for the ordinal if not set via configuration
+     */
+    protected void initOrdinal(int defaultOrdinal) {
+        ordinal = defaultOrdinal;
+
+        String configuredOrdinalString = getValue(CONFIG_ORDINAL);
+
+        try {
+            if (configuredOrdinalString != null) {
+                ordinal = Integer.parseInt(configuredOrdinalString.trim());
+            }
+        } catch (NumberFormatException e) {
+            LOG.log(Level.WARNING, e,
+                    () -> "The configured config-ordinal isn't a valid integer. Invalid value: " + configuredOrdinalString);
+        }
+    }
+
+    protected String getPrefix() {
+        return getClass().getPackage().getName() + DOT;
+    }
+
+    protected String getPrefixWithKey(String key) {
+        String prefix = getPrefix();
+        if (key == null)
+            return prefix;
+        return prefix + key;
+    }
+
+    private Config createConfig() {
+        return ConfigProviderResolver.instance()
+                .getBuilder()
+                .addDefaultSources()
+                .build();
+    }
+
+    protected static final String DOT = ".";
+}

--- a/sources/yaml/README.md
+++ b/sources/yaml/README.md
@@ -1,0 +1,128 @@
+# Yaml Config Source
+
+This source gets values from some yaml file(s).
+
+## Usage
+
+```xml
+
+    <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-source-yaml</artifactId>
+        <version>XXXXX</version>
+        <scope>runtime</scope>
+    </dependency>
+
+```
+
+## Example:
+
+```yaml
+
+    location:
+        protocol: "http"
+        host: "localhost"
+        port: "8080"
+        path: "/some/path"
+        jedis:
+            - Yoda
+            - Qui-Gon Jinn
+            - Obi-Wan Kenobi
+            - Luke Skywalker
+```
+
+will create the following properties:
+
+```property
+    
+    "location.protocol": "http"
+    "location.host": "localhost"
+    "location.port": "8080"
+    "location.path": "/some/path"
+    "location.jedis": "Yoda, Qui-Gon Jinn, Obi-Wan Kenobi, Luke Skywalker"
+
+```
+
+You can `inject` the jedis using any of the following:
+
+```java
+
+    @Inject
+    @ConfigProperty(name = "location.jedis")
+    String jedisAsString; 
+    
+    @Inject
+    @ConfigProperty(name = "location.jedis")
+    List<String> jedisAsList;
+    
+    @Inject
+    @ConfigProperty(name = "location.jedis")
+    Set<String> jedisAsSet;
+    
+    @Inject
+    @ConfigProperty(name = "location.jedis")
+    String[] jedisAsArray;
+
+```
+
+## Configure options
+
+### Url(s)
+
+By default the config source will look for a file called `application.yaml`. You can set the location(s) of the files:
+
+    io.smallrye.config.source.yaml.url=<here the url(s)>
+
+example:
+
+    io.smallrye.config.source.yaml.url=file:/tmp/myconfig.yml
+
+You can also add more than one location by comma-separating the location:
+
+    io.smallrye.config.source.yaml.url=file:/tmp/myconfig.yml,http://localhost/myconfig.yml
+
+The latest files will override properties in previous files. As example, if using above configuration, property `foo=bar` in `file:/tmp/myconfig.yml` will be override if it's added to `http://localhost/myconfig.yml`.
+
+### Detecting changes.
+
+You can detect and update changes.
+
+Read more about [Dynamic updates](Read more about [Config Events](https://github.com/smallrye/smallrye-config/tree/master/utils/dynamic))
+
+### Events
+
+This config source fires CDI Events on changes (if above detecting for changes is enabled).
+
+Read more about [Config Events](https://github.com/smallrye/smallrye-config/tree/master/utils/events)
+
+You can disable this with the `io.smallrye.config.source.yaml.notifyOnChanges` property:
+
+    io.smallrye.config.source.yaml.notifyOnChanges=false
+
+If you added more than one resource as source, the event will only fire if the resulting file change also changed the global source change, as one file takes priority over the other.
+
+### Key separator
+
+By default the separator used in the key is a DOT (.) example:
+
+```property
+    
+    "location.protocol": "http"
+```
+
+You can change this by setting `io.smallrye.config.source.yaml.keyseparator` to the desired separator, example:
+
+    io.smallrye.config.source.yaml.keyseparator=_
+
+will create:
+
+```property
+    
+    "location_protocol": "http"
+```
+
+### Enable
+
+You can disable this config source:
+    
+    io.smallrye.config.source.yaml.enabled=false

--- a/sources/yaml/application.yaml
+++ b/sources/yaml/application.yaml
@@ -1,0 +1,13 @@
+test:
+    property: "a-string-value"
+deepList:
+    level1:
+        - l1
+        - l2
+listTest:
+  - item1
+  - item2
+  - item3,stillItem3
+
+    
+  

--- a/sources/yaml/pom.xml
+++ b/sources/yaml/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-config-parent</artifactId>
+        <version>1.3.10-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-source-yaml</artifactId>
+
+    <name>SmallRye: MicroProfile Config Source - Yaml</name>
+    <description>A config that gets its values from a yaml file(s) at a URL</description>
+    
+    <properties>
+        <snakeyaml.version>1.25</snakeyaml.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>            
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-config-source-abstract-file</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+          
+    </dependencies>
+</project>

--- a/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSource.java
+++ b/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSource.java
@@ -1,0 +1,88 @@
+package io.smallrye.config.source.yaml;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.yaml.snakeyaml.Yaml;
+
+import io.smallrye.config.source.file.AbstractUrlBasedSource;
+
+/**
+ * Yaml config source
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+public class YamlConfigSource extends AbstractUrlBasedSource {
+
+    @Override
+    protected String getFileExtension() {
+        return "yaml";
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Map<String, String> toMap(InputStream inputStream) {
+        final Map<String, String> properties = new TreeMap<>();
+        Yaml yaml = new Yaml();
+        Map<String, Object> yamlInput = yaml.loadAs(inputStream, TreeMap.class);
+
+        for (String key : yamlInput.keySet()) {
+            populateMap(properties, key, yamlInput.get(key));
+        }
+        return properties;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void populateMap(Map<String, String> properties, String key, Object o) {
+        if (o instanceof Map) {
+            Map map = (Map) o;
+            for (Object mapKey : map.keySet()) {
+                populateEntry(properties, key, String.valueOf(mapKey), map);
+            }
+        } else if (o instanceof List) {
+            List<String> l = toStringList((List) o);
+            properties.put(key, String.join(COMMA, l));
+        } else {
+            if (o != null) {
+                properties.put(key, String.valueOf(o));
+            } else {
+                properties.put(key, null);
+            }
+
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void populateEntry(Map<String, String> properties, String key, String mapKey, Map<String, Object> map) {
+        String format = "%s" + super.getKeySeparator() + "%s";
+        if (map.get(mapKey) instanceof Map) {
+            populateMap(properties, String.format(format, key, mapKey), (Map<String, Object>) map.get(mapKey));
+        } else if (map.get(mapKey) instanceof List) {
+            List<String> l = toStringList((List) map.get(mapKey));
+            properties.put(String.format(format, key, mapKey), String.join(COMMA, l));
+        } else {
+            Object value = map.get(mapKey);
+            if (value != null) {
+                properties.put(String.format(format, key, mapKey), String.valueOf(value));
+            } else {
+                properties.put(String.format(format, key, mapKey), null);
+            }
+        }
+    }
+
+    private List<String> toStringList(List l) {
+        List<String> nl = new ArrayList<>();
+        for (Object o : l) {
+            String s = String.valueOf(o);
+            if (s.contains(COMMA))
+                s = s.replaceAll(COMMA, "\\\\,"); // Escape comma
+            nl.add(s);
+        }
+        return nl;
+    }
+
+    private static final String COMMA = ",";
+}

--- a/sources/yaml/src/main/resources/META-INF/beans.xml
+++ b/sources/yaml/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/sources/yaml/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/sources/yaml/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+io.smallrye.config.source.yaml.YamlConfigSource

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/DeployableUnit.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/DeployableUnit.java
@@ -1,0 +1,49 @@
+package io.smallrye.config.source.yaml;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import io.smallrye.config.source.EnabledConfigSource;
+import io.smallrye.config.source.file.AbstractUrlBasedSource;
+
+/**
+ * Create a deployable unit to test against
+ * 
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class DeployableUnit {
+
+    public static WebArchive create() {
+        return create(null);
+    }
+
+    public static WebArchive create(String includeConfigFile) {
+
+        final File[] smallryeConfig = Maven.resolver()
+                .loadPomFromFile("pom.xml")
+                .resolve("io.smallrye:smallrye-config")
+                .withoutTransitivity().asFile();
+
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "YamlConfigSourceTest.war")
+                .addPackage(YamlConfigSource.class.getPackage())
+                .addPackage(AbstractUrlBasedSource.class.getPackage())
+                .addPackage(EnabledConfigSource.class.getPackage())
+                .addAsLibraries(smallryeConfig)
+                .addAsResource(
+                        new File("src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource"),
+                        "META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        if (includeConfigFile != null && !includeConfigFile.isEmpty()) {
+            archive = archive.addAsResource(
+                    DeployableUnit.class.getClassLoader().getResource(includeConfigFile),
+                    "META-INF/microprofile-config.properties");
+        }
+
+        return archive;
+    }
+}

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/DisabledWhenEnabledKeyIsFalseTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/DisabledWhenEnabledKeyIsFalseTest.java
@@ -1,0 +1,34 @@
+package io.smallrye.config.source.yaml;
+
+import java.util.NoSuchElementException;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Make sure that if the source is disabled that the property is not available
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@RunWith(Arquillian.class)
+public class DisabledWhenEnabledKeyIsFalseTest {
+
+    @Inject
+    Config config;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return DeployableUnit.create("config-disabled.properties");
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testPropertyFailsWhenExplicitlyDisabled() {
+        config.getValue("test.property", String.class);
+    }
+}

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/EnabledWhenEnabledKeyIsMissingTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/EnabledWhenEnabledKeyIsMissingTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.config.source.yaml;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Make sure that by default the config source is enabled.
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@RunWith(Arquillian.class)
+public class EnabledWhenEnabledKeyIsMissingTest {
+
+    @Inject
+    Config config;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return DeployableUnit.create();
+    }
+
+    @Test
+    public void testPropertyLoadsWhenNotExplicitlyEnabled() {
+        Assert.assertEquals("test.property in application.properties is set to a-string-value",
+                "a-string-value", config.getOptionalValue("test.property", String.class).get());
+    }
+
+}

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/EnabledWhenEnabledKeyIsTrueTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/EnabledWhenEnabledKeyIsTrueTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.config.source.yaml;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Make sure that the property is available when the config source is explicitly enabled
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@RunWith(Arquillian.class)
+public class EnabledWhenEnabledKeyIsTrueTest {
+
+    @Inject
+    Config config;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return DeployableUnit.create("config-enabled.properties");
+    }
+
+    @Test
+    public void testPropertyLoadsWhenExplicitlyEnabled() {
+        Assert.assertEquals("test.property in application.properties is set to a-string-value",
+                "a-string-value", config.getOptionalValue("test.property", String.class).get());
+    }
+
+}

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ListTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ListTest.java
@@ -1,0 +1,78 @@
+package io.smallrye.config.source.yaml;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Testing some list behavior
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@RunWith(Arquillian.class)
+public class ListTest {
+
+    @Inject
+    @ConfigProperty(name = "listTest", defaultValue = "")
+    String stringList;
+
+    @Inject
+    @ConfigProperty(name = "listTest", defaultValue = "")
+    List<String> listList;
+
+    @Inject
+    @ConfigProperty(name = "listTest", defaultValue = "")
+    Set<String> setList;
+
+    @Inject
+    @ConfigProperty(name = "listTest", defaultValue = "")
+    String[] arrayList;
+
+    @Inject
+    @ConfigProperty(name = "deepList.level1", defaultValue = "")
+    List<String> deepList;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return DeployableUnit.create();
+    }
+
+    @Test
+    public void testStringList() {
+        Assert.assertEquals("item1,item2,item3\\,stillItem3", stringList);
+    }
+
+    @Test
+    public void testListList() {
+        Assert.assertNotNull(listList);
+        Assert.assertEquals(3, listList.size());
+
+    }
+
+    @Test
+    public void testSetList() {
+        Assert.assertNotNull(setList);
+        Assert.assertEquals(3, setList.size());
+    }
+
+    @Test
+    public void testArrayList() {
+        Assert.assertNotNull(arrayList);
+        Assert.assertEquals(3, arrayList.length);
+    }
+
+    @Test
+    public void testDeepList() {
+        Assert.assertNotNull(deepList);
+        Assert.assertEquals(2, deepList.size());
+    }
+}

--- a/sources/yaml/src/test/resources/config-disabled.properties
+++ b/sources/yaml/src/test/resources/config-disabled.properties
@@ -1,0 +1,1 @@
+io.smallrye.config.source.yaml.enabled=false

--- a/sources/yaml/src/test/resources/config-enabled.properties
+++ b/sources/yaml/src/test/resources/config-enabled.properties
@@ -1,0 +1,2 @@
+io.smallrye.config.source.yaml.enabled=true
+io.smallrye.config.source.yaml.pollForChanges=true

--- a/utils/dynamic/README.md
+++ b/utils/dynamic/README.md
@@ -1,0 +1,31 @@
+# Dynamic Config
+
+Util library to detect and update changes in file based config sources
+
+## Usage
+
+**WARNING:** Use with care. 
+
+You can watch the resource for changes. This feature is disabled by default. 
+To enable you need to include the dynamic util jar:
+
+```xml
+
+    <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-dynamic</artifactId>
+        <version>XXXX</version>
+        <scope>runtime</scope>
+    </dependency>
+
+```
+
+And you also need to set the flag to start using this:
+
+    io.smallrye.config.source.yaml.pollForChanges=true
+ 
+By default it will poll every **5 seconds**.  (Only applicable to HTTP based URLs) You can change that, example to poll every 5 minutes:
+
+    io.smallrye.config.source.yaml.pollInterval=300
+
+When you make a change to the file contents of the config source, the config source will load the new value, and notify via CDI Events.

--- a/utils/dynamic/pom.xml
+++ b/utils/dynamic/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-config-parent</artifactId>
+        <version>1.3.10-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-dynamic</artifactId>
+        
+    <packaging>jar</packaging>
+    <name>SmallRye: MicroProfile Config Dynamic</name>
+    <description>A library to make it easy to dynamically update a file based config source</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-config-source-abstract-file</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-config-events</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>smallrye-config-source-injection</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/utils/dynamic/src/main/java/io/smallrye/config/dynamic/FileResourceWatcher.java
+++ b/utils/dynamic/src/main/java/io/smallrye/config/dynamic/FileResourceWatcher.java
@@ -1,0 +1,74 @@
+package io.smallrye.config.dynamic;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.smallrye.config.events.ChangeEventNotifier;
+import io.smallrye.config.source.file.AbstractUrlBasedSource;
+
+/**
+ * Watching files for changes
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@ApplicationScoped
+public class FileResourceWatcher {
+    private static final Logger log = Logger.getLogger(FileResourceWatcher.class.getName());
+
+    @Inject
+    private ChangeEventNotifier changeEventNotifier;
+
+    public void startWatching(URL url, AbstractUrlBasedSource source, boolean notifyOnChanges) {
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                WatchService watchService = FileSystems.getDefault().newWatchService();
+                Path fileWeAreWatching = Paths.get(url.toURI());
+                Path dir = fileWeAreWatching.getParent();
+                String filename = fileWeAreWatching.getFileName().toString();
+
+                log.log(Level.INFO, "Monitoring [{0}] in {1} for changes", new Object[] { filename, dir });
+                dir.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+
+                WatchKey key;
+                while ((key = watchService.take()) != null) {
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        WatchEvent<Path> ev = (WatchEvent<Path>) event;
+                        Path fileThatChanged = dir.resolve(ev.context());
+
+                        if (fileThatChanged.equals(fileWeAreWatching)) {
+                            Map<String, String> before = new HashMap<>(source.getProperties());
+                            source.reload(url);
+                            Map<String, String> after = new HashMap<>(source.getProperties());
+                            if (notifyOnChanges)
+                                changeEventNotifier.detectChangesAndFire(before, after, source.getName());
+                        }
+                    }
+                    key.reset();
+                }
+
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                log.log(Level.WARNING, "Can not watch url [" + url + "]", ex);
+            } catch (URISyntaxException | IOException ex) {
+                log.log(Level.WARNING, "Can not watch url [" + url + "]", ex);
+            }
+        });
+    }
+}

--- a/utils/dynamic/src/main/java/io/smallrye/config/dynamic/ResourceWatcher.java
+++ b/utils/dynamic/src/main/java/io/smallrye/config/dynamic/ResourceWatcher.java
@@ -1,0 +1,143 @@
+package io.smallrye.config.dynamic;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import io.smallrye.config.injection.ConfigSourceMap;
+import io.smallrye.config.source.file.AbstractUrlBasedSource;
+
+/**
+ * Watching for changes in files
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@ApplicationScoped
+public class ResourceWatcher {
+    private static final Logger log = Logger.getLogger(ResourceWatcher.class.getName());
+
+    @Inject
+    private Config config;
+
+    @Inject
+    @ConfigSourceMap
+    private Map<String, ConfigSource> configSourceMap;
+
+    @Inject
+    private FileResourceWatcher fileResourceWatcher;
+
+    @Inject
+    private WebResourceWatcher webResourceWatcher;
+
+    public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
+        for (Map.Entry<String, ConfigSource> configSourceEntry : configSourceMap.entrySet()) {
+
+            Class<? extends ConfigSource> configSourceClass = configSourceEntry.getValue().getClass();
+            // First see if this is a File bases config source.
+            boolean isAbstractUrlBasedSource = extendsAbstractUrlBasedSource(configSourceClass);
+            // Then see if it's configured to be dynamic
+            boolean pollForChanges = loadPollForChanges(configSourceClass);
+            // Now check the poll interval. Has to more than 0
+            int pollInterval = loadPollInterval(configSourceClass);
+            // Also see if we need to notify on detected changed
+            boolean notifyOnChanges = loadNotifyOnChanges(configSourceClass);
+            if (isAbstractUrlBasedSource && pollForChanges && pollInterval > 0) {
+                // Now get all the URL's and start watching
+                AbstractUrlBasedSource source = (AbstractUrlBasedSource) configSourceEntry.getValue();
+                List<URL> urls = source.getUrlList();
+                for (URL url : urls) {
+                    if (isLocalResource(url)) {
+                        this.fileResourceWatcher.startWatching(url, source, notifyOnChanges);
+                    } else if (isWebResource(url)) {
+                        this.webResourceWatcher.startWatching(url, source, notifyOnChanges, pollInterval);
+                    } else {
+                        log.log(Level.WARNING, "Can not detect changes on resource {0}", url.getFile());
+                    }
+                }
+            }
+        }
+
+    }
+
+    private boolean isLocalResource(URL u) {
+        return u.getProtocol().equalsIgnoreCase(FILE);
+    }
+
+    private boolean isWebResource(URL u) {
+        return u.getProtocol().equalsIgnoreCase(HTTP) || u.getProtocol().equalsIgnoreCase(HTTPS);
+    }
+
+    private boolean extendsAbstractUrlBasedSource(Class configsource) {
+        if (configsource.getName().equals(Object.class.getName()))
+            return false;
+        if (configsource.getName().equals(AbstractUrlBasedSource.class.getName()))
+            return true;
+        return extendsAbstractUrlBasedSource(configsource.getSuperclass());
+    }
+
+    private boolean loadPollForChanges(Class clazz) {
+        String key = getKeyWithPrefix(clazz, POLL_FOR_CHANGES);
+        if (configPropertyIsSet(key)) {
+            return config.getOptionalValue(key, Boolean.class).get();
+        } else {
+            return DEFAULT_POLL_FOR_CHANGES;
+        }
+    }
+
+    private int loadPollInterval(Class clazz) {
+        String key = getKeyWithPrefix(clazz, POLL_INTERVAL);
+        if (configPropertyIsSet(key)) {
+            return config.getOptionalValue(key, Integer.class).get();
+        } else {
+            return DEFAULT_POLL_INTERVAL;
+        }
+    }
+
+    private boolean loadNotifyOnChanges(Class clazz) {
+        String key = getKeyWithPrefix(clazz, NOTIFY_ON_CHANGES);
+        if (configPropertyIsSet(key)) {
+            return config.getOptionalValue(key, Boolean.class).get();
+        } else {
+            return DEFAULT_NOTIFY_ON_CHANGES;
+        }
+    }
+
+    private String getKeyWithPrefix(Class clazz, String key) {
+        String prefix = clazz.getPackage().getName() + DOT;
+        if (key == null)
+            return prefix;
+        return prefix + key;
+    }
+
+    private boolean configPropertyIsSet(String key) {
+        for (String name : config.getPropertyNames()) {
+            if (name.equals(key))
+                return true;
+        }
+        return false;
+    }
+
+    private static final String DOT = ".";
+    private static final String POLL_FOR_CHANGES = "pollForChanges";
+    private static final boolean DEFAULT_POLL_FOR_CHANGES = false;
+
+    private static final String POLL_INTERVAL = "pollInterval";
+    private static final int DEFAULT_POLL_INTERVAL = 5; // 5 seconds
+
+    private static final String NOTIFY_ON_CHANGES = "notifyOnChanges";
+    private static final boolean DEFAULT_NOTIFY_ON_CHANGES = true;
+
+    private static final String FILE = "file";
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+}

--- a/utils/dynamic/src/main/java/io/smallrye/config/dynamic/WebResourceWatcher.java
+++ b/utils/dynamic/src/main/java/io/smallrye/config/dynamic/WebResourceWatcher.java
@@ -1,0 +1,79 @@
+package io.smallrye.config.dynamic;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.smallrye.config.events.ChangeEventNotifier;
+import io.smallrye.config.source.file.AbstractUrlBasedSource;
+
+/**
+ * Watching web resources for changes
+ * 
+ * @author <a href="mailto:phillip.kruger@redhat.com">Phillip Kruger</a>
+ */
+@ApplicationScoped
+public class WebResourceWatcher {
+    private static final Logger log = Logger.getLogger(WebResourceWatcher.class.getName());
+
+    @Inject
+    private ChangeEventNotifier changeEventNotifier;
+
+    private final ScheduledExecutorService scheduledThreadPool = Executors.newSingleThreadScheduledExecutor();
+
+    public void startWatching(URL url, AbstractUrlBasedSource source, boolean notifyOnChanges, long pollInterval) {
+        if (!urlsToWatch.containsKey(url)) {
+            long lastModified = getLastModified(url);
+            if (lastModified > 0) {
+                scheduledThreadPool.scheduleAtFixedRate(() -> {
+                    long latestLastModified = getLastModified(url);
+                    if (latestLastModified != urlsToWatch.get(url)) {
+                        urlsToWatch.put(url, latestLastModified);
+                        Map<String, String> before = new HashMap<>(source.getProperties());
+                        source.reload(url);
+                        Map<String, String> after = new HashMap<>(source.getProperties());
+                        if (notifyOnChanges)
+                            changeEventNotifier.detectChangesAndFire(before, after, source.getName());
+                    }
+                }, pollInterval, pollInterval, TimeUnit.SECONDS);
+
+                urlsToWatch.put(url, lastModified);
+            } else {
+                log.log(Level.WARNING, "Can not poll {0} for changes, lastModified not implemented", url);
+            }
+        }
+    }
+
+    private long getLastModified(URL url) {
+        HttpURLConnection con = null;
+        try {
+            con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod(HEAD);
+            con.setConnectTimeout(5000);
+            con.setReadTimeout(5000);
+            return con.getLastModified();
+        } catch (IOException ex) {
+            log.log(Level.SEVERE, ex.getMessage());
+        } finally {
+            if (con != null)
+                con.disconnect();
+        }
+
+        return -1;
+    }
+
+    private static final String HEAD = "HEAD";
+
+    private final Map<URL, Long> urlsToWatch = new ConcurrentHashMap<>();
+}

--- a/utils/dynamic/src/main/resources/META-INF/beans.xml
+++ b/utils/dynamic/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

Re-factored all the dynamic stuff out of the Abstract File Class. When you now use the yaml (and other file based sources to be donated) you have no dynamic option build in.

You can however add a jar that will allow you to enable this. see https://github.com/phillip-kruger/smallrye-config/tree/master/utils/dynamic on how to do that.

Let me know if this is more acceptable.