### PR TITLE
Introduce ArgumentConfigSource

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ArgumentConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/ArgumentConfigSource.java
@@ -1,0 +1,66 @@
+package io.smallrye.config;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.smallrye.config.common.MapBackedConfigSource;
+
+/**
+ * Parses a String array of arguments (-f or -f=foo or --file or --file=foo)
+ *
+ * @author George Gastaldi <gegastaldi@gmail.com>
+ */
+public class ArgumentConfigSource extends MapBackedConfigSource {
+
+    static final String TRUE = "true";
+    private static final Pattern ARG_MATCHER = Pattern.compile("-{1,2}([\\w\\d-_]+)=?(.*)");
+
+    public ArgumentConfigSource(String[] args) {
+        this("ArgumentConfigSource", args, 500);
+    }
+
+    public ArgumentConfigSource(String name, String... args) {
+        this(name, args, 500);
+    }
+
+    public ArgumentConfigSource(String name, String[] args, int ordinal) {
+        super(name, toMap(Objects.requireNonNull(args, "args cannot be null")), ordinal);
+    }
+
+    private static Map<String, String> toMap(String[] args) {
+        Map<String, List<String>> values = new LinkedHashMap<>();
+        String lastKey = null;
+        for (String arg : args) {
+            if (arg == null || arg.isEmpty()) {
+                continue;
+            }
+            Matcher matcher = ARG_MATCHER.matcher(arg);
+            if (matcher.matches()) {
+                String key = lastKey = matcher.group(1);
+                String value = matcher.group(2);
+                // When "-f" is specified
+                if (value.isEmpty()) {
+                    // If right side was not provided, assume "true"
+                    value = TRUE;
+                }
+                values.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+            } else if (lastKey != null) {
+                //When "-f foo" is specified
+                List<String> list = values.computeIfAbsent(lastKey, k -> new ArrayList<>());
+                list.remove(TRUE);
+                list.add(arg);
+            }
+        }
+        Map<String, String> map = new LinkedHashMap<>();
+        for (Entry<String, List<String>> entry : values.entrySet()) {
+            map.put(entry.getKey(), String.join(",", entry.getValue()));
+        }
+        return map;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ArgumentConfigSourceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ArgumentConfigSourceTest.java
@@ -1,0 +1,54 @@
+package io.smallrye.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ArgumentConfigSourceTest {
+
+    @Test
+    public void shouldParseOptionsWithEquals() {
+        ArgumentConfigSource source = new ArgumentConfigSource(new String[] {
+                "-f=yes",
+                "--version=1.0",
+                "--arg-name=foo"
+        });
+        assertEquals("yes", source.getValue("f"));
+        assertEquals("1.0", source.getValue("version"));
+        assertEquals("foo", source.getValue("arg-name"));
+    }
+
+    @Test
+    public void shouldParseEmptyOptions() {
+        ArgumentConfigSource source = new ArgumentConfigSource(new String[] {
+                "-f",
+                "--version",
+                "--arg-name"
+        });
+        assertEquals(ArgumentConfigSource.TRUE, source.getValue("f"));
+        assertEquals(ArgumentConfigSource.TRUE, source.getValue("version"));
+        assertEquals(ArgumentConfigSource.TRUE, source.getValue("arg-name"));
+    }
+
+    @Test
+    public void shouldParseSeparateOptions() {
+        ArgumentConfigSource source = new ArgumentConfigSource(new String[] {
+                "-f", "foo.txt",
+                "--arg-name",
+                "--arg", "foo"
+        });
+        assertEquals("foo.txt", source.getValue("f"));
+        assertEquals(ArgumentConfigSource.TRUE, source.getValue("arg-name"));
+        assertEquals("foo", source.getValue("arg"));
+    }
+
+    @Test
+    public void shouldSupportMultipleValuesAsSeparateArguments() {
+        ArgumentConfigSource source = new ArgumentConfigSource(new String[] {
+                "--foo=1",
+                "--foo=2",
+                "--foo=3"
+        });
+        assertEquals("1,2,3", source.getValue("foo"));
+    }
+}


### PR DESCRIPTION
- Uses a GNU-style argument form (essentially --arg-name=foo and --arg-name foo).
- Short arguments with no value should be supported corresponding to boolean properties e.g. -x

This should check one of the boxes in https://github.com/quarkusio/quarkus/issues/6497

cc @dmlloyd 