### PR TITLE
Don't replace passed in classloader with TCCL

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceLoader.java
@@ -111,7 +111,8 @@ public abstract class AbstractLocationConfigSourceLoader {
     protected List<ConfigSource> tryClassPath(final URI uri, final ClassLoader classLoader) {
         final List<ConfigSource> configSources = new ArrayList<>();
         try {
-            consumeAsPaths(uri.getPath(), new ConfigSourcePathConsumer(configSources));
+            ClassLoader useCl = classLoader != null ? classLoader : SecuritySupport.getContextClassLoader();
+            consumeAsPaths(useCl, uri.getPath(), new ConfigSourcePathConsumer(configSources));
         } catch (IOException e) {
             throw ConfigMessages.msg.failedToLoadResource(e);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
An alternative fix could be to enforce that the passed in classloader is not null via either an assert or IllegalStateException as there are a few ways we could go to to get here, some of which take null classloader into account.

