### PR TITLE
Introduce friendlier NumberFormatException messages

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
@@ -100,4 +100,16 @@ interface ConfigMessages {
 
     @Message(id = 28, value = "Could not find a mapping for %s with prefix %s")
     NoSuchElementException mappingPrefixNotFound(String className, String prefix);
+
+    @Message(id = 29, value = "Expected an integer value, got \"%s\"")
+    NumberFormatException integerExpected(String value);
+
+    @Message(id = 30, value = "Expected a long value, got \"%s\"")
+    NumberFormatException longExpected(String value);
+
+    @Message(id = 31, value = "Expected a double value, got \"%s\"")
+    NumberFormatException doubleExpected(String value);
+
+    @Message(id = 32, value = "Expected a float value, got \"%s\"")
+    NumberFormatException floatExpected(String value);
 }

--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -68,16 +68,40 @@ public final class Converters {
                             || "OUI".equalsIgnoreCase(value)))));
 
     static final Converter<Double> DOUBLE_CONVERTER = BuiltInConverter.of(2,
-            newTrimmingConverter(newEmptyValueConverter(Double::valueOf)));
+            newTrimmingConverter(newEmptyValueConverter(value -> {
+                try {
+                    return Double.valueOf(value);
+                } catch (NumberFormatException nfe) {
+                    throw ConfigMessages.msg.doubleExpected(value);
+                }
+            })));
 
     static final Converter<Float> FLOAT_CONVERTER = BuiltInConverter.of(3,
-            newTrimmingConverter(newEmptyValueConverter(Float::valueOf)));
+            newTrimmingConverter(newEmptyValueConverter(value -> {
+                try {
+                    return Float.valueOf(value);
+                } catch (NumberFormatException nfe) {
+                    throw ConfigMessages.msg.floatExpected(value);
+                }
+            })));
 
     static final Converter<Long> LONG_CONVERTER = BuiltInConverter.of(4,
-            newTrimmingConverter(newEmptyValueConverter(Long::valueOf)));
+            newTrimmingConverter(newEmptyValueConverter(value -> {
+                try {
+                    return Long.valueOf(value);
+                } catch (NumberFormatException nfe) {
+                    throw ConfigMessages.msg.longExpected(value);
+                }
+            })));
 
     static final Converter<Integer> INTEGER_CONVERTER = BuiltInConverter.of(5,
-            newTrimmingConverter(newEmptyValueConverter(Integer::valueOf)));
+            newTrimmingConverter(newEmptyValueConverter(value -> {
+                try {
+                    return Integer.valueOf(value);
+                } catch (NumberFormatException nfe) {
+                    throw ConfigMessages.msg.integerExpected(value);
+                }
+            })));
 
     static final Converter<Class<?>> CLASS_CONVERTER = BuiltInConverter.of(6,
             newTrimmingConverter(newEmptyValueConverter(value -> {
@@ -108,7 +132,7 @@ public final class Converters {
 
     static final Converter<Character> CHARACTER_CONVERTER = BuiltInConverter.of(11, newEmptyValueConverter(value -> {
         if (value.length() == 1) {
-            return Character.valueOf(value.charAt(0));
+            return value.charAt(0);
         }
         throw ConfigMessages.msg.failedCharacterConversion(value);
     }));


### PR DESCRIPTION
Required for https://github.com/quarkusio/quarkus/issues/2292

Here is a sample output with this patch: 
```
ᐅ java -Dquarkus.log.console.darken=1.3 -jar target/greeting-quarkus-0.1.0-runner.jar
Oct 21, 2020 4:02:12 PM io.quarkus.config
ERROR: An invalid value was given for configuration key "quarkus.log.console.darken": Expected an integer value but got "1.3"
Oct 21, 2020 4:02:12 PM io.quarkus.runtime.ApplicationLifecycleManager run
ERROR: Failed to start application (with profile prod)
io.quarkus.runtime.configuration.ConfigurationException: One or more configuration errors has prevented the application from starting. The errors are:
An invalid value was given for configuration key "quarkus.log.console.darken": Expected an integer value but got "1.3"
```


Without it the message is: `An invalid value was given for configuration key "quarkus.log.console.darken": For input string: "1.5"`