### PR TITLE
Add ConverterTest for Integer/int custom converter

### DIFF
--- a/testsuite/extra/src/test/java/io/smallrye/config/test/converter/ConverterBean.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/converter/ConverterBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.config.test.converter;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public class ConverterBean {
+
+    @Inject
+    @ConfigProperty(name = "myInt", defaultValue = "1")
+    private int myInt;
+
+    @Inject
+    @ConfigProperty(name = "myInteger", defaultValue = "1")
+    private Integer myInteger;
+
+    public int getInt() {
+        return myInt;
+    }
+
+    public Integer getInteger() {
+        return myInteger;
+    }
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/converter/ConverterTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/converter/ConverterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.config.test.converter;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Test that a high-priority converter for {@code Integer} will take precedence to built-in converters
+ * for both Integer and int types.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2020 Red Hat inc.
+ */
+public class ConverterTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        return ShrinkWrap
+                .create(WebArchive.class, "CollectionWithConfiguredValueTest.war")
+                .addClasses(ConverterTest.class, ConverterBean.class)
+                .addClass(IntConverter.class)
+                .addAsServiceProvider(Converter.class, IntConverter.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private ConverterBean bean;
+
+    @Test
+    public void testHighPriorityConverterforInt() {
+        assertEquals(bean.getInt(), 102);
+    }
+
+    @Test
+    public void testHighPriorityConverterforInteger() {
+        assertEquals(bean.getInteger().intValue(), 102);
+    }
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/converter/IntConverter.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/converter/IntConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.smallrye.config.test.converter;
+
+import javax.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+@Priority(102)
+public class IntConverter implements Converter<Integer> {
+
+    @Override
+    public Integer convert(String s) {
+        return 102;
+    }
+}


### PR DESCRIPTION
Add a test to ensure that a `Converter<Integer>` will be taken into
account for both `Integer` and primitive `int` types.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>