### PR TITLE
Provide a way to exclude the filesystem lookup if the resource should only be present in the classpath.

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceLoader.java
@@ -77,9 +77,11 @@ public abstract class AbstractLocationConfigSourceLoader {
         final List<ConfigSource> configSources = new ArrayList<>();
         for (String location : locations) {
             final URI uri = URI_CONVERTER.convert(location);
-            if (uri.getScheme() == null || uri.getScheme().equals("file")) {
+            if (uri.getScheme() == null) {
                 configSources.addAll(tryFileSystem(uri));
                 configSources.addAll(tryClassPath(uri, classLoader));
+            } else if (uri.getScheme().equals("file")) {
+                configSources.addAll(tryFileSystem(uri));
             } else if (uri.getScheme().equals("jar")) {
                 configSources.addAll(tryJar(uri));
             } else if (uri.getScheme().startsWith("http")) {

--- a/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceProvider.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.smallrye.config;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +29,15 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
  */
 public class PropertiesConfigSourceProvider extends AbstractLocationConfigSourceLoader implements ConfigSourceProvider {
     private final List<ConfigSource> configSources = new ArrayList<>();
+    private final boolean includeFileSystem;
 
     public PropertiesConfigSourceProvider(final String location, final ClassLoader classLoader) {
+        this(location, classLoader, true);
+    }
+
+    public PropertiesConfigSourceProvider(final String location, final ClassLoader classLoader,
+            final boolean includeFileSystem) {
+        this.includeFileSystem = includeFileSystem;
         this.configSources.addAll(loadConfigSources(location, classLoader));
     }
 
@@ -55,5 +62,22 @@ public class PropertiesConfigSourceProvider extends AbstractLocationConfigSource
     @Override
     protected ConfigSource loadConfigSource(final URL url, final int ordinal) throws IOException {
         return new PropertiesConfigSource(url, ordinal);
+    }
+
+    @Override
+    protected List<ConfigSource> tryFileSystem(final URI uri) {
+        if (includeFileSystem) {
+            return super.tryFileSystem(uri);
+        } else {
+            return new ArrayList<>();
+        }
+    }
+
+    public static PropertiesConfigSourceProvider resource(final String location, final ClassLoader classLoader) {
+        return new PropertiesConfigSourceProvider(location, classLoader);
+    }
+
+    public static PropertiesConfigSourceProvider classPathResource(final String location, final ClassLoader classLoader) {
+        return new PropertiesConfigSourceProvider(location, classLoader, false);
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -141,10 +141,10 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
 
         defaultSources.add(new EnvConfigSource());
         defaultSources.add(new SysPropConfigSource());
-        defaultSources.addAll(new PropertiesConfigSourceProvider(META_INF_MICROPROFILE_CONFIG_PROPERTIES, classLoader)
-                .getConfigSources(classLoader));
-        defaultSources.addAll(new PropertiesConfigSourceProvider(WEB_INF_MICROPROFILE_CONFIG_PROPERTIES, classLoader)
-                .getConfigSources(classLoader));
+        defaultSources.addAll(PropertiesConfigSourceProvider
+                .classPathResource(META_INF_MICROPROFILE_CONFIG_PROPERTIES, classLoader).getConfigSources(classLoader));
+        defaultSources.addAll(PropertiesConfigSourceProvider
+                .classPathResource(WEB_INF_MICROPROFILE_CONFIG_PROPERTIES, classLoader).getConfigSources(classLoader));
 
         return defaultSources;
     }


### PR DESCRIPTION
Fixes #468.