### PR TITLE
Add new default converter for java.util.UUID

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
@@ -91,4 +91,7 @@ interface ConfigMessages {
 
     @Message(id = 25, value = "Recursive expression expansion is too deep for %s")
     IllegalArgumentException expressionExpansionTooDepth(String name);
+
+    @Message(id = 26, value = "%s cannot be converted into a UUID")
+    IllegalArgumentException malformedUUID(@Cause Throwable cause, String malformedUUID);
 }

--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.UUID;
 import java.util.function.IntFunction;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -118,6 +119,15 @@ public final class Converters {
     static final Converter<Byte> BYTE_CONVERTER = BuiltInConverter.of(13,
             newTrimmingConverter(newEmptyValueConverter(Byte::valueOf)));
 
+    static final Converter<UUID> UUID_CONVERTER = BuiltInConverter.of(14,
+            newTrimmingConverter(newEmptyValueConverter((s) -> {
+                try {
+                    return UUID.fromString(s);
+                } catch (IllegalArgumentException e) {
+                    throw ConfigMessages.msg.malformedUUID(e, s);
+                }
+            })));
+
     static final Map<Class<?>, Class<?>> PRIMITIVE_TYPES;
 
     static final Map<Type, Converter<?>> ALL_CONVERTERS = new HashMap<>();
@@ -147,6 +157,8 @@ public final class Converters {
         ALL_CONVERTERS.put(Character.class, CHARACTER_CONVERTER);
 
         ALL_CONVERTERS.put(Byte.class, BYTE_CONVERTER);
+
+        ALL_CONVERTERS.put(UUID.class, UUID_CONVERTER);
 
         Map<Class<?>, Class<?>> primitiveTypes = new HashMap<>(9);
         primitiveTypes.put(byte.class, Byte.class);
@@ -860,6 +872,8 @@ public final class Converters {
                     return SHORT_CONVERTER;
                 case 13:
                     return BYTE_CONVERTER;
+                case 14:
+                    return UUID_CONVERTER;
                 default:
                     throw ConfigMessages.msg.unknownConverterId(id);
             }

--- a/implementation/src/test/java/io/smallrye/config/ConfigSerializationTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigSerializationTest.java
@@ -30,14 +30,14 @@ public class ConfigSerializationTest {
             out.writeObject(config);
         } catch (Exception e) {
             e.printStackTrace();
-            fail("Config should be serializable, but could not serialize it");
+            fail("Config should be serializable, but could not serialize it", e);
         }
 
         Object readObject = null;
         try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))) {
             readObject = in.readObject();
         } catch (Exception e) {
-            fail("Config config should be serializable, but could not deserialize the instance");
+            fail("Config config should be serializable, but could not deserialize the instance", e);
         }
 
         SmallRyeConfig serialized = (SmallRyeConfig) readObject;


### PR DESCRIPTION
This PR introduces a new default converter for UUIDs.

There are many instances where a configuration value can be reasonably expected to be a UUID as it is becoming an increasingly common identifier.

My motivation for this PR is to allow UUIDs within configuration properties in Quarkus like so:

```java
import io.quarkus.arc.config.ConfigProperties;
import java.util.UUID;

@ConfigProperties(prefix = "some.config")
public interface InvoicingConfigurationProperties {
    UUID getFallbackId();
}
```

Currently, without further plumbing work, this would result in a runtime exception of:
`java.lang.IllegalArgumentException: SRCFG00013: No Converter registered for class java.util.UUID`

I think it would be more useful to have this as a default converter within this library however if it's out of scope, please let me know!

This PR also adjusts the ConfigSerializationTest and prints out any exception caused in serialization/deserialization. I'd forgotten to update the case statement within Converters.Ser#readResolve and so that rightfully broke the test, however, since the unknownConverterId exception was swallowed it made the cause slightly obscure!