### PR TITLE
Improve exception performance for getValue

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
@@ -57,7 +57,7 @@ interface ConfigMessages {
     IllegalArgumentException noRegisteredConverter(Class<?> type);
 
     @Message(id = 14, value = "Property %s not found")
-    NoSuchElementException propertyNotFound(String name);
+    String propertyNotFound(String name);
 
     @Message(id = 15, value = "No configuration is available for this class loader")
     IllegalStateException noConfigForClassloader();

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -165,11 +166,11 @@ public class SmallRyeConfig implements Config, Serializable {
             try {
                 converted = converter.convert("");
             } catch (IllegalArgumentException ignored) {
-                throw ConfigMessages.msg.propertyNotFound(name);
+                throw new NoSuchElementException(ConfigMessages.msg.propertyNotFound(name));
             }
         }
         if (converted == null) {
-            throw ConfigMessages.msg.propertyNotFound(name);
+            throw new NoSuchElementException(ConfigMessages.msg.propertyNotFound(name));
         }
         return converted;
     }


### PR DESCRIPTION
Using JBoss logging to create an exception with a localized message can
be noticably slower than constructing the exception yourself due to
additional processing that JBoss logging does to remove itself from the
exception stack trace.

While users should use Config.getOptionalValue() rather than calling
Config.getValue() and then catching and handling the exception, we
shouldn't impose an unnecessary performance penalty on them if they do
this.

Fixes #428 