### PR TITLE
Trimming converter should throw NPE

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -919,7 +919,7 @@ public final class Converters {
         }
 
         public T convert(final String value) {
-            return value == null ? null : getDelegate().convert(value.trim());
+            return getDelegate().convert(value.trim());
         }
     }
 }


### PR DESCRIPTION
The correct behaviour for a converter which is passed null is to throw an NPE rather than handling it gracefully.

Fixes #422 