### PR TITLE
[CVE-2020-1729] Ensure utility methods wrapping doPrivileged calls ar…

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -16,7 +16,7 @@
 
 package io.smallrye.config.inject;
 
-import static io.smallrye.config.SecuritySupport.getContextClassLoader;
+import static io.smallrye.config.inject.SecuritySupport.getContextClassLoader;
 
 import java.io.Serializable;
 import java.util.*;

--- a/implementation/src/main/java/io/smallrye/config/inject/SecuritySupport.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/SecuritySupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.smallrye.config;
+package io.smallrye.config.inject;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -25,8 +25,10 @@ import org.jboss.logging.Logger;
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
  */
 class SecuritySupport {
-
     private static final Logger LOG = Logger.getLogger("io.smallrye.config");
+
+    private SecuritySupport() {
+    }
 
     static ClassLoader getContextClassLoader() {
         if (System.getSecurityManager() == null) {


### PR DESCRIPTION
…e not publicly available.

Additionally a doPrivileged is not necessary if no SecurityManager is installed.

This is a back port fix the CVE-2020-1729(https://github.com/smallrye/smallrye-config/pull/239) to `1.3.x` branch