### PR TITLE
CDI Producers for Byte, Short and Character.

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -164,6 +164,12 @@ public class ConfigExtension implements Extension {
                 || requiredType == Float.class
                 || requiredType == Float.TYPE
                 || requiredType == Double.class
-                || requiredType == Double.TYPE;
+                || requiredType == Double.TYPE
+                || requiredType == Short.class
+                || requiredType == Short.TYPE
+                || requiredType == Byte.class
+                || requiredType == Byte.TYPE
+                || requiredType == Character.class
+                || requiredType == Character.TYPE;
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -89,6 +89,27 @@ public class ConfigProducer implements Serializable {
     @Dependent
     @Produces
     @ConfigProperty
+    Short produceShortConfigProperty(InjectionPoint ip) {
+        return ConfigProducerUtil.getValue(ip, getConfig(ip));
+    }
+
+    @Dependent
+    @Produces
+    @ConfigProperty
+    Byte produceByteConfigProperty(InjectionPoint ip) {
+        return ConfigProducerUtil.getValue(ip, getConfig(ip));
+    }
+
+    @Dependent
+    @Produces
+    @ConfigProperty
+    Character produceCharacterConfigProperty(InjectionPoint ip) {
+        return ConfigProducerUtil.getValue(ip, getConfig(ip));
+    }
+
+    @Dependent
+    @Produces
+    @ConfigProperty
     <T> Optional<T> produceOptionalConfigValue(InjectionPoint ip) {
         return ConfigProducerUtil.getValue(ip, getConfig(ip));
     }


### PR DESCRIPTION
This will be required for MP 1.4 to support CDI Injection on all native types.