### PR TITLE
Keep validating if injection point name missing

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/implementation/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -138,7 +138,13 @@ public class ConfigExtension implements Extension {
             }
 
             ConfigProperty configProperty = injectionPoint.getAnnotated().getAnnotation(ConfigProperty.class);
-            String name = ConfigProducerUtil.getConfigKey(injectionPoint, configProperty);
+            String name;
+            try {
+                name = ConfigProducerUtil.getConfigKey(injectionPoint, configProperty);
+            } catch (IllegalStateException e) {
+                adv.addDeploymentProblem(e);
+                continue;
+            }
 
             // Check if the name is part of the properties first. Since properties can be a subset, then search for the actual property for a value.
             if (!configNames.contains(name) && ConfigProducerUtil.getRawValue(name, (SmallRyeConfig) config) == null) {


### PR DESCRIPTION
If an injection point name is missing, record the error and continue
validating, rather than allowing the exception to be thrown.

Enhancement to #409 