### PR TITLE
Fix thread local leak

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/Expressions.java
+++ b/implementation/src/main/java/io/smallrye/config/Expressions.java
@@ -4,14 +4,15 @@ import java.util.function.Supplier;
 
 @SuppressWarnings("squid:S5164")
 public final class Expressions {
-    private static final ThreadLocal<Boolean> ENABLE = ThreadLocal.withInitial(() -> Boolean.TRUE);
+    private static final ThreadLocal<Boolean> ENABLE = new ThreadLocal<>();
 
     private Expressions() {
         throw new UnsupportedOperationException();
     }
 
     public static boolean isEnabled() {
-        return ENABLE.get();
+        Boolean result = ENABLE.get();
+        return result == null ? true : result;
     }
 
     public static void withoutExpansion(final Runnable action) {
@@ -27,7 +28,7 @@ public final class Expressions {
             try {
                 return supplier.get();
             } finally {
-                ENABLE.set(true);
+                ENABLE.remove();
             }
         } else {
             return supplier.get();

--- a/implementation/src/main/java/io/smallrye/config/SecretKeys.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeys.java
@@ -4,14 +4,15 @@ import java.util.function.Supplier;
 
 @SuppressWarnings("squid:S5164")
 public final class SecretKeys {
-    private static final ThreadLocal<Boolean> LOCKED = ThreadLocal.withInitial(() -> Boolean.TRUE);
+    private static final ThreadLocal<Boolean> LOCKED = new ThreadLocal<>();
 
     private SecretKeys() {
         throw new UnsupportedOperationException();
     }
 
     public static boolean isLocked() {
-        return LOCKED.get();
+        Boolean result = LOCKED.get();
+        return result == null ? true : result;
     }
 
     public static void doUnlocked(Runnable runnable) {
@@ -27,7 +28,7 @@ public final class SecretKeys {
             try {
                 return supplier.get();
             } finally {
-                LOCKED.set(true);
+                LOCKED.remove();
             }
         } else {
             return supplier.get();


### PR DESCRIPTION
As the thread local was set and not cleaned up
threads end up with a reference to the lambda
used to supply the initial value. This can
result in a ClassLoader leak.

Signed-off-by: Stuart Douglas <sdouglas@redhat.com>