### PR TITLE
Do not scan configMap sub directories

### DIFF
--- a/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
+++ b/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
@@ -77,12 +77,13 @@ public class FileSystemConfigSource extends MapBackedConfigSource {
 
     private static Map<String, String> scan(File directory) {
         if (directory != null && directory.isDirectory()) {
-            try (Stream<Path> stream = Files.walk(directory.toPath())) {
+            try (Stream<Path> stream = Files.walk(directory.toPath(), 1)) {
 
                 return stream.filter(p -> p.toFile().isFile())
                         .collect(Collectors.toMap(it -> it.getFileName().toString(), FileSystemConfigSource::readContent));
             } catch (Exception e) {
-                LOG.warnf("Unable to read content from file %s", directory.getAbsolutePath());
+                LOG.warnf("Unable to read content from file %s. Exception: %s", directory.getAbsolutePath(),
+                        e.getLocalizedMessage());
             }
         }
         return Collections.emptyMap();


### PR DESCRIPTION
Fix issue: https://github.com/smallrye/smallrye-config/issues/231
Sub directory shouldn't be scanned. Added exception message to the trace.

For example, in openshift, the configMap dir contains an hidden directory that contains the actual files. Files in the configMap dir are links to hidden files. This hidden dir is discovered when scanning, so keys discovered twice and failure occurs.
