### PR TITLE
Add SmallRyeConfigBuilder.withSources(Collection)

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -18,6 +18,7 @@ package io.smallrye.config;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -115,6 +116,11 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
     @Override
     public SmallRyeConfigBuilder withSources(ConfigSource... configSources) {
         Collections.addAll(sources, configSources);
+        return this;
+    }
+
+    public SmallRyeConfigBuilder withSources(Collection<ConfigSource> configSources) {
+        sources.addAll(configSources);
         return this;
     }
 


### PR DESCRIPTION
This enables a minor improvement on not requiring collections to be transformed into array
eg. https://github.com/quarkusio/quarkus/blob/34aa20e42c47ddc516de9b701f107cc7b0c63b9c/core/runtime/src/main/java/io/quarkus/runtime/configuration/ConfigUtils.java#L68