### PR TITLE
Properties from file system should be search with the same rules used for environment variables

### DIFF
--- a/doc/modules/ROOT/pages/config-sources/filesystem-config-source.adoc
+++ b/doc/modules/ROOT/pages/config-sources/filesystem-config-source.adoc
@@ -25,6 +25,12 @@ Nested directories are not supported.
 This Config Source can be used to read configuration from
 https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap[Kubernetes ConfigMap].
 
+The same mapping rules as defined for environment variables are applied, so the FileSystemConfigSource will search for a given property name (e.g. com.ACME.size):
+
+* Exact match (i.e. com.ACME.size)
+* Replace each character that is neither alphanumeric nor _ with _ (i.e. com_ACME_size)
+* Replace each character that is neither alphanumeric nor _ with _; then convert the name to upper case (i.e. COM_ACME_SIZE)
+
 === Usage
 
 To use the FileSystem Config Source, add the following to your Maven `pom.xml`:

--- a/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceTestCase.java
+++ b/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceTestCase.java
@@ -17,6 +17,7 @@
 package io.smallrye.config.source.file;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -41,5 +42,21 @@ public class FileSystemConfigSourceTestCase {
 
         assertEquals("myValue1", configSource.getValue("myKey1"));
         assertEquals("true", configSource.getValue("myKey2"));
+    }
+
+    @Test
+    public void testCharacterReplacement() throws URISyntaxException {
+        URL configDirURL = this.getClass().getResource("configDir");
+        File dir = new File(configDirURL.toURI());
+
+        ConfigSource configSource = new FileSystemConfigSource(dir);
+        // the non-alphanumeric chars may be replaced by _ 
+        assertEquals("http://localhost:8080/my-service", configSource.getValue("MyService/mp-rest/url"));
+        // or the file name is uppercased
+        assertEquals("http://localhost:8080/other-service", configSource.getValue("OtherService/mp-rest/url"));
+        // but the key is still case sensitive 
+        assertNull(configSource.getValue("myservice/mp-rest/url"));
+        // you can't rewrite the key, only the file name 
+        assertNull(configSource.getValue("MYSERVICE_MP_REST_URL"));
     }
 }

--- a/sources/file-system/src/test/resources/io/smallrye/config/source/file/configDir/MyService_mp_rest_url
+++ b/sources/file-system/src/test/resources/io/smallrye/config/source/file/configDir/MyService_mp_rest_url
@@ -1,0 +1,1 @@
+http://localhost:8080/my-service

--- a/sources/file-system/src/test/resources/io/smallrye/config/source/file/configDir/OTHERSERVICE_MP_REST_URL
+++ b/sources/file-system/src/test/resources/io/smallrye/config/source/file/configDir/OTHERSERVICE_MP_REST_URL
@@ -1,0 +1,1 @@
+http://localhost:8080/other-service


### PR DESCRIPTION
**Statement of problem**

given a interface for the MicroProfile REST client

```
package com.example;
@Produces(APPLICATION_JSON)
@RegisterRestClient
public interface QuickQuoteService {
  ...
}
```

which will retrieve its URL from MP Config with the key

`com.example.QuickQuoteService/mp-rest/url`

and a ConfigMap in Kubernetes with entries

```apiVersion: v1
kind: ConfigMap
data:
 com_example_QuickQuoteService_mp_rest_url: https://quote.cnbc.com/quote-html-webservice
```

A ConfigMap defines rules on the key, which forbids '/', because it cannot be mapped to an environment variable or a file name. 

According to specification the replacement rules are defined for environment variables, all non-alphanumeric characters are replaced with '_'; and if that doesn't resolve, all alphabetical characters can be upper-case. 

This ConfigMap will be mounted in a volume, resulting in a file named  com_example_QuickQuoteService_mp_rest_url with the value as content.

The FileSystemConfigSource should pick up that file (which it does) and the Config should return its content as value for the key `com.example.QuickQuoteService/mp-rest/url` (which is doesn't)

**Solution**

The mapping rules for environment variables (see  EnvConfigSource) should apply to file names as well, even if the specification does not define this behavior. 