### PR TITLE
Provide a way to load the ConfigMapping implementation classes in separate steps.

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -9,7 +9,6 @@ import static io.smallrye.config.ConfigMappingInterface.rawTypeOf;
 import static io.smallrye.config.ConfigMappingInterface.typeOfParameter;
 import static io.smallrye.config.ConfigValidationException.Problem;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
@@ -67,25 +66,9 @@ public final class ConfigMappingContext {
     }
 
     public <T> T constructGroup(Class<T> interfaceType) {
-        Constructor<? extends ConfigMappingObject> constructor = getConfigurationInterface(interfaceType).getConstructor();
-        ConfigMappingObject instance;
-        try {
-            instance = constructor.newInstance(this);
-        } catch (InstantiationException e) {
-            throw new InstantiationError(e.getMessage());
-        } catch (IllegalAccessException e) {
-            throw new IllegalAccessError(e.getMessage());
-        } catch (InvocationTargetException e) {
-            try {
-                throw e.getCause();
-            } catch (RuntimeException | Error e2) {
-                throw e2;
-            } catch (Throwable t) {
-                throw new UndeclaredThrowableException(t);
-            }
-        }
-        allInstances.add(instance);
-        return interfaceType.cast(instance);
+        final T mappingObject = ConfigMappingObjectLoader.configMappingObject(interfaceType, this);
+        allInstances.add((ConfigMappingObject) mappingObject);
+        return mappingObject;
     }
 
     @SuppressWarnings({ "unchecked", "unused" })

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingMetadata.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingMetadata.java
@@ -1,0 +1,9 @@
+package io.smallrye.config;
+
+public interface ConfigMappingMetadata {
+    Class<?> getInterfaceType();
+
+    String getClassName();
+
+    byte[] getClassBytes();
+}

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingObjectLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingObjectLoader.java
@@ -1,0 +1,82 @@
+package io.smallrye.config;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.UndeclaredThrowableException;
+
+import io.smallrye.common.classloader.ClassDefiner;
+
+public final class ConfigMappingObjectLoader {
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    private static final ClassValue<ConfigMappingObjectHolder> CACHE = new ClassValue<ConfigMappingObjectHolder>() {
+        @Override
+        protected ConfigMappingObjectHolder computeValue(final Class<?> type) {
+            return new ConfigMappingObjectHolder(getImplementationClass(type));
+        }
+    };
+
+    public static ConfigMappingMetadata getConfigMappingMetadata(Class<?> interfaceType) {
+        return ConfigMappingInterface.getConfigurationInterface(interfaceType);
+    }
+
+    static <T> T configMappingObject(Class<T> interfaceType, ConfigMappingContext configMappingContext) {
+        ConfigMappingObject instance;
+        try {
+            Constructor<? extends ConfigMappingObject> constructor = CACHE.get(interfaceType).getImplementationClass()
+                    .getDeclaredConstructor(ConfigMappingContext.class);
+            instance = constructor.newInstance(configMappingContext);
+        } catch (NoSuchMethodException e) {
+            throw new NoSuchMethodError(e.getMessage());
+        } catch (InstantiationException e) {
+            throw new InstantiationError(e.getMessage());
+        } catch (IllegalAccessException e) {
+            throw new IllegalAccessError(e.getMessage());
+        } catch (InvocationTargetException e) {
+            try {
+                throw e.getCause();
+            } catch (RuntimeException | Error e2) {
+                throw e2;
+            } catch (Throwable t) {
+                throw new UndeclaredThrowableException(t);
+            }
+        }
+        return interfaceType.cast(instance);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> Class<? extends ConfigMappingObject> getImplementationClass(Class<T> interfaceType) {
+        final ConfigMappingMetadata mappingMetadata = getConfigMappingMetadata(interfaceType);
+
+        // Check if the interface implementation was already loaded. If not we will load it.
+        try {
+            return (Class<? extends ConfigMappingObject>) interfaceType.getClassLoader()
+                    .loadClass(mappingMetadata.getClassName());
+        } catch (ClassNotFoundException e) {
+            // Ignore
+        }
+
+        return createMappingObjectClass(mappingMetadata.getClassName(),
+                mappingMetadata.getClassBytes());
+    }
+
+    @SuppressWarnings("unchecked")
+    static Class<? extends ConfigMappingObject> createMappingObjectClass(final String className,
+            final byte[] classBytes) {
+        return (Class<? extends ConfigMappingObject>) ClassDefiner.defineClass(LOOKUP, ConfigMappingObjectLoader.class,
+                className, classBytes);
+    }
+
+    private static final class ConfigMappingObjectHolder {
+        private final Class<? extends ConfigMappingObject> implementationClass;
+
+        ConfigMappingObjectHolder(final Class<? extends ConfigMappingObject> implementationClass) {
+            this.implementationClass = implementationClass;
+        }
+
+        public Class<? extends ConfigMappingObject> getImplementationClass() {
+            return implementationClass;
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -68,7 +68,7 @@ public final class ConfigMappings implements Serializable {
         private final Class<?> klass;
         private final String prefix;
 
-        private ConfigMappingWithPrefix(final Class<?> klass, final String prefix) {
+        public ConfigMappingWithPrefix(final Class<?> klass, final String prefix) {
             this.klass = klass;
             this.prefix = prefix;
         }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingObjectLoaderTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingObjectLoaderTest.java
@@ -1,0 +1,43 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ConfigMappingObjectLoaderTest {
+    @Test
+    void multipleLoads() {
+        ConfigMappingObjectLoader.getImplementationClass(Server.class);
+        ConfigMappingObjectLoader.getImplementationClass(Server.class);
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withSources(
+                KeyValuesConfigSource.config("server.host", "localhost", "server.port", "8080"))
+                .withMapping(Server.class)
+                .build();
+
+        Server server = config.getConfigMapping(Server.class);
+        assertEquals("localhost", server.host());
+        assertEquals(8080, server.port());
+    }
+
+    @Test
+    void loadManually() {
+        ConfigMappingMetadata mappingMetadata = ConfigMappingObjectLoader.getConfigMappingMetadata(ServerManual.class);
+        ConfigMappingObjectLoader.createMappingObjectClass(mappingMetadata.getClassName(), mappingMetadata.getClassBytes());
+        ConfigMappingObjectLoader.getImplementationClass(ServerManual.class);
+        ConfigMappingObjectLoader.getImplementationClass(ServerManual.class);
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface Server {
+        String host();
+
+        int port();
+    }
+
+    interface ServerManual {
+        String host();
+
+        int port();
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingProviderTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingProviderTest.java
@@ -416,6 +416,19 @@ public class ConfigMappingProviderTest {
         assertEquals(9090, cloud.port());
     }
 
+    @Test
+    void superTypes() {
+        final SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerChild.class, "server")
+                .withSources(config("server.host", "localhost", "server.port", "8080"))
+                .build();
+
+        final ServerChild server = config.getConfigMapping(ServerChild.class, "server");
+        assertNotNull(server);
+        assertEquals("localhost", server.host());
+        assertEquals(8080, server.port());
+    }
+
     interface Server {
         String host();
 
@@ -552,6 +565,14 @@ public class ConfigMappingProviderTest {
     public interface ServerAnnotated {
         String host();
 
+        int port();
+    }
+
+    public interface ServerParent {
+        String host();
+    }
+
+    public interface ServerChild extends ServerParent {
         int port();
     }
 }


### PR DESCRIPTION
This is mostly to help with Quarkus integration.

Prototype for Quarkus (still missing the CDI bits):
https://github.com/radcortez/quarkus/commit/9a8f24a872c72510b0b6197ea0ff9b1f49460801