### PR TITLE
Change getConverter to match proposed MP Config 2.0 API without breaking compatibility

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -78,6 +78,19 @@
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jboss.bridger</groupId>
+        <artifactId>bridger</artifactId>
+        <executions>
+          <execution>
+            <id>weave</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>transform</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -164,7 +164,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     // no @Override
     public <T, C extends Collection<T>> C getValues(String name, Class<T> itemClass, IntFunction<C> collectionFactory) {
-        return getValues(name, getConverter(itemClass), collectionFactory);
+        return getValues(name, requireConverter(itemClass), collectionFactory);
     }
 
     public <T, C extends Collection<T>> C getValues(String name, Converter<T> converter, IntFunction<C> collectionFactory) {
@@ -173,7 +173,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     @Override
     public <T> T getValue(String name, Class<T> aClass) {
-        return getValue(name, getConverter(aClass));
+        return getValue(name, requireConverter(aClass));
     }
 
     public <T> T getValue(String name, Converter<T> converter) {
@@ -228,7 +228,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     public <T, C extends Collection<T>> Optional<C> getOptionalValues(String name, Class<T> itemClass,
             IntFunction<C> collectionFactory) {
-        return getOptionalValues(name, getConverter(itemClass), collectionFactory);
+        return getOptionalValues(name, requireConverter(itemClass), collectionFactory);
     }
 
     public <T, C extends Collection<T>> Optional<C> getOptionalValues(String name, Converter<T> converter,
@@ -270,30 +270,43 @@ public class SmallRyeConfig implements Config, Serializable {
     }
 
     public <T> T convert(String value, Class<T> asType) {
-        return value != null ? getConverter(asType).convert(value) : null;
+        return value != null ? requireConverter(asType).convert(value) : null;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private <T> Converter<Optional<T>> getOptionalConverter(Class<T> asType) {
         return optionalConverters.computeIfAbsent(asType,
-                clazz -> Converters.newOptionalConverter(getConverter((Class) clazz)));
+                clazz -> Converters.newOptionalConverter(requireConverter((Class) clazz)));
+    }
+
+    @Deprecated // binary-compatibility bridge method for Quarkus
+    public <T> Converter<T> getConverter$$bridge(Class<T> asType) {
+        return requireConverter(asType);
+    }
+
+    // @Override // in MP Config 2.0+
+    public <T> Optional<Converter<T>> getConverter(Class<T> asType) {
+        return Optional.ofNullable(getConverterOrNull(asType));
+    }
+
+    <T> Converter<T> requireConverter(final Class<T> asType) {
+        final Converter<T> conv = getConverterOrNull(asType);
+        if (conv == null) {
+            throw new IllegalArgumentException("No Converter registered for " + asType);
+        }
+        return conv;
     }
 
     @SuppressWarnings("unchecked")
-    public <T> Converter<T> getConverter(Class<T> asType) {
+    <T> Converter<T> getConverterOrNull(Class<T> asType) {
         if (asType.isPrimitive()) {
-            return (Converter<T>) getConverter(Converters.wrapPrimitiveType(asType));
+            return (Converter<T>) getConverterOrNull(Converters.wrapPrimitiveType(asType));
         }
         if (asType.isArray()) {
-            return Converters.newArrayConverter(getConverter(asType.getComponentType()), asType);
+            final Converter<?> conv = getConverterOrNull(asType.getComponentType());
+            return conv == null ? null : Converters.newArrayConverter(conv, asType);
         }
-        return (Converter<T>) converters.computeIfAbsent(asType, clazz -> {
-            final Converter<?> conv = ImplicitConverters.getConverter((Class<?>) clazz);
-            if (conv == null) {
-                throw new IllegalArgumentException("No Converter registered for " + asType);
-            }
-            return conv;
-        });
+        return (Converter<T>) converters.computeIfAbsent(asType, clazz -> ImplicitConverters.getConverter((Class<?>) clazz));
     }
 
     private static NoSuchElementException propertyNotFound(final String name) {

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -82,7 +82,8 @@ public class ConfigProducerUtil {
             }
         }
         // just try the raw type
-        return src.getConverter(rawType);
+        return src.getConverter(rawType).orElseThrow(() -> new IllegalArgumentException("No Converter registered for " +
+                rawType));
     }
 
     @SuppressWarnings("unchecked")

--- a/implementation/src/test/java/io/smallrye/config/ConvertersStringCleanupTestCase.java
+++ b/implementation/src/test/java/io/smallrye/config/ConvertersStringCleanupTestCase.java
@@ -68,28 +68,28 @@ public class ConvertersStringCleanupTestCase<T> {
     @Test
     public void testSimple() {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(string));
     }
 
     @Test
     public void testTrailingSpace() {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(string + " "));
     }
 
     @Test
     public void testLeadingSpace() {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(" " + string));
     }
 
     @Test
     public void testLeadingAndTrailingWhitespaces() {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(" \t " + string + "\t\t "));
     }
 


### PR DESCRIPTION
Depends on eclipse/microprofile-config#495; don't take out of draft until/unless that gets merged.