### PR TITLE
Fix Converter Priority and add unit test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,22 +31,10 @@ jobs:
       - uses: actions/checkout@v2
         name: checkout
 
-      - uses: actions/checkout@v2
-        name: checkout mp 2.0
-        with:
-          repository: eclipse/microprofile-config
-          path: microprofile-config
-
       - uses: actions/setup-java@v1.3.0
         name: set up jdk ${{matrix.java}}
         with:
           java-version: ${{matrix.java}}
-
-      - name: build microprofile config
-        run: |
-          cd microprofile-config
-          mvn install
-          cd ..
 
       - name: build with maven
         run: mvn -B formatter:validate verify --file pom.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: 
       - master
-      - mp2.0
+      - mpconfig20
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - master
+      - mp2.0
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -30,10 +31,22 @@ jobs:
       - uses: actions/checkout@v2
         name: checkout
 
+      - uses: actions/checkout@v2
+        name: checkout mp 2.0
+        with:
+          repository: eclipse/microprofile-config
+          path: microprofile-config
+
       - uses: actions/setup-java@v1.3.0
         name: set up jdk ${{matrix.java}}
         with:
           java-version: ${{matrix.java}}
+
+      - name: build microprofile config
+        run: |
+          cd microprofile-config
+          mvn install
+          cd ..
 
       - name: build with maven
         run: mvn -B formatter:validate verify --file pom.xml

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -118,6 +118,19 @@
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jboss.bridger</groupId>
+        <artifactId>bridger</artifactId>
+        <executions>
+          <execution>
+            <id>weave</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>transform</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -51,7 +51,9 @@ final class ConfigMappingClass {
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
 
         String classInternalName = getInternalName(classType);
-        String interfaceInternalName = classInternalName + "I";
+        String interfaceName = classType.getName() + "I";
+        String interfaceInternalName = interfaceName.replace('.', '/');
+
         writer.visit(V1_8, ACC_PUBLIC | ACC_INTERFACE | ACC_ABSTRACT, interfaceInternalName, null, I_OBJECT,
                 new String[] { getInternalName(ConfigMappingClassMapper.class) });
 
@@ -86,7 +88,7 @@ final class ConfigMappingClass {
         ctor.visitMaxs(2, 2);
         writer.visitEnd();
 
-        return ClassDefiner.defineClass(MethodHandles.lookup(), ConfigMappingClass.class, interfaceInternalName,
+        return ClassDefiner.defineClass(MethodHandles.lookup(), ConfigMappingClass.class, interfaceName,
                 writer.toByteArray());
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -15,7 +15,6 @@ import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.NEW;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.V1_8;
-import static org.objectweb.asm.Type.BOOLEAN;
 import static org.objectweb.asm.Type.getDescriptor;
 import static org.objectweb.asm.Type.getInternalName;
 import static org.objectweb.asm.Type.getMethodDescriptor;
@@ -147,6 +146,11 @@ final class ConfigMappingClass {
         ctor.visitVarInsn(ASTORE, 1);
 
         for (Field declaredField : declaredFields) {
+            if (Modifier.isStatic(declaredField.getModifiers()) || Modifier.isVolatile(declaredField.getModifiers())
+                    || Modifier.isFinal(declaredField.getModifiers())) {
+                continue;
+            }
+
             String name = declaredField.getName();
             Class<?> type = declaredField.getType();
 

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -1,0 +1,111 @@
+package io.smallrye.config;
+
+import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
+import static org.objectweb.asm.Opcodes.ACC_INTERFACE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.objectweb.asm.Opcodes.PUTFIELD;
+import static org.objectweb.asm.Opcodes.V1_8;
+import static org.objectweb.asm.Type.getDescriptor;
+import static org.objectweb.asm.Type.getInternalName;
+import static org.objectweb.asm.Type.getMethodDescriptor;
+import static org.objectweb.asm.Type.getType;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+
+import sun.misc.Unsafe;
+
+final class ConfigMappingClass {
+    private static final ClassValue<Class<?>> cv = new ClassValue<Class<?>>() {
+        @Override
+        protected Class<?> computeValue(final Class<?> type) {
+            return createConfigurationClass(type);
+        }
+    };
+    private static final Unsafe unsafe;
+
+    static {
+        unsafe = AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
+            public Unsafe run() {
+                try {
+                    final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+                    field.setAccessible(true);
+                    return (Unsafe) field.get(null);
+                } catch (IllegalAccessException e) {
+                    throw new IllegalAccessError(e.getMessage());
+                } catch (NoSuchFieldException e) {
+                    throw new NoSuchFieldError(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private static final String I_OBJECT = getInternalName(Object.class);
+
+    static Class<?> toInterface(final Class<?> classType) {
+        return cv.get(classType);
+    }
+
+    private static Class<?> createConfigurationClass(final Class<?> classType) {
+        if (classType.isInterface() && classType.getTypeParameters().length == 0 ||
+                Modifier.isAbstract(classType.getModifiers()) ||
+                classType.isEnum()) {
+            return classType;
+        }
+
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+
+        String classInternalName = getInternalName(classType);
+        String interfaceInternalName = classInternalName + "I";
+        writer.visit(V1_8, ACC_PUBLIC | ACC_INTERFACE | ACC_ABSTRACT, interfaceInternalName, null, I_OBJECT,
+                new String[] { getInternalName(ConfigMappingClassMapper.class) });
+
+        Field[] declaredFields = classType.getDeclaredFields();
+        for (Field declaredField : declaredFields) {
+            writer.visitMethod(ACC_PUBLIC | ACC_ABSTRACT, declaredField.getName(),
+                    getMethodDescriptor(getType(declaredField.getType())), null, null);
+            writer.visitEnd();
+        }
+
+        MethodVisitor ctor = writer.visitMethod(ACC_PUBLIC, "map", "()L" + I_OBJECT + ";", null, null);
+        Label ctorStart = new Label();
+        ctor.visitLabel(ctorStart);
+        ctor.visitTypeInsn(NEW, classInternalName);
+        ctor.visitInsn(DUP);
+        ctor.visitMethodInsn(INVOKESPECIAL, classInternalName, "<init>", "()V", false);
+        ctor.visitVarInsn(ASTORE, 1);
+
+        for (Field declaredField : declaredFields) {
+            String name = declaredField.getName();
+            Class<?> type = declaredField.getType();
+
+            ctor.visitVarInsn(ALOAD, 1);
+            ctor.visitVarInsn(ALOAD, 0);
+            ctor.visitMethodInsn(INVOKEINTERFACE, interfaceInternalName, name, getMethodDescriptor(getType(type)),
+                    true);
+            ctor.visitFieldInsn(PUTFIELD, classInternalName, name, getDescriptor(type));
+        }
+
+        ctor.visitVarInsn(ALOAD, 1);
+        ctor.visitInsn(ARETURN);
+        ctor.visitMaxs(2, 2);
+        writer.visitEnd();
+
+        byte[] bytes = writer.toByteArray();
+        return unsafe.defineClass(classType.getName() + "I", bytes, 0, bytes.length, ConfigMappingClass.class.getClassLoader(),
+                null);
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -15,6 +15,7 @@ import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.NEW;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.V1_8;
+import static org.objectweb.asm.Type.BOOLEAN;
 import static org.objectweb.asm.Type.getDescriptor;
 import static org.objectweb.asm.Type.getInternalName;
 import static org.objectweb.asm.Type.getMethodDescriptor;
@@ -124,7 +125,7 @@ final class ConfigMappingClass {
                 try {
                     declaredField.setAccessible(true);
                     Object defaultValue = declaredField.get(classInstance);
-                    if (defaultValue != null) {
+                    if (hasDefaultValue(declaredField.getType(), defaultValue)) {
                         AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithDefault.class) + ";", true);
                         av.visit("value", defaultValue.toString());
                         av.visitEnd();
@@ -221,5 +222,25 @@ final class ConfigMappingClass {
         }
 
         return null;
+    }
+
+    private static boolean hasDefaultValue(final Class<?> klass, final Object value) {
+        if (value == null) {
+            return false;
+        }
+
+        if (klass.isPrimitive() && value instanceof Number && value.equals(0)) {
+            return false;
+        }
+
+        if (klass.isPrimitive() && value instanceof Boolean && value.equals(Boolean.FALSE)) {
+            return false;
+        }
+
+        if (klass.isPrimitive() && value instanceof Character && value.equals(0)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -66,7 +66,7 @@ final class ConfigMappingClass {
         Field[] declaredFields = classType.getDeclaredFields();
         for (Field declaredField : declaredFields) {
             writer.visitMethod(ACC_PUBLIC | ACC_ABSTRACT, declaredField.getName(),
-                    getMethodDescriptor(getType(declaredField.getType())), null, null);
+                    getMethodDescriptor(getType(declaredField.getType())), getSignature(declaredField), null);
             writer.visitEnd();
         }
 
@@ -142,5 +142,17 @@ final class ConfigMappingClass {
 
         return ClassDefiner.defineClass(MethodHandles.lookup(), ConfigMappingClass.class, interfaceName,
                 writer.toByteArray());
+    }
+
+    private static String getSignature(final Field field) {
+        final String typeName = field.getGenericType().getTypeName();
+        if (typeName.indexOf('<') != -1 && typeName.indexOf('>') != -1) {
+            String signature = "()L" + typeName.replace(".", "/");
+            signature = signature.replace("<", "<L");
+            signature = signature.replace(">", ";>;");
+            return signature;
+        }
+
+        return null;
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -57,7 +57,8 @@ final class ConfigMappingClass {
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
 
         String classInternalName = getInternalName(classType);
-        String interfaceName = classType.getName() + "I";
+        String interfaceName = ConfigMappingClass.class.getPackage().getName() + "." + classType.getSimpleName() +
+                classType.getName().hashCode() + "I";
         String interfaceInternalName = interfaceName.replace('.', '/');
 
         writer.visit(V1_8, ACC_PUBLIC | ACC_INTERFACE | ACC_ABSTRACT, interfaceInternalName, null, I_OBJECT,

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClassMapper.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClassMapper.java
@@ -1,0 +1,7 @@
+package io.smallrye.config;
+
+public interface ConfigMappingClassMapper {
+    default Object map() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -108,14 +108,14 @@ public final class ConfigMappingContext {
                             Class<?> valueRawType = leafProperty.getValueRawType();
                             if (valueRawType == List.class) {
                                 return Converters.newCollectionConverter(
-                                        config.getConverter(rawTypeOf(typeOfParameter(leafProperty.getValueType(), 0))),
+                                        config.requireConverter(rawTypeOf(typeOfParameter(leafProperty.getValueType(), 0))),
                                         ArrayList::new);
                             } else if (valueRawType == Set.class) {
                                 return Converters.newCollectionConverter(
-                                        config.getConverter(rawTypeOf(typeOfParameter(leafProperty.getValueType(), 0))),
+                                        config.requireConverter(rawTypeOf(typeOfParameter(leafProperty.getValueType(), 0))),
                                         HashSet::new);
                             } else {
-                                return config.getConverter(valueRawType);
+                                return config.requireConverter(valueRawType);
                             }
                         }
                     } else if (property.isPrimitive()) {
@@ -123,7 +123,7 @@ public final class ConfigMappingContext {
                         if (primitiveProperty.hasConvertWith()) {
                             return getConverterInstance(primitiveProperty.getConvertWith());
                         } else {
-                            return config.getConverter(primitiveProperty.getBoxType());
+                            return config.requireConverter(primitiveProperty.getBoxType());
                         }
                     } else {
                         throw new IllegalStateException();
@@ -153,12 +153,14 @@ public final class ConfigMappingContext {
                         Class<?> valueRawType = property.getKeyRawType();
                         if (valueRawType == List.class) {
                             return Converters.newCollectionConverter(
-                                    config.getConverter(rawTypeOf(typeOfParameter(property.getKeyType(), 0))), ArrayList::new);
+                                    config.requireConverter(rawTypeOf(typeOfParameter(property.getKeyType(), 0))),
+                                    ArrayList::new);
                         } else if (valueRawType == Set.class) {
                             return Converters.newCollectionConverter(
-                                    config.getConverter(rawTypeOf(typeOfParameter(property.getKeyType(), 0))), HashSet::new);
+                                    config.requireConverter(rawTypeOf(typeOfParameter(property.getKeyType(), 0))),
+                                    HashSet::new);
                         } else {
-                            return config.getConverter(valueRawType);
+                            return config.requireConverter(valueRawType);
                         }
                     }
                 });

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
@@ -668,7 +668,7 @@ final class ConfigMappingProvider implements Serializable {
 
         public Builder addRoot(String path, Class<?> type) {
             Assert.checkNotNullParam("type", type);
-            return addRoot(path, getConfigurationInterface(type));
+            return addRoot(path, getConfigurationInterface(ConfigMappingClass.toInterface(type)));
         }
 
         public Builder addRoot(String path, ConfigMappingInterface info) {

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
@@ -388,14 +388,14 @@ final class ConfigMappingProvider implements Serializable {
                 if (keyConvertWith != null) {
                     keyConv = mc.getConverterInstance(keyConvertWith);
                 } else {
-                    keyConv = config.getConverter(keyRawType);
+                    keyConv = config.requireConverter(keyRawType);
                 }
                 Object key = keyConv.convert(rawMapKey);
                 Converter<?> valueConv;
                 if (valConvertWith != null) {
                     valueConv = mc.getConverterInstance(valConvertWith);
                 } else {
-                    valueConv = config.getConverter(valueRawType);
+                    valueConv = config.requireConverter(valueRawType);
                 }
                 ((Map) map).put(key, config.getValue(configKey, valueConv));
             });
@@ -411,7 +411,7 @@ final class ConfigMappingProvider implements Serializable {
                 if (keyConvertWith != null) {
                     keyConv = mc.getConverterInstance(keyConvertWith);
                 } else {
-                    keyConv = config.getConverter(keyRawType);
+                    keyConv = config.requireConverter(keyRawType);
                 }
                 Object key = keyConv.convert(rawMapKey);
                 return (Map) ((Map) enclosingMap).computeIfAbsent(key, x -> new HashMap<>());

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
@@ -46,6 +46,7 @@ final class ConfigMappingProvider implements Serializable {
     private final Map<String, List<ConfigMappingInterface>> roots;
     private final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions;
     private final KeyMap<String> defaultValues;
+    private final boolean validateUnknown;
 
     ConfigMappingProvider(final Builder builder) {
         roots = new HashMap<>(builder.roots);
@@ -83,6 +84,7 @@ final class ConfigMappingProvider implements Serializable {
         }
         this.matchActions = matchActions;
         this.defaultValues = defaultValues;
+        this.validateUnknown = builder.validateUnknown;
     }
 
     static String skewer(Method method) {
@@ -635,7 +637,9 @@ final class ConfigMappingProvider implements Serializable {
             if (action != null) {
                 action.accept(context, ni);
             } else {
-                context.unknownConfigElement(name);
+                if (validateUnknown) {
+                    context.unknownConfigElement(name);
+                }
             }
         }
         ArrayList<ConfigValidationException.Problem> problems = context.getProblems();
@@ -662,6 +666,7 @@ final class ConfigMappingProvider implements Serializable {
     public static final class Builder {
         final Map<String, List<ConfigMappingInterface>> roots = new HashMap<>();
         final List<String[]> ignored = new ArrayList<>();
+        boolean validateUnknown = true;
 
         Builder() {
         }
@@ -681,6 +686,11 @@ final class ConfigMappingProvider implements Serializable {
         public Builder addIgnored(String path) {
             Assert.checkNotNullParam("path", path);
             ignored.add(path.split("\\."));
+            return this;
+        }
+
+        public Builder validateUnknown(boolean validateUnknown) {
+            this.validateUnknown = validateUnknown;
             return this;
         }
 

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -29,7 +29,7 @@ public final class ConfigMappings implements Serializable {
 
     public void registerConfigMappings(final SmallRyeConfig config, final Set<ConfigMappingWithPrefix> mappings)
             throws ConfigValidationException {
-        final ConfigMappingProvider.Builder builder = ConfigMappingProvider.builder();
+        final ConfigMappingProvider.Builder builder = ConfigMappingProvider.builder().validateUnknown(false);
         for (ConfigMappingWithPrefix mapping : mappings) {
             builder.addRoot(mapping.getPrefix(), mapping.getKlass());
         }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 public final class ConfigMappings implements Serializable {
@@ -45,7 +46,11 @@ public final class ConfigMappings implements Serializable {
     }
 
     <T> T getConfigMapping(Class<T> type) {
-        String prefix = Optional.ofNullable(type.getAnnotation(ConfigMapping.class)).map(ConfigMapping::prefix).orElse("");
+        final String prefix = Optional.ofNullable(type.getAnnotation(ConfigMapping.class))
+                .map(ConfigMapping::prefix)
+                .orElseGet(() -> Optional.ofNullable(type.getAnnotation(ConfigProperties.class)).map(ConfigProperties::prefix)
+                        .orElse(""));
+
         return getConfigMapping(type, prefix);
     }
 
@@ -54,8 +59,8 @@ public final class ConfigMappings implements Serializable {
             return getConfigMapping(type);
         }
 
-        final ConfigMappingObject configMappingObject =
-            mappings.getOrDefault(ConfigMappingClass.toInterface(type), Collections.emptyMap()).get(prefix);
+        final ConfigMappingObject configMappingObject = mappings
+                .getOrDefault(ConfigMappingClass.toInterface(type), Collections.emptyMap()).get(prefix);
         if (configMappingObject == null) {
             throw ConfigMessages.msg.mappingNotFound(type.getName(), prefix);
         }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -54,10 +54,16 @@ public final class ConfigMappings implements Serializable {
             return getConfigMapping(type);
         }
 
-        final ConfigMappingObject configMappingObject = mappings.getOrDefault(type, Collections.emptyMap()).get(prefix);
+        final ConfigMappingObject configMappingObject =
+            mappings.getOrDefault(ConfigMappingClass.toInterface(type), Collections.emptyMap()).get(prefix);
         if (configMappingObject == null) {
             throw ConfigMessages.msg.mappingNotFound(type.getName(), prefix);
         }
+
+        if (configMappingObject instanceof ConfigMappingClassMapper) {
+            return type.cast(((ConfigMappingClassMapper) configMappingObject).map());
+        }
+
         return type.cast(configMappingObject);
     }
 

--- a/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
@@ -97,4 +97,7 @@ interface ConfigMessages {
 
     @Message(id = 27, value = "Could not find a mapping for %s with prefix %s")
     NoSuchElementException mappingNotFound(String className, String prefix);
+
+    @Message(id = 28, value = "Type %s not supported for unwrapping.")
+    IllegalArgumentException getTypeNotSupportedForUnwrapping(Class<?> type);
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigValue.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigValue.java
@@ -17,7 +17,7 @@ import io.smallrye.common.annotation.Experimental;
  * Configuration lookup metadata.
  */
 @Experimental("Extension to the original ConfigSource to allow retrieval of additional metadata on config lookup")
-public class ConfigValue {
+public class ConfigValue implements org.eclipse.microprofile.config.ConfigValue {
     private final String name;
     private final String value;
     private final String configSourceName;
@@ -33,12 +33,24 @@ public class ConfigValue {
         this.lineNumber = builder.lineNumber;
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public String getSourceName() {
+        return getConfigSourceName();
+    }
+
+    @Override
+    public int getSourceOrdinal() {
+        return getConfigSourceOrdinal();
     }
 
     public String getConfigSourceName() {

--- a/implementation/src/main/java/io/smallrye/config/EnvConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/EnvConfigSource.java
@@ -20,6 +20,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import io.smallrye.config.common.AbstractConfigSource;
 
@@ -37,6 +38,11 @@ public class EnvConfigSource extends AbstractConfigSource {
     public Map<String, String> getProperties() {
         return Collections
                 .unmodifiableMap(AccessController.doPrivileged((PrivilegedAction<Map<String, String>>) System::getenv));
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Collections.unmodifiableSet(getProperties().keySet());
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/KeyMapBackedConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/KeyMapBackedConfigSource.java
@@ -2,6 +2,7 @@ package io.smallrye.config;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -29,6 +30,11 @@ public class KeyMapBackedConfigSource extends AbstractConfigSource {
 
     KeyMap<String> getKeyMapProperties() {
         return properties;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/MapBackedConfigValueConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/MapBackedConfigValueConfigSource.java
@@ -3,6 +3,7 @@ package io.smallrye.config;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -47,6 +48,11 @@ public abstract class MapBackedConfigValueConfigSource extends AbstractConfigSou
     public MapBackedConfigValueConfigSource(String name, Map<String, ConfigValue> propertyMap, int defaultOrdinal,
             boolean copy) {
         this(name, copy ? new LinkedHashMap<>(propertyMap) : propertyMap, defaultOrdinal);
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return properties.keySet();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/ProfilePropertiesConfigSourceProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/ProfilePropertiesConfigSourceProvider.java
@@ -1,0 +1,49 @@
+package io.smallrye.config;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalInt;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+public class ProfilePropertiesConfigSourceProvider implements ConfigSourceProvider {
+    private final List<ConfigSource> configSources;
+
+    public ProfilePropertiesConfigSourceProvider(String propertyFileName, boolean optional, ClassLoader classLoader) {
+        final ConfigurableConfigSource configurableConfigSource = new ConfigurableConfigSource(
+                new ConfigSourceFactory() {
+                    @Override
+                    public ConfigSource getConfigSource(final ConfigSourceContext context) {
+                        return null;
+                    }
+
+                    @Override
+                    public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
+                        final ConfigValue value = context.getValue("smallrye.config.profile");
+                        if (value != null) {
+                            final String profileName = value.getValue();
+                            final String profileFileName = propertyFileName.replaceAll("microprofile-config",
+                                    "microprofile-config-" + profileName);
+                            final PropertiesConfigSourceProvider propertiesConfigSourceProvider = new PropertiesConfigSourceProvider(
+                                    profileFileName, optional, classLoader);
+                            return propertiesConfigSourceProvider.getConfigSources(classLoader);
+                        }
+
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public OptionalInt getPriority() {
+                        return OptionalInt.of(101);
+                    }
+                });
+
+        this.configSources = Collections.singletonList(configurableConfigSource);
+    }
+
+    @Override
+    public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
+        return configSources;
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -127,7 +127,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     // no @Override
     public <T, C extends Collection<T>> C getValues(String name, Class<T> itemClass, IntFunction<C> collectionFactory) {
-        return getValues(name, getConverter(itemClass), collectionFactory);
+        return getValues(name, requireConverter(itemClass), collectionFactory);
     }
 
     public <T, C extends Collection<T>> C getValues(String name, Converter<T> converter, IntFunction<C> collectionFactory) {
@@ -136,7 +136,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     @Override
     public <T> T getValue(String name, Class<T> aClass) {
-        return getValue(name, getConverter(aClass));
+        return getValue(name, requireConverter(aClass));
     }
 
     public <T> T getValue(String name, Converter<T> converter) {
@@ -197,7 +197,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     public <T, C extends Collection<T>> Optional<C> getOptionalValues(String name, Class<T> itemClass,
             IntFunction<C> collectionFactory) {
-        return getOptionalValues(name, getConverter(itemClass), collectionFactory);
+        return getOptionalValues(name, requireConverter(itemClass), collectionFactory);
     }
 
     public <T, C extends Collection<T>> Optional<C> getOptionalValues(String name, Converter<T> converter,
@@ -244,34 +244,47 @@ public class SmallRyeConfig implements Config, Serializable {
     }
 
     public <T> T convert(String value, Class<T> asType) {
-        return value != null ? getConverter(asType).convert(value) : null;
+        return value != null ? requireConverter(asType).convert(value) : null;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private <T> Converter<Optional<T>> getOptionalConverter(Class<T> asType) {
         return optionalConverters.computeIfAbsent(asType,
-                clazz -> Converters.newOptionalConverter(getConverter((Class) clazz)));
+                clazz -> Converters.newOptionalConverter(requireConverter((Class) clazz)));
+    }
+
+    @Deprecated // binary-compatibility bridge method for Quarkus
+    public <T> Converter<T> getConverter$$bridge(Class<T> asType) {
+        return requireConverter(asType);
+    }
+
+    // @Override // in MP Config 2.0+
+    public <T> Optional<Converter<T>> getConverter(Class<T> asType) {
+        return Optional.ofNullable(getConverterOrNull(asType));
+    }
+
+    <T> Converter<T> requireConverter(final Class<T> asType) {
+        final Converter<T> conv = getConverterOrNull(asType);
+        if (conv == null) {
+            throw ConfigMessages.msg.noRegisteredConverter(asType);
+        }
+        return conv;
     }
 
     @SuppressWarnings("unchecked")
-    public <T> Converter<T> getConverter(Class<T> asType) {
+    <T> Converter<T> getConverterOrNull(Class<T> asType) {
         final Converter<?> exactConverter = converters.get(asType);
         if (exactConverter != null) {
             return (Converter<T>) exactConverter;
         }
         if (asType.isPrimitive()) {
-            return (Converter<T>) getConverter(Converters.wrapPrimitiveType(asType));
+            return (Converter<T>) getConverterOrNull(Converters.wrapPrimitiveType(asType));
         }
         if (asType.isArray()) {
-            return Converters.newArrayConverter(getConverter(asType.getComponentType()), asType);
+            final Converter<?> conv = getConverterOrNull(asType.getComponentType());
+            return conv == null ? null : Converters.newArrayConverter(conv, asType);
         }
-        return (Converter<T>) converters.computeIfAbsent(asType, clazz -> {
-            final Converter<?> conv = ImplicitConverters.getConverter((Class<?>) clazz);
-            if (conv == null) {
-                throw ConfigMessages.msg.noRegisteredConverter(asType);
-            }
-            return conv;
-        });
+        return (Converter<T>) converters.computeIfAbsent(asType, clazz -> ImplicitConverters.getConverter((Class<?>) clazz));
     }
 
     private static class ConfigSources implements Serializable {

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -221,12 +221,12 @@ public class SmallRyeConfig implements Config, Serializable {
 
     @Override
     public <T> T getConfigProperties(final Class<T> configProperties, final String prefix) {
-        throw new UnsupportedOperationException();
+        return getConfigMapping(configProperties, prefix);
     }
 
     @Override
     public <T> T getConfigProperties(final Class<T> configProperties) {
-        throw new UnsupportedOperationException();
+        return getConfigMapping(configProperties);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -220,6 +220,16 @@ public class SmallRyeConfig implements Config, Serializable {
     }
 
     @Override
+    public <T> T getConfigProperties(final Class<T> configProperties, final String prefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T getConfigProperties(final Class<T> configProperties) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Iterable<String> getPropertyNames() {
         final HashSet<String> names = new HashSet<>();
         configSources.get().getInterceptorChain().iterateNames().forEachRemaining(names::add);
@@ -285,6 +295,15 @@ public class SmallRyeConfig implements Config, Serializable {
             return conv == null ? null : Converters.newArrayConverter(conv, asType);
         }
         return (Converter<T>) converters.computeIfAbsent(asType, clazz -> ImplicitConverters.getConverter((Class<?>) clazz));
+    }
+
+    @Override
+    public <T> T unwrap(final Class<T> type) {
+        if (Config.class.isAssignableFrom(type)) {
+            return type.cast(this);
+        }
+
+        throw ConfigMessages.msg.getTypeNotSupportedForUnwrapping(type);
     }
 
     private static class ConfigSources implements Serializable {

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -170,7 +170,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
 
             @Override
             public OptionalInt getPriority() {
-                return OptionalInt.of(Priorities.LIBRARY + 800 - 1);
+                return OptionalInt.of(Priorities.LIBRARY + 600 - 1);
             }
         }));
         interceptors.add(new InterceptorWithPriority(new ExpressionConfigSourceInterceptor()));

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -160,6 +160,19 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
                 return OptionalInt.of(Priorities.LIBRARY + 600);
             }
         }));
+        interceptors.add(new InterceptorWithPriority(new ConfigSourceInterceptorFactory() {
+            @Override
+            public ConfigSourceInterceptor getInterceptor(final ConfigSourceInterceptorContext context) {
+                final Map<String, String> relocations = new HashMap<>();
+                relocations.put(ProfileConfigSourceInterceptor.SMALLRYE_PROFILE, "mp.config.profile");
+                return new RelocateConfigSourceInterceptor(relocations);
+            }
+
+            @Override
+            public OptionalInt getPriority() {
+                return OptionalInt.of(Priorities.LIBRARY + 800 - 1);
+            }
+        }));
         interceptors.add(new InterceptorWithPriority(new ExpressionConfigSourceInterceptor()));
         interceptors.add(new InterceptorWithPriority(new SecretKeysConfigSourceInterceptor(secretKeys)));
 

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -136,6 +136,12 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
                 .getConfigSources(classLoader));
         defaultSources.addAll(new PropertiesConfigSourceProvider(WEB_INF_MICROPROFILE_CONFIG_PROPERTIES, true, classLoader)
                 .getConfigSources(classLoader));
+        defaultSources
+                .addAll(new ProfilePropertiesConfigSourceProvider(META_INF_MICROPROFILE_CONFIG_PROPERTIES, true, classLoader)
+                        .getConfigSources(classLoader));
+        defaultSources
+                .addAll(new ProfilePropertiesConfigSourceProvider(WEB_INF_MICROPROFILE_CONFIG_PROPERTIES, true, classLoader)
+                        .getConfigSources(classLoader));
 
         return defaultSources;
     }

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -258,6 +258,11 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         return this;
     }
 
+    public SmallRyeConfigBuilder withValidateUnknown(boolean validateUnknown) {
+        mappingsBuilder.validateUnknown(validateUnknown);
+        return this;
+    }
+
     @Override
     public SmallRyeConfigBuilder withConverters(Converter<?>[] converters) {
         for (Converter<?> converter : converters) {

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -295,9 +295,8 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
             Map<Type, ConverterWithPriority> converters) {
         // add the converter only if it has a higher priority than another converter for the same type
         ConverterWithPriority oldConverter = converters.get(type);
-        int newPriority = getPriority(converter);
         if (oldConverter == null || priority > oldConverter.priority) {
-            converters.put(type, new ConverterWithPriority(converter, newPriority));
+            converters.put(type, new ConverterWithPriority(converter, priority));
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/config/SysPropConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/SysPropConfigSource.java
@@ -23,6 +23,7 @@ import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import io.smallrye.config.common.AbstractConfigSource;
 
@@ -40,6 +41,11 @@ class SysPropConfigSource extends AbstractConfigSource {
     public Map<String, String> getProperties() {
         return Collections.unmodifiableMap(
                 propertiesToMap(AccessController.doPrivileged((PrivilegedAction<Properties>) System::getProperties)));
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return getProperties().keySet();
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/WithDefault.java
+++ b/implementation/src/main/java/io/smallrye/config/WithDefault.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.FIELD })
 public @interface WithDefault {
     String value();
 }

--- a/implementation/src/main/java/io/smallrye/config/WithName.java
+++ b/implementation/src/main/java/io/smallrye/config/WithName.java
@@ -10,8 +10,8 @@ import java.lang.annotation.Target;
  * The name of the configuration property or group.
  */
 @Documented
-@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD })
 public @interface WithName {
     /**
      * The name of the property or group. Must not be empty.

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -128,7 +128,7 @@ public class ConfigExtension implements Extension {
             Type type = injectionPoint.getType();
 
             // We don't validate the Optional / Provider / Supplier / ConfigValue for defaultValue.
-            if (type instanceof Class && ConfigValue.class.isAssignableFrom((Class<?>) type)
+            if (type instanceof Class && org.eclipse.microprofile.config.ConfigValue.class.isAssignableFrom((Class<?>) type)
                     || type instanceof Class && OptionalInt.class.isAssignableFrom((Class<?>) type)
                     || type instanceof Class && OptionalLong.class.isAssignableFrom((Class<?>) type)
                     || type instanceof Class && OptionalDouble.class.isAssignableFrom((Class<?>) type)

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -47,13 +47,13 @@ import javax.inject.Provider;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.Converter;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.ConfigMappings;
 import io.smallrye.config.ConfigValidationException;
-import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SecretKeys;
 import io.smallrye.config.SmallRyeConfig;
 
@@ -77,10 +77,12 @@ public class ConfigExtension implements Extension {
     }
 
     protected void processConfigMappings(
-            @Observes @WithAnnotations({ ConfigMapping.class }) ProcessAnnotatedType<?> processAnnotatedType) {
+            @Observes @WithAnnotations({ ConfigProperties.class,
+                    ConfigMapping.class }) ProcessAnnotatedType<?> processAnnotatedType) {
 
         // Even if we filter in the CDI event, beans containing injection points of ConfigMapping are also fired.
-        if (processAnnotatedType.getAnnotatedType().isAnnotationPresent(ConfigMapping.class)) {
+        if (processAnnotatedType.getAnnotatedType().isAnnotationPresent(ConfigProperties.class)
+                || processAnnotatedType.getAnnotatedType().isAnnotationPresent(ConfigMapping.class)) {
             // We are going to veto, because it may be a managed bean and we will use a configurator bean
             processAnnotatedType.veto();
             configMappings.add(processAnnotatedType.getAnnotatedType());
@@ -92,7 +94,8 @@ public class ConfigExtension implements Extension {
             configPropertyInjectionPoints.add(pip.getInjectionPoint());
         }
 
-        if (pip.getInjectionPoint().getAnnotated().isAnnotationPresent(ConfigMapping.class)) {
+        if (pip.getInjectionPoint().getAnnotated().isAnnotationPresent(ConfigProperties.class)
+                || pip.getInjectionPoint().getAnnotated().isAnnotationPresent(ConfigMapping.class)) {
             configMappingInjectionPoints.add(pip.getInjectionPoint());
         }
     }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigMappingInjectionBean.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigMappingInjectionBean.java
@@ -21,6 +21,7 @@ import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.util.AnnotationLiteral;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperties;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.SmallRyeConfig;
@@ -36,6 +37,9 @@ public class ConfigMappingInjectionBean<T> implements Bean<T> {
         this.klass = type.getJavaClass();
         this.prefix = getConfigMappingPrefix(type);
         this.qualifiers.add(Default.Literal.INSTANCE);
+        if (type.isAnnotationPresent(ConfigProperties.class)) {
+            this.qualifiers.add(ConfigProperties.Literal.of(prefix));
+        }
     }
 
     @Override
@@ -62,6 +66,15 @@ public class ConfigMappingInjectionBean<T> implements Bean<T> {
         if (injectionPoint.getAnnotated() != null &&
                 injectionPoint.getAnnotated().isAnnotationPresent(ConfigMapping.class)) {
             overridePrefix = getConfigMappingPrefix(injectionPoint.getAnnotated());
+        } else if (!injectionPoint.getQualifiers().isEmpty()) {
+            overridePrefix = injectionPoint.getQualifiers()
+                    .stream()
+                    .filter(ConfigProperties.class::isInstance)
+                    .map(ConfigProperties.class::cast)
+                    .map(ConfigProperties::prefix)
+                    .findFirst()
+                    .orElse(prefix);
+
         } else {
             overridePrefix = prefix;
         }
@@ -106,7 +119,11 @@ public class ConfigMappingInjectionBean<T> implements Bean<T> {
     }
 
     static String getConfigMappingPrefix(final Annotated annotated) {
-        return Optional.ofNullable(annotated.getAnnotation(ConfigMapping.class)).map(ConfigMapping::prefix).orElse("");
+        return Optional.ofNullable(annotated.getAnnotation(ConfigMapping.class))
+                .map(ConfigMapping::prefix)
+                .orElseGet(
+                        () -> Optional.ofNullable(annotated.getAnnotation(ConfigProperties.class)).map(ConfigProperties::prefix)
+                                .orElse(""));
     }
 
     private static class MetadataInjectionPoint implements InjectionPoint {

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -185,6 +185,7 @@ public class ConfigProducer {
                 || requiredType == OptionalLong.class
                 || requiredType == OptionalDouble.class
                 || requiredType == Supplier.class
-                || requiredType == ConfigValue.class;
+                || requiredType == ConfigValue.class
+                || requiredType == org.eclipse.microprofile.config.ConfigValue.class;
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -103,7 +103,8 @@ public final class ConfigProducerUtil {
             }
         }
         // just try the raw type
-        return src.getConverter(rawType);
+        return src.getConverter(rawType).orElseThrow(() -> new IllegalArgumentException("No Converter registered for " +
+                rawType));
     }
 
     @SuppressWarnings("unchecked")

--- a/implementation/src/test/java/io/smallrye/config/ConfigConfigSourceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigConfigSourceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -28,6 +29,11 @@ public class ConfigConfigSourceTest {
 
                             @Override
                             public Map<String, String> getProperties() {
+                                return null;
+                            }
+
+                            @Override
+                            public Set<String> getPropertyNames() {
                                 return null;
                             }
 
@@ -69,6 +75,11 @@ public class ConfigConfigSourceTest {
 
                             @Override
                             public Map<String, String> getProperties() {
+                                return null;
+                            }
+
+                            @Override
+                            public Set<String> getPropertyNames() {
                                 return null;
                             }
 

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -79,6 +79,17 @@ class ConfigMappingClassTest {
         assertEquals(8080, server.getPort().getPort());
     }
 
+    @Test
+    void initialized() {
+        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerInitialized.class)
+                .withDefaultValue("host", "localhost")
+                //.withDefaultValue("port", "8080")
+                .build();
+        final ServerInitialized server = config.getConfigMapping(ServerInitialized.class);
+        assertEquals("localhost", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+
     static class ServerClass {
         String host;
         int port;
@@ -180,6 +191,19 @@ class ConfigMappingClassTest {
         @Override
         public ServerPort convert(final String value) {
             return new ServerPort(value);
+        }
+    }
+
+    static class ServerInitialized {
+        private String host;
+        private int port = 8080;
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
         }
     }
 }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -1,0 +1,35 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ConfigMappingClassTest {
+    @Test
+    void toClass() {
+        final Class<?> klass = ConfigMappingClass.toInterface(ServerClass.class);
+        ConfigMappingClass.toInterface(ServerClass.class);
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(klass)
+                .withDefaultValue("host", "localhost")
+                .withDefaultValue("port", "8080")
+                .build();
+
+        final ServerClass server = config.getConfigMapping(ServerClass.class);
+        assertEquals("localhost", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+
+    static class ServerClass {
+        String host;
+        int port;
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
@@ -88,6 +89,11 @@ class ConfigMappingClassTest {
         final ServerInitialized server = config.getConfigMapping(ServerInitialized.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
+    }
+
+    @Test
+    void initializedDefault() {
+        assertThrows(Exception.class, () -> new SmallRyeConfigBuilder().withMapping(ServerInitializedDefault.class).build());
     }
 
     @Test
@@ -211,6 +217,14 @@ class ConfigMappingClassTest {
         public String getHost() {
             return host;
         }
+
+        public int getPort() {
+            return port;
+        }
+    }
+
+    static class ServerInitializedDefault {
+        private int port;
 
         public int getPort() {
             return port;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.Converter;
 import org.junit.jupiter.api.Test;
 
@@ -83,9 +84,18 @@ class ConfigMappingClassTest {
     void initialized() {
         final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerInitialized.class)
                 .withDefaultValue("host", "localhost")
-                //.withDefaultValue("port", "8080")
                 .build();
         final ServerInitialized server = config.getConfigMapping(ServerInitialized.class);
+        assertEquals("localhost", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+
+    @Test
+    void mpConfig20() {
+        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerMPConfig20.class)
+                .withDefaultValue("name", "localhost")
+                .build();
+        final ServerMPConfig20 server = config.getConfigMapping(ServerMPConfig20.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
@@ -197,6 +207,21 @@ class ConfigMappingClassTest {
     static class ServerInitialized {
         private String host;
         private int port = 8080;
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+    }
+
+    static class ServerMPConfig20 {
+        @ConfigProperty(name = "name")
+        private String host;
+        @ConfigProperty(defaultValue = "8080")
+        private int port;
 
         public String getHost() {
             return host;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -8,9 +8,7 @@ class ConfigMappingClassTest {
     @Test
     void toClass() {
         final Class<?> klass = ConfigMappingClass.toInterface(ServerClass.class);
-        ConfigMappingClass.toInterface(ServerClass.class);
-
-        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(klass)
+        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(klass)
                 .withDefaultValue("host", "localhost")
                 .withDefaultValue("port", "8080")
                 .build();
@@ -20,9 +18,35 @@ class ConfigMappingClassTest {
         assertEquals(8080, server.getPort());
     }
 
+    @Test
+    void privateFields() {
+        final Class<?> klass = ConfigMappingClass.toInterface(ServerPrivate.class);
+        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(klass)
+                .withDefaultValue("host", "localhost")
+                .withDefaultValue("port", "8080")
+                .build();
+
+        final ServerPrivate server = config.getConfigMapping(ServerPrivate.class);
+        assertEquals("localhost", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+
     static class ServerClass {
         String host;
         int port;
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+    }
+
+    static class ServerPrivate {
+        private String host;
+        private int port;
 
         public String getHost() {
             return host;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -1,6 +1,10 @@
 package io.smallrye.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +35,21 @@ class ConfigMappingClassTest {
         assertEquals(8080, server.getPort());
     }
 
+    @Test
+    void optionals() {
+        final Class<?> klass = ConfigMappingClass.toInterface(ServerOptional.class);
+        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(klass)
+                .withDefaultValue("host", "localhost")
+                .withDefaultValue("port", "8080")
+                .build();
+
+        final ServerOptional server = config.getConfigMapping(ServerOptional.class);
+        assertTrue(server.getHost().isPresent());
+        assertEquals("localhost", server.getHost().get());
+        assertTrue(server.getPort().isPresent());
+        assertEquals(8080, server.getPort().getAsInt());
+    }
+
     static class ServerClass {
         String host;
         int port;
@@ -53,6 +72,19 @@ class ConfigMappingClassTest {
         }
 
         public int getPort() {
+            return port;
+        }
+    }
+
+    static class ServerOptional {
+        Optional<String> host;
+        OptionalInt port;
+
+        public Optional<String> getHost() {
+            return host;
+        }
+
+        public OptionalInt getPort() {
             return port;
         }
     }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingProviderTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingProviderTest.java
@@ -120,6 +120,24 @@ public class ConfigMappingProviderTest {
     }
 
     @Test
+    void validateUnknown() {
+        assertThrows(IllegalStateException.class,
+                () -> new SmallRyeConfigBuilder().addDefaultSources().withMapping(Server.class).build());
+
+        final SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultSources()
+                .withMapping(Server.class)
+                .withMapping(Server.class, "server")
+                .withValidateUnknown(false)
+                .withSources(config("server.host", "localhost", "server.port", "8080", "host", "localhost", "port", "8080"))
+                .build();
+
+        final Server configProperties = config.getConfigMapping(Server.class);
+        assertEquals("localhost", configProperties.host());
+        assertEquals(8080, configProperties.port());
+    }
+
+    @Test
     void splitRoots() throws Exception {
         final SmallRyeConfig config = new SmallRyeConfigBuilder().withSources(
                 config("server.host", "localhost", "server.port", "8080", "server.name", "konoha"))

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingProviderTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingProviderTest.java
@@ -339,6 +339,29 @@ public class ConfigMappingProviderTest {
     }
 
     @Test
+    void mapClass() {
+        final SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerClass.class, "server")
+                .withSources(config("server.host", "localhost", "server.port", "8080")).build();
+        final ServerClass server = config.getConfigMapping(ServerClass.class, "server");
+        assertEquals("localhost", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+
+    static class ServerClass {
+        String host;
+        int port;
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+    }
+
+    @Test
     void configMappingAnnotation() {
         final SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withMapping(ServerAnnotated.class, "server")

--- a/implementation/src/test/java/io/smallrye/config/ConfigSourceWrapperTestCase.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigSourceWrapperTestCase.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -92,6 +93,11 @@ public class ConfigSourceWrapperTestCase {
 
         public Map<String, String> getProperties() {
             return delegate.getProperties();
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return delegate.getPropertyNames();
         }
 
         public String getValue(final String propertyName) {

--- a/implementation/src/test/java/io/smallrye/config/ConfigValueTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigValueTest.java
@@ -1,0 +1,87 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+
+public class ConfigValueTest {
+    @Test
+    void configValue() {
+        final Config config = new SmallRyeConfigBuilder().addDefaultSources()
+                .addDefaultInterceptors()
+                .withSources(new ConfigValueConfigSource())
+                .withSources(new ConfigValueLowerConfigSource())
+                .build();
+
+        final ConfigValue configValue = config.getConfigValue("my.prop");
+        assertEquals("my.prop", configValue.getName());
+        assertEquals("1234", configValue.getValue());
+        assertEquals("ConfigValueConfigSource", configValue.getSourceName());
+        assertEquals(1000, configValue.getSourceOrdinal());
+    }
+
+    public static class ConfigValueConfigSource implements ConfigSource {
+        private Map<String, String> properties;
+
+        public ConfigValueConfigSource() {
+            properties = new HashMap<>();
+            properties.put("my.prop", "1234");
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return properties.keySet();
+        }
+
+        @Override
+        public String getValue(final String propertyName) {
+            return properties.get(propertyName);
+        }
+
+        @Override
+        public String getName() {
+            return this.getClass().getSimpleName();
+        }
+
+        @Override
+        public int getOrdinal() {
+            return 1000;
+        }
+    }
+
+    public static class ConfigValueLowerConfigSource implements ConfigSource {
+        private Map<String, String> properties;
+
+        public ConfigValueLowerConfigSource() {
+            properties = new HashMap<>();
+            properties.put("my.prop", "5678");
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            return properties.keySet();
+        }
+
+        @Override
+        public String getValue(final String propertyName) {
+            return properties.get(propertyName);
+        }
+
+        @Override
+        public String getName() {
+            return this.getClass().getSimpleName();
+        }
+
+        @Override
+        public int getOrdinal() {
+            return 900;
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ConvertersStringCleanupTestCase.java
+++ b/implementation/src/test/java/io/smallrye/config/ConvertersStringCleanupTestCase.java
@@ -56,7 +56,7 @@ public class ConvertersStringCleanupTestCase<T> {
     @MethodSource("data")
     public void testSimple(Class<T> type, T expected, String string) {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(string));
     }
 
@@ -64,7 +64,7 @@ public class ConvertersStringCleanupTestCase<T> {
     @MethodSource("data")
     public void testTrailingSpace(Class<T> type, T expected, String string) {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(string + " "));
     }
 
@@ -72,7 +72,7 @@ public class ConvertersStringCleanupTestCase<T> {
     @MethodSource("data")
     public void testLeadingSpace(Class<T> type, T expected, String string) {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(" " + string));
     }
 
@@ -80,7 +80,7 @@ public class ConvertersStringCleanupTestCase<T> {
     @MethodSource("data")
     public void testLeadingAndTrailingWhitespaces(Class<T> type, T expected, String string) {
         SmallRyeConfig config = buildConfig();
-        final Converter<T> converter = config.getConverter(type);
+        final Converter<T> converter = config.requireConverter(type);
         assertEquals(expected, converter.convert(" \t " + string + "\t\t "));
     }
 

--- a/implementation/src/test/java/io/smallrye/config/KeyValuesConfigSource.java
+++ b/implementation/src/test/java/io/smallrye/config/KeyValuesConfigSource.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -33,6 +34,11 @@ public class KeyValuesConfigSource implements ConfigSource, Serializable {
     @Override
     public Map<String, String> getProperties() {
         return Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Collections.unmodifiableSet(properties.keySet());
     }
 
     @Override

--- a/implementation/src/test/java/io/smallrye/config/ProfileConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ProfileConfigSourceInterceptorTest.java
@@ -188,6 +188,21 @@ public class ProfileConfigSourceInterceptorTest {
         assertEquals("2", config.getConfigValue("my.prop").getValue());
     }
 
+    @Test
+    public void mpProfileRelocate() {
+        final SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultInterceptors()
+                .withSources(
+                        KeyValuesConfigSource.config("my.prop", "1", "%prof.my.prop", "2", "mp.config.profile", "prof"))
+                .build();
+
+        assertEquals("2", config.getValue("my.prop", String.class));
+
+        assertEquals("my.prop", config.getConfigValue("my.prop").getName());
+        assertEquals("my.prop", config.getConfigValue("%prof.my.prop").getName());
+        assertEquals("2", config.getConfigValue("my.prop").getValue());
+    }
+
     private static Config buildConfig(String... keyValues) {
         return new SmallRyeConfigBuilder()
                 .withSources(KeyValuesConfigSource.config(keyValues))

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -56,7 +56,7 @@ public class SmallRyeConfigTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder().withSources(KeyValuesConfigSource.config("my.list", "1,2,3,4"))
                 .build();
 
-        List<Integer> values = config.getValues("my.list", config.getConverter(Integer.class), ArrayList::new);
+        List<Integer> values = config.getValues("my.list", config.getConverter(Integer.class).get(), ArrayList::new);
         assertEquals(Arrays.asList(1, 2, 3, 4), values);
     }
 
@@ -75,7 +75,7 @@ public class SmallRyeConfigTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder().withSources(KeyValuesConfigSource.config("my.list", "1,2,3,4"))
                 .build();
 
-        Optional<List<Integer>> values = config.getOptionalValues("my.list", config.getConverter(Integer.class),
+        Optional<List<Integer>> values = config.getOptionalValues("my.list", config.getConverter(Integer.class).get(),
                 ArrayList::new);
         assertTrue(values.isPresent());
         assertEquals(Arrays.asList(1, 2, 3, 4), values.get());

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -2,7 +2,9 @@ package io.smallrye.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -11,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.microprofile.config.Config;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.common.MapBackedConfigSource;
@@ -96,5 +99,14 @@ public class SmallRyeConfigTest {
 
         assertEquals(1234, config.convert("1234", Integer.class).intValue());
         assertNull(config.convert(null, Integer.class));
+    }
+
+    @Test
+    void unwrap() {
+        Config config = new SmallRyeConfigBuilder().build();
+        SmallRyeConfig smallRyeConfig = config.unwrap(SmallRyeConfig.class);
+
+        assertNotNull(smallRyeConfig);
+        assertThrows(IllegalArgumentException.class, () -> config.unwrap(Object.class));
     }
 }

--- a/implementation/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
+++ b/implementation/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
@@ -35,6 +35,7 @@ public class ConfigInjectionTest extends InjectionTest {
         assertEquals("1234", configBean.getMyProp());
         assertEquals("1234", configBean.getExpansion());
         assertEquals("12345678", configBean.getSecret());
+        assertEquals("5678", configBean.getMyPropProfile());
         assertThrows(SecurityException.class, () -> configBean.getConfig().getValue("secret", String.class),
                 "Not allowed to access secret key secret");
     }
@@ -67,6 +68,9 @@ public class ConfigInjectionTest extends InjectionTest {
         @ConfigProperty(name = "secret")
         private String secret;
         @Inject
+        @ConfigProperty(name = "my.prop.profile")
+        private String myPropProfile;
+        @Inject
         private Config config;
         @Inject
         @ConfigProperty(name = "my.prop")
@@ -85,6 +89,10 @@ public class ConfigInjectionTest extends InjectionTest {
 
         String getSecret() {
             return secret;
+        }
+
+        String getMyPropProfile() {
+            return myPropProfile;
         }
 
         Config getConfig() {

--- a/implementation/src/test/java/io/smallrye/config/inject/ConfigMappingInjectionTest.java
+++ b/implementation/src/test/java/io/smallrye/config/inject/ConfigMappingInjectionTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
@@ -19,7 +20,8 @@ import io.smallrye.config.WithDefault;
 public class ConfigMappingInjectionTest extends InjectionTest {
     @WeldSetup
     public WeldInitiator weld = WeldInitiator
-            .from(ConfigExtension.class, ConfigMappingInjectionTest.class, Server.class, Client.class)
+            .from(ConfigExtension.class, ConfigMappingInjectionTest.class, Server.class, Client.class,
+                    ServerConfigProperties.class)
             .inject(this)
             .build();
 
@@ -30,6 +32,11 @@ public class ConfigMappingInjectionTest extends InjectionTest {
     @Inject
     @ConfigMapping(prefix = "cloud")
     Server cloud;
+    @Inject
+    ServerConfigProperties serverConfigProperties;
+    @Inject
+    @ConfigProperties(prefix = "cloud")
+    ServerConfigProperties serverConfigPropertiesCloud;
 
     @Test
     void configMapping() {
@@ -50,6 +57,17 @@ public class ConfigMappingInjectionTest extends InjectionTest {
         assertNotNull(cloud);
         assertEquals("cloud", cloud.host());
         assertEquals(9090, cloud.port());
+    }
+
+    @Test
+    void configProperties() {
+        assertNotNull(serverConfigProperties);
+        assertEquals("localhost", serverConfigProperties.host);
+        assertEquals(8080, serverConfigProperties.port);
+
+        assertNotNull(serverConfigPropertiesCloud);
+        assertEquals("cloud", serverConfigPropertiesCloud.host);
+        assertEquals(9090, serverConfigPropertiesCloud.port);
     }
 
     @Test
@@ -74,5 +92,11 @@ public class ConfigMappingInjectionTest extends InjectionTest {
 
         @WithDefault("8080")
         int port();
+    }
+
+    @ConfigProperties(prefix = "server")
+    public static class ServerConfigProperties {
+        public String host;
+        public int port;
     }
 }

--- a/implementation/src/test/java/io/smallrye/config/inject/InjectionTestConfigFactory.java
+++ b/implementation/src/test/java/io/smallrye/config/inject/InjectionTestConfigFactory.java
@@ -1,7 +1,9 @@
 package io.smallrye.config.inject;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -17,13 +19,19 @@ public class InjectionTestConfigFactory extends SmallRyeConfigFactory {
         return configProviderResolver.getBuilder().forClassLoader(classLoader)
                 .addDefaultSources()
                 .addDefaultInterceptors()
-                .withSources(KeyValuesConfigSource.config("my.prop", "1234", "expansion", "${my.prop}", "secret", "12345678"))
+                .withSources(KeyValuesConfigSource.config("my.prop", "1234", "expansion", "${my.prop}", "secret", "12345678",
+                        "mp.config.profile", "prof", "my.prop.profile", "1234", "%prof.my.prop.profile", "5678"))
                 .withSources(new ConfigSource() {
                     int counter = 1;
 
                     @Override
                     public Map<String, String> getProperties() {
                         return new HashMap<>();
+                    }
+
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        return new HashSet<>();
                     }
 
                     @Override

--- a/implementation/src/test/java/io/smallrye/config/inject/InjectionTestConfigFactory.java
+++ b/implementation/src/test/java/io/smallrye/config/inject/InjectionTestConfigFactory.java
@@ -1,5 +1,7 @@
 package io.smallrye.config.inject;
 
+import static io.smallrye.config.KeyValuesConfigSource.config;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -7,7 +9,6 @@ import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
-import io.smallrye.config.KeyValuesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigFactory;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
@@ -19,7 +20,7 @@ public class InjectionTestConfigFactory extends SmallRyeConfigFactory {
         return configProviderResolver.getBuilder().forClassLoader(classLoader)
                 .addDefaultSources()
                 .addDefaultInterceptors()
-                .withSources(KeyValuesConfigSource.config("my.prop", "1234", "expansion", "${my.prop}", "secret", "12345678",
+                .withSources(config("my.prop", "1234", "expansion", "${my.prop}", "secret", "12345678",
                         "mp.config.profile", "prof", "my.prop.profile", "1234", "%prof.my.prop.profile", "5678"))
                 .withSources(new ConfigSource() {
                     int counter = 1;
@@ -44,13 +45,10 @@ public class InjectionTestConfigFactory extends SmallRyeConfigFactory {
                         return this.getClass().getName();
                     }
                 })
-                .withSources(KeyValuesConfigSource.config("optional.int.value", "1", "optional.long.value", "2",
-                        "optional.double.value", "3.3"))
+                .withSources(config("optional.int.value", "1", "optional.long.value", "2", "optional.double.value", "3.3"))
+                .withSources(
+                        config("server.host", "localhost", "server.port", "8080", "cloud.host", "cloud", "cloud.port", "9090"))
                 .withSecretKeys("secret")
-                .withDefaultValue("server.host", "localhost")
-                .withDefaultValue("cloud.host", "cloud")
-                .withDefaultValue("server.port", "8080")
-                .withDefaultValue("cloud.port", "9090")
                 .build();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <version.asm>8.0.1</version.asm>
-    <version.eclipse.microprofile.config>2.0-SNAPSHOT</version.eclipse.microprofile.config>
+    <version.eclipse.microprofile.config>2.0-M1</version.eclipse.microprofile.config>
     <version.smallrye.common>1.3.0</version.smallrye.common>
 
     <version.weld.junit>2.0.1.Final</version.weld.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <version.asm>8.0.1</version.asm>
-    <version.eclipse.microprofile.config>1.4</version.eclipse.microprofile.config>
+    <version.eclipse.microprofile.config>2.0-SNAPSHOT</version.eclipse.microprofile.config>
     <version.smallrye.common>1.3.0</version.smallrye.common>
 
     <version.weld.junit>2.0.1.Final</version.weld.junit>

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/source/MultipleProfilePropertiesConfigSourceTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/source/MultipleProfilePropertiesConfigSourceTest.java
@@ -1,0 +1,45 @@
+package io.smallrye.config.test.source;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class MultipleProfilePropertiesConfigSourceTest extends Arquillian {
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive sourceOne = ShrinkWrap
+                .create(JavaArchive.class)
+                .addAsManifestResource(new StringAsset("smallrye.config.profile=prod"), "microprofile-config.properties")
+                .addAsManifestResource(new StringAsset("my.prop.one=1234"), "microprofile-config-prod.properties")
+                .as(JavaArchive.class);
+
+        JavaArchive sourceTwo = ShrinkWrap
+                .create(JavaArchive.class)
+                .addAsManifestResource(new StringAsset("my.prop.two=1234"), "microprofile-config-prod.properties")
+                .as(JavaArchive.class);
+
+        WebArchive webArchive = ShrinkWrap
+                .create(WebArchive.class, "sources.war")
+                .addAsLibraries(sourceOne, sourceTwo);
+        System.out.println(webArchive.toString(true));
+        return webArchive;
+    }
+
+    @Inject
+    Config config;
+
+    @Test
+    public void multiple() {
+        assertEquals("1234", config.getValue("my.prop.one", String.class));
+        assertEquals("1234", config.getValue("my.prop.two", String.class));
+    }
+}

--- a/testsuite/extra/src/test/java/io/smallrye/config/test/source/MultiplePropertiesConfigSourceTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/config/test/source/MultiplePropertiesConfigSourceTest.java
@@ -1,0 +1,44 @@
+package io.smallrye.config.test.source;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class MultiplePropertiesConfigSourceTest extends Arquillian {
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive sourceOne = ShrinkWrap
+                .create(JavaArchive.class, "source-one.jar")
+                .addAsManifestResource(new StringAsset("my.prop.one=1234"), "microprofile-config.properties")
+                .as(JavaArchive.class);
+
+        JavaArchive sourceTwo = ShrinkWrap
+                .create(JavaArchive.class, "source-two.jar")
+                .addAsManifestResource(new StringAsset("my.prop.two=1234"), "microprofile-config.properties")
+                .as(JavaArchive.class);
+
+        WebArchive webArchive = ShrinkWrap
+                .create(WebArchive.class, "sources.war")
+                .addAsLibraries(sourceOne, sourceTwo);
+        System.out.println(webArchive.toString(true));
+        return webArchive;
+    }
+
+    @Inject
+    Config config;
+
+    @Test
+    public void multiple() {
+        assertEquals("1234", config.getValue("my.prop.one", String.class));
+        assertEquals("1234", config.getValue("my.prop.two", String.class));
+    }
+}

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -40,12 +40,15 @@
           </suiteXmlFiles>
           <!-- These env variables are required for org.eclipse.microprofile.config.tck.CDIPropertyNameMatchingTest -->
           <environmentVariables>
+            <MP_TCK_ENV_DUMMY>dummy</MP_TCK_ENV_DUMMY>
             <my_int_property>45</my_int_property>
             <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
             <my_string_property>haha</my_string_property>
             <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
           </environmentVariables>
-        </configuration>
+          <systemProperties>
+            <mp.tck.prop.dummy>dummy</mp.tck.prop.dummy>
+          </systemProperties>        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/testsuite/tck/src/test/java/io/smallrye/config/ConfigPropertiesTestFactory.java
+++ b/testsuite/tck/src/test/java/io/smallrye/config/ConfigPropertiesTestFactory.java
@@ -14,6 +14,7 @@ public class ConfigPropertiesTestFactory extends SmallRyeConfigFactory {
                 .addDiscoveredSources()
                 .addDiscoveredConverters()
                 .addDiscoveredInterceptors()
+                .withValidateUnknown(false)
                 .withMapping(ConfigPropertiesTest.BeanThree.class)
                 .withMapping(ConfigPropertiesTest.BeanThree.class, "other")
                 .build();

--- a/testsuite/tck/src/test/java/io/smallrye/config/ConfigPropertiesTestFactory.java
+++ b/testsuite/tck/src/test/java/io/smallrye/config/ConfigPropertiesTestFactory.java
@@ -1,0 +1,21 @@
+package io.smallrye.config;
+
+import org.eclipse.microprofile.config.tck.ConfigPropertiesTest;
+
+public class ConfigPropertiesTestFactory extends SmallRyeConfigFactory {
+    @Override
+    public SmallRyeConfig getConfigFor(
+            final SmallRyeConfigProviderResolver configProviderResolver, final ClassLoader classLoader) {
+
+        return configProviderResolver.getBuilder()
+                .forClassLoader(classLoader)
+                .addDefaultSources()
+                .addDefaultInterceptors()
+                .addDiscoveredSources()
+                .addDiscoveredConverters()
+                .addDiscoveredInterceptors()
+                .withMapping(ConfigPropertiesTest.BeanThree.class)
+                .withMapping(ConfigPropertiesTest.BeanThree.class, "other")
+                .build();
+    }
+}

--- a/testsuite/tck/src/test/java/io/smallrye/config/SmallRyeConfigArchiveProcessor.java
+++ b/testsuite/tck/src/test/java/io/smallrye/config/SmallRyeConfigArchiveProcessor.java
@@ -1,5 +1,6 @@
 package io.smallrye.config;
 
+import org.eclipse.microprofile.config.tck.ConfigPropertiesTest;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
@@ -10,7 +11,15 @@ public class SmallRyeConfigArchiveProcessor implements ApplicationArchiveProcess
     public void process(Archive<?> applicationArchive, TestClass testClass) {
         if (applicationArchive instanceof WebArchive) {
             WebArchive war = (WebArchive) applicationArchive;
-            war.addAsServiceProvider(SmallRyeConfigFactory.class, SmallRyeConfigTestFactory.class);
+            war.addAsServiceProvider(SmallRyeConfigFactory.class, useFactoryForTest(testClass));
         }
+    }
+
+    private static Class<?> useFactoryForTest(TestClass testClass) {
+        if (testClass.getJavaClass().equals(ConfigPropertiesTest.class)) {
+            return ConfigPropertiesTestFactory.class;
+        }
+
+        return SmallRyeConfigTestFactory.class;
     }
 }

--- a/testsuite/tck/tck-suite.xml
+++ b/testsuite/tck/tck-suite.xml
@@ -1,20 +1,11 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-
 <suite name="microprofile-config-TCK" verbose="2" configfailurepolicy="continue" >
-
-    <test name="microprofile-config 1.4 TCK">
+    <test name="microprofile-config 2.0 TCK">
         <packages>
-            <package name="org.eclipse.microprofile.config.tck.*">
-            </package>
+            <package name="org.eclipse.microprofile.config.tck.*"/>
         </packages>
-
-        <!-- TCK and spec dispute: https://github.com/eclipse/microprofile-config/pull/407 -->
         <classes>
-            <class name="org.eclipse.microprofile.config.tck.ConfigProviderTest">
-                <methods>
-                    <exclude name="testEnvironmentConfigSource"/>
-                </methods>
-            </class>
+            <!-- TCK and spec dispute: https://github.com/eclipse/microprofile-config/pull/407 -->
             <class name="org.eclipse.microprofile.config.tck.EmptyValuesTest">
                 <methods>
                     <exclude name="testEmptyStringPropertyFromConfigFile"/>
@@ -22,7 +13,18 @@
                     <exclude name="testEmptyStringValues"/>
                 </methods>
             </class>
+            <!-- TCK and spec dispute: https://github.com/eclipse/microprofile-config/issues/588 -->
+            <class name="org.eclipse.microprofile.config.tck.ConfigPropertiesTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <!-- TCK and spec dispute: https://github.com/eclipse/microprofile-config/issues/588 -->
+            <class name="org.eclipse.microprofile.config.tck.broken.ConfigPropertiesMissingPropertyPLTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
         </classes>
     </test>
-
 </suite>


### PR DESCRIPTION
Signed-off-by: tevans <tevans@uk.ibm.com>

@radcortez The `SmallRyeConfigBuilder.addConverter` method always stored the annotated priority rather than the one provided as a parameter.