### PR TITLE
Add TypeSafe Config config source

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -20,6 +20,7 @@ In addition to the features provided by MicroProfile Config, smallrye-config pro
  This ConfigSource can be used to read configuration from https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap[Kubernetes ConfigMap].
 * https://github.com/smallrye/smallrye-config/tree/master/sources/zookeeper[ZkMicroProfileConfig] creates a ConfigSource that is backed by Apache Zookeeper
 * https://github.com/smallrye/smallrye-config/blob/master/sources/hocon[HoconConfigSource] Creates a ConfigSource from configuration files in https://github.com/lightbend/config/blob/master/HOCON.md[HOCON] format.
+* https://github.com/smallrye/smallrye-config/blob/master/sources/typesafe-config[TypeSafeConfigConfigSource] Creates a ConfigSource which uses the standard behavior of TypeSafe (Lightbend) Config described https://github.com/lightbend/config#standard-behavior[here].
 
 [[more-resources]]
 == More Resources

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <module>testsuite</module>
     <module>docs</module>
     <module>sources/hocon</module>
+    <module>sources/typesafe-config</module>
     <module>sources/zookeeper</module>
     <module>converters/json</module>
     <module>utils/events</module>
@@ -114,6 +115,16 @@
       </dependency>
 
       <!-- Config Sources -->
+      <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-source-hocon</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-source-typesafe-config</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-source-zookeeper</artifactId>

--- a/sources/typesafe-config/Readme.adoc
+++ b/sources/typesafe-config/Readme.adoc
@@ -1,0 +1,19 @@
+= TypeSafe Config source config
+
+Implementation of a https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc[MicroProfile ConfigSource] to support https://github.com/lightbend/config[TypeSafe (Lightbend) config].
+
+Using the MicroProfile Configuration API is a really convenient way to configure your application.
+The standard MicroProfile Configuration Sources are Environment Variables, System Variables and via a microprofile-config.properties file in the Classpath.
+This project adds an additional source which uses Lightbend config and it's standard behavior described https://github.com/lightbend/config#standard-behavior[here].
+
+== Usage
+
+To use the TypeSafe Config MicroProfile Config source, add the following to your Maven `pom.xml`
+
+```xml
+<dependency>
+    <groupId>io.smallrye.config</groupId>
+    <artifactId>smallrye-config-source-typesafe-config</artifactId>
+    <version>1.3.10-SNAPSHOT</version>
+</dependency>
+```

--- a/sources/typesafe-config/pom.xml
+++ b/sources/typesafe-config/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>smallrye-config-parent</artifactId>
+    <groupId>io.smallrye</groupId>
+    <version>1.3.10-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>io.smallrye.config</groupId>
+  <artifactId>smallrye-config-source-typesafe-config</artifactId>
+  <name>SmallRye: TypeSafe Config ConfigSource</name>
+
+  <properties>
+    <lightbend-config.version>1.4.0</lightbend-config.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>${lightbend-config.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <properties>
+        <argLine>@{jacocoArgLine}</argLine>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/sources/typesafe-config/src/main/java/io/smallrye/configsource/TypeSafeConfigConfigSource.java
+++ b/sources/typesafe-config/src/main/java/io/smallrye/configsource/TypeSafeConfigConfigSource.java
@@ -1,0 +1,53 @@
+package io.smallrye.configsource;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+public class TypeSafeConfigConfigSource implements ConfigSource, Serializable {
+
+    static final int DEFAULT_ORDINAL = 50;
+
+    private final Map<String, String> properties;
+    private final int ordinal;
+
+    public TypeSafeConfigConfigSource() {
+        final Config config = ConfigFactory.load();
+        this.ordinal = config.hasPath(CONFIG_ORDINAL) ? config.getInt(CONFIG_ORDINAL) : DEFAULT_ORDINAL;
+        this.properties = Collections.unmodifiableMap(config.entrySet().stream()
+                .collect(
+                        Collectors.toMap(Map.Entry::getKey, entry -> config.getString(entry.getKey()))));
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return this.properties;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return this.ordinal;
+    }
+
+    @Override
+    public String getValue(String s) {
+        return this.properties.get(s);
+    }
+
+    @Override
+    public String getName() {
+        return TypeSafeConfigConfigSource.class.getSimpleName();
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+}

--- a/sources/typesafe-config/src/main/resources/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/sources/typesafe-config/src/main/resources/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+io.smallrye.configsource.TypeSafeConfigConfigSource

--- a/sources/typesafe-config/src/test/java/io/smallrye/configsource/TypeSafeConfigConfigSourceTest.java
+++ b/sources/typesafe-config/src/test/java/io/smallrye/configsource/TypeSafeConfigConfigSourceTest.java
@@ -1,0 +1,19 @@
+package io.smallrye.configsource;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.Test;
+
+public class TypeSafeConfigConfigSourceTest {
+
+    @Test
+    public void testBasic() {
+        final ConfigSource configSource = new TypeSafeConfigConfigSource();
+        assertEquals(TypeSafeConfigConfigSource.DEFAULT_ORDINAL, configSource.getOrdinal());
+        assertEquals("1", configSource.getValue("hello.world"));
+        assertEquals("Hello there!", configSource.getValue("hello.foo.bar"));
+        assertEquals("1", configSource.getProperties().get("hello.world"));
+        assertEquals("Hello there!", configSource.getProperties().get("hello.foo.bar"));
+    }
+}

--- a/sources/typesafe-config/src/test/resources/application.conf
+++ b/sources/typesafe-config/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+hello {
+  foo {
+    bar = "Hello there!"
+  }
+}

--- a/sources/typesafe-config/src/test/resources/reference.conf
+++ b/sources/typesafe-config/src/test/resources/reference.conf
@@ -1,0 +1,6 @@
+hello {
+  world = 1
+  foo {
+    bar = "Hell yeah!"
+  }
+}


### PR DESCRIPTION
This implementation is just of port of [Microprofile config extension](https://github.com/microprofile-extensions/config-ext/tree/master/configsource-typesafeconfig) into SmallRye.