### PR TITLE
Handle Provider<T> and Instance<T> config property injections correctly

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigInjectionBean.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigInjectionBean.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Annotated;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -92,10 +93,12 @@ public class ConfigInjectionBean<T> implements Bean<T>, PassivationCapable {
             ParameterizedType paramType = (ParameterizedType) annotated.getBaseType();
             Type rawType = paramType.getRawType();
 
-            // handle Provider<T>
-            if (rawType instanceof Class && ((Class) rawType).isAssignableFrom(Provider.class)
+            // handle Provider<T> and Instance<T>
+            if (rawType instanceof Class
+                    && (((Class<?>) rawType).isAssignableFrom(Provider.class)
+                            || ((Class<?>) rawType).isAssignableFrom(Instance.class))
                     && paramType.getActualTypeArguments().length == 1) {
-                Class paramTypeClass = (Class) paramType.getActualTypeArguments()[0];
+                Class<?> paramTypeClass = (Class<?>) paramType.getActualTypeArguments()[0];
                 return (T) getConfig().getValue(key, paramTypeClass);
             }
         } else {

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/provider/InstanceAlone.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/provider/InstanceAlone.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.smallrye.config.test.provider;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public class InstanceAlone {
+
+    @Inject
+    @ConfigProperty(name = "myEmail")
+    Instance<Email> emailInstance;
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/provider/InstanceAloneTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/provider/InstanceAloneTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.config.test.provider;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Test that configuration is injected into Instance.
+ */
+public class InstanceAloneTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "ProviderTest.jar")
+                .addClasses(InstanceAloneTest.class, Email.class, InstanceAlone.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(new StringAsset(
+                        "myEmail=example@smallrye.io"), "microprofile-config.properties")
+                .as(JavaArchive.class);
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "ProviderTest.war")
+                .addAsLibrary(testJar);
+        return war;
+    }
+
+    @Inject
+    InstanceAlone bean;
+
+    @Test
+    public void testProvider() {
+        Provider<Email> emailProvider = bean.emailInstance;
+        assertNotNull(emailProvider);
+        Email email = emailProvider.get();
+        assertNotNull(email);
+        assertEquals("example", email.getName());
+        assertEquals("smallrye.io", email.getDomain());
+    }
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderAlone.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderAlone.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.smallrye.config.test.provider;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public class ProviderAlone {
+
+    @Inject
+    @ConfigProperty(name = "myEmail")
+    Provider<Email> emailProvider;
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderAloneTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/provider/ProviderAloneTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.smallrye.config.test.provider;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Test that configuration is injected into Provider.
+ */
+public class ProviderAloneTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "ProviderTest.jar")
+                .addClasses(ProviderAloneTest.class, Email.class, ProviderAlone.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(new StringAsset(
+                        "myEmail=example@smallrye.io"), "microprofile-config.properties")
+                .as(JavaArchive.class);
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "ProviderTest.war")
+                .addAsLibrary(testJar);
+        return war;
+    }
+
+    @Inject
+    ProviderAlone bean;
+
+    @Test
+    public void testProvider() {
+        Provider<Email> emailProvider = bean.emailProvider;
+        assertNotNull(emailProvider);
+        Email email = emailProvider.get();
+        assertNotNull(email);
+        assertEquals("example", email.getName());
+        assertEquals("smallrye.io", email.getDomain());
+    }
+}


### PR DESCRIPTION
- resolves #101
- note that this does not fix the general problem with parameterized
types

NOTE: this PR does not fix the problem with parameterized types - I'm not an MP Config expert and I'm not sure whether it needs to be supported.