### PR TITLE
[CVE-2020-1729] Ensure utility methods wrapping doPrivileged calls are not publicly available.

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -16,7 +16,7 @@
 
 package io.smallrye.config.inject;
 
-import static io.smallrye.config.SecuritySupport.getContextClassLoader;
+import static io.smallrye.config.inject.SecuritySupport.getContextClassLoader;
 
 import java.io.Serializable;
 import java.util.*;

--- a/implementation/src/main/java/io/smallrye/config/inject/SecuritySupport.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/SecuritySupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.smallrye.config;
+package io.smallrye.config.inject;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;


### PR DESCRIPTION
Additionally a doPrivileged is not necessary if no SecurityManager is installed.