### PR TITLE
Register default interceptors in the default SmallRyeConfigFactory Config builder.

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigFactory.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigFactory.java
@@ -52,6 +52,7 @@ public abstract class SmallRyeConfigFactory {
         public SmallRyeConfig getConfigFor(SmallRyeConfigProviderResolver configProviderResolver, ClassLoader classLoader) {
             return configProviderResolver.getBuilder().forClassLoader(classLoader)
                     .addDefaultSources()
+                    .addDefaultInterceptors()
                     .addDiscoveredSources()
                     .addDiscoveredConverters()
                     .addDiscoveredInterceptors()

--- a/sources/zookeeper/src/main/java/io/smallrye/config/source/zookeeper/ZooKeeperConfigSource.java
+++ b/sources/zookeeper/src/main/java/io/smallrye/config/source/zookeeper/ZooKeeperConfigSource.java
@@ -89,7 +89,8 @@ public class ZooKeeperConfigSource extends AbstractConfigSource {
          * Explicitly ignore all keys that are prefixed with the prefix used to configure the Zookeeper connection.
          * Other wise a stack overflow obviously happens.
          */
-        if (key.startsWith(IGNORED_PREFIX)) {
+        // TODO - radcortez - We need to add a feature that allows ConfigSource to config itself with other ConfigSource
+        if (key.startsWith(IGNORED_PREFIX) || key.startsWith("smallrye.config")) {
             return null;
         }
         try {


### PR DESCRIPTION
This is to register Expansion and Profile as default features. Required a workaround fix in the ZookeeperConfigSource.