### PR TITLE
Support Indexed Properties

### DIFF
--- a/doc/modules/ROOT/pages/config/config.adoc
+++ b/doc/modules/ROOT/pages/config/config.adoc
@@ -5,9 +5,12 @@ include::../attributes.adoc[]
 
 = Config
 
+* <<indexed-properties>>
 * <<profiles>>
 * <<locations>>
 * <<secret-keys>>
+
+include::indexed-properties.adoc[]
 
 include::profiles.adoc[]
 

--- a/doc/modules/ROOT/pages/config/indexed-properties.adoc
+++ b/doc/modules/ROOT/pages/config/indexed-properties.adoc
@@ -1,0 +1,31 @@
+[[indexed-properties]]
+== Indexed Properties
+
+In Microprofile Config, a config value which contains unescaped commas may be converted to `Collection`. This works
+for simple cases, but it becomes cumbersome and limited for more advanced cases.
+
+Indexed Properties provide a way to use indexes in config property names to map specific elements in a `Collection`
+type. Since the indexed element is part of the property name and not contained in the value, this can also be used to
+map complex object types as `Collectionª elements. Consider:
+
+[source,properties]
+----
+# MicroProfile Config - Collection Values
+my.collection=dog,cat,turtle
+
+# SmallRye Config - Indexed Property
+my.indexed.collection[0]=dog
+my.indexed.collection[1]=cat
+my.indexed.collection[2]=turtle
+----
+
+The indexed property syntax uses the property name and square brackets with an index in between.
+
+A call to `Config#getValues("my.collection", String.class)`, will automatically create and convert a `List<String>`
+that contains the values `dog`, `cat` and `turtle`. A call to `Config#getValues("my.indexed.collection", String.class)`
+returns the exact same result. For compatibility reasons, if SmallRye Config finds the same property name in their
+indexed and unindexed format, the unindexed value takes priority.
+
+The indexed property is sorted by their index before being added to the target `Collection`. Any gaps contained in the
+indexes do not resolve to the target `Collection`, which means that the `Collection` result will store all values in a
+continued fashion and without gaps.

--- a/examples/mapping/src/main/java/io/smallrye/config/examples/mapping/Server.java
+++ b/examples/mapping/src/main/java/io/smallrye/config/examples/mapping/Server.java
@@ -28,6 +28,8 @@ public interface Server {
 
     Optional<Proxy> proxy();
 
+    Optional<Cors> cors();
+
     Log log();
 
     interface Ssl {
@@ -61,6 +63,18 @@ public interface Server {
             SHORT,
             COMBINED,
             LONG;
+        }
+    }
+
+    interface Cors {
+        List<Origin> origins();
+
+        List<String> methods();
+
+        interface Origin {
+            String host();
+
+            int port();
         }
     }
 }

--- a/examples/mapping/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/mapping/src/main/resources/META-INF/microprofile-config.properties
@@ -9,3 +9,10 @@ server.form.landing-page=index.html
 
 server.ssl.port=8443
 server.ssl.certificate=certificate
+
+server.cors.origins[0].host=some-server
+server.cors.origins[0].port=9000
+server.cors.origins[1].host=another-server
+server.cors.origins[1].port=8000
+server.cors.methods[0]=GET
+server.cors.methods[1]=POST

--- a/examples/mapping/src/test/java/io/smallrye/config/examples/mapping/ServerMappingTest.java
+++ b/examples/mapping/src/test/java/io/smallrye/config/examples/mapping/ServerMappingTest.java
@@ -33,5 +33,13 @@ class ServerMappingTest {
         assertEquals(".log", server.log().suffix());
         assertTrue(server.log().rotate());
         assertEquals(Server.Log.Pattern.COMMON, server.log().pattern());
+
+        assertTrue(server.cors().isPresent());
+        assertEquals("some-server", server.cors().get().origins().get(0).host());
+        assertEquals(9000, server.cors().get().origins().get(0).port());
+        assertEquals("another-server", server.cors().get().origins().get(1).host());
+        assertEquals(8000, server.cors().get().origins().get(1).port());
+        assertEquals("GET", server.cors().get().methods().get(0));
+        assertEquals("POST", server.cors().get().methods().get(1));
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.eclipse.microprofile.config.spi.Converter;
@@ -204,6 +205,10 @@ final class ConfigMappingInterface implements ConfigMappingMetadata {
             return false;
         }
 
+        public boolean isCollection() {
+            return false;
+        }
+
         public PrimitiveProperty asPrimitive() {
             throw new ClassCastException();
         }
@@ -225,6 +230,10 @@ final class ConfigMappingInterface implements ConfigMappingMetadata {
         }
 
         public MayBeOptionalProperty asMayBeOptional() {
+            throw new ClassCastException();
+        }
+
+        public CollectionProperty asCollection() {
             throw new ClassCastException();
         }
     }
@@ -512,6 +521,36 @@ final class ConfigMappingInterface implements ConfigMappingMetadata {
         }
     }
 
+    public static final class CollectionProperty extends MayBeOptionalProperty {
+        private final Class<?> collectionRawType;
+        private final Property element;
+
+        CollectionProperty(final Class<?> collectionType, final Property element) {
+            // TODO - Naming Strategy
+            super(element.getMethod(), element.getPropertyName());
+            this.collectionRawType = collectionType;
+            this.element = element;
+        }
+
+        public Class<?> getCollectionRawType() {
+            return collectionRawType;
+        }
+
+        public Property getElement() {
+            return element;
+        }
+
+        @Override
+        public boolean isCollection() {
+            return true;
+        }
+
+        @Override
+        public CollectionProperty asCollection() {
+            return this;
+        }
+    }
+
     private static ConfigMappingInterface createConfigurationInterface(Class<?> interfaceType) {
         if (!interfaceType.isInterface() || interfaceType.getTypeParameters().length != 0) {
             return null;
@@ -601,6 +640,17 @@ final class ConfigMappingInterface implements ConfigMappingMetadata {
                 Type valueType = typeOfParameter(type, 1);
                 return new MapProperty(method, propertyName, keyType, keyConvertWith, getPropertyDef(method, valueType));
             }
+            if (rawType == List.class || rawType == Set.class) {
+                Type elementType = typeOfParameter(type, 0);
+                ConfigMappingInterface configurationInterface = getConfigurationInterface((Class<?>) elementType);
+                if (configurationInterface != null) {
+                    return new CollectionProperty(rawType, new GroupProperty(method, propertyName, configurationInterface));
+                }
+
+                WithDefault annotation = method.getAnnotation(WithDefault.class);
+                return new CollectionProperty(rawType, new LeafProperty(method, propertyName, elementType, null,
+                        annotation == null ? null : annotation.value()));
+            }
             ConfigMappingInterface configurationInterface = getConfigurationInterface(rawType);
             if (configurationInterface != null) {
                 // it's a group
@@ -608,6 +658,14 @@ final class ConfigMappingInterface implements ConfigMappingMetadata {
             }
             // fall out (leaf)
         }
+
+        if (rawType == List.class || rawType == Set.class) {
+            Type elementType = typeOfParameter(type, 0);
+            WithDefault annotation = method.getAnnotation(WithDefault.class);
+            return new CollectionProperty(rawType,
+                    new LeafProperty(method, propertyName, elementType, null, annotation == null ? null : annotation.value()));
+        }
+
         // otherwise it's a leaf
         WithDefault annotation = method.getAnnotation(WithDefault.class);
         return new LeafProperty(method, propertyName, type, convertWith, annotation == null ? null : annotation.value());
@@ -671,12 +729,20 @@ final class ConfigMappingInterface implements ConfigMappingMetadata {
                     ConfigMappingInterface group = groupProperty.getGroupType();
                     nested.add(group);
                     getNested(group.properties, nested);
+                } else if (optionalProperty.getNestedProperty() instanceof CollectionProperty) {
+                    CollectionProperty collectionProperty = (CollectionProperty) optionalProperty.getNestedProperty();
+                    getNested(new Property[] { collectionProperty.element }, nested);
                 }
             }
 
             if (property instanceof MapProperty) {
                 MapProperty mapProperty = (MapProperty) property;
                 getNested(new Property[] { mapProperty.valueProperty }, nested);
+            }
+
+            if (property instanceof CollectionProperty) {
+                CollectionProperty collectionProperty = (CollectionProperty) property;
+                getNested(new Property[] { collectionProperty.element }, nested);
             }
         }
     }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
@@ -3,7 +3,6 @@ package io.smallrye.config;
 import static io.smallrye.config.ConfigMappingInterface.GroupProperty;
 import static io.smallrye.config.ConfigMappingInterface.LeafProperty;
 import static io.smallrye.config.ConfigMappingInterface.MapProperty;
-import static io.smallrye.config.ConfigMappingInterface.MayBeOptionalProperty;
 import static io.smallrye.config.ConfigMappingInterface.PrimitiveProperty;
 import static io.smallrye.config.ConfigMappingInterface.Property;
 import static io.smallrye.config.ConfigMappingLoader.getConfigMappingClass;
@@ -24,6 +23,7 @@ import org.eclipse.microprofile.config.spi.Converter;
 
 import io.smallrye.common.constraint.Assert;
 import io.smallrye.common.function.Functions;
+import io.smallrye.config.ConfigMappingInterface.CollectionProperty;
 
 /**
  *
@@ -210,50 +210,8 @@ final class ConfigMappingProvider implements Serializable {
                         ni.next();
                     }
                 }
-                if (property.isOptional()) {
-                    // switch to lazy mode
-                    MayBeOptionalProperty nestedProperty = property.asOptional().getNestedProperty();
-                    if (nestedProperty.isGroup()) {
-                        GroupProperty nestedGroup = nestedProperty.asGroup();
-                        // on match, always create the outermost group, which recursively creates inner groups
-                        GetOrCreateEnclosingGroupInGroup matchAction = new GetOrCreateEnclosingGroupInGroup(
-                                getEnclosingFunction, group, nestedGroup);
-                        GetFieldOfEnclosing ef = new GetFieldOfEnclosing(
-                                nestedGroup.isParentPropertyName() ? getEnclosingFunction
-                                        : new ConsumeOneAndThenFn<>(getEnclosingFunction),
-                                type, memberName);
-                        processLazyGroupInGroup(currentPath, matchActions, defaultValues, nestedGroup, ef, matchAction,
-                                new HashSet<>());
-                    } else if (nestedProperty.isLeaf()) {
-                        LeafProperty leafProperty = nestedProperty.asLeaf();
-                        if (leafProperty.hasDefaultValue()) {
-                            defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
-                        }
-                        matchActions.findOrAdd(currentPath).putRootValue(DO_NOTHING);
-                    }
-                } else if (property.isGroup()) {
-                    processEagerGroup(currentPath, matchActions, defaultValues, property.asGroup().getGroupType(),
-                            new GetOrCreateEnclosingGroupInGroup(getEnclosingFunction, group, property.asGroup()));
-                } else if (property.isPrimitive()) {
-                    // already processed eagerly
-                    PrimitiveProperty primitiveProperty = property.asPrimitive();
-                    if (primitiveProperty.hasDefaultValue()) {
-                        defaultValues.findOrAdd(currentPath).putRootValue(primitiveProperty.getDefaultValue());
-                    }
-                    matchActions.findOrAdd(currentPath).putRootValue(DO_NOTHING);
-                } else if (property.isLeaf()) {
-                    // already processed eagerly
-                    LeafProperty leafProperty = property.asLeaf();
-                    if (leafProperty.hasDefaultValue()) {
-                        defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
-                    }
-                    // ignore with no error message
-                    matchActions.findOrAdd(currentPath).putRootValue(DO_NOTHING);
-                } else if (property.isMap()) {
-                    // the enclosure of the map is this group
-                    processLazyMapInGroup(currentPath, matchActions, defaultValues, property.asMap(), getEnclosingFunction,
-                            group);
-                }
+                processProperty(currentPath, matchActions, defaultValues, group, getEnclosingFunction, type, memberName,
+                        property);
                 while (currentPath.size() > pathLen) {
                     currentPath.removeLast();
                 }
@@ -262,6 +220,82 @@ final class ConfigMappingProvider implements Serializable {
         int sc = group.getSuperTypeCount();
         for (int i = 0; i < sc; i++) {
             processEagerGroup(currentPath, matchActions, defaultValues, group.getSuperType(i), getEnclosingFunction);
+        }
+    }
+
+    private void processProperty(
+            final ArrayDeque<String> currentPath,
+            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
+            final KeyMap<String> defaultValues,
+            final ConfigMappingInterface group,
+            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingFunction,
+            final Class<?> type,
+            final String memberName, final Property property) {
+
+        if (property.isOptional()) {
+            // switch to lazy mode
+            Property nestedProperty = property.asOptional().getNestedProperty();
+            processOptionalProperty(currentPath, matchActions, defaultValues, group, getEnclosingFunction, type, memberName,
+                    nestedProperty);
+        } else if (property.isGroup()) {
+            processEagerGroup(currentPath, matchActions, defaultValues, property.asGroup().getGroupType(),
+                    new GetOrCreateEnclosingGroupInGroup(getEnclosingFunction, group, property.asGroup()));
+        } else if (property.isPrimitive()) {
+            // already processed eagerly
+            PrimitiveProperty primitiveProperty = property.asPrimitive();
+            if (primitiveProperty.hasDefaultValue()) {
+                defaultValues.findOrAdd(currentPath).putRootValue(primitiveProperty.getDefaultValue());
+            }
+            matchActions.findOrAdd(currentPath).putRootValue(DO_NOTHING);
+        } else if (property.isLeaf()) {
+            // already processed eagerly
+            LeafProperty leafProperty = property.asLeaf();
+            if (leafProperty.hasDefaultValue()) {
+                defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
+            }
+            // ignore with no error message
+            matchActions.findOrAdd(currentPath).putRootValue(DO_NOTHING);
+        } else if (property.isMap()) {
+            // the enclosure of the map is this group
+            processLazyMapInGroup(currentPath, matchActions, defaultValues, property.asMap(), getEnclosingFunction,
+                    group);
+        } else if (property.isCollection()) {
+            CollectionProperty collectionProperty = property.asCollection();
+            currentPath.addLast(currentPath.removeLast() + "[*]");
+            processProperty(currentPath, matchActions, defaultValues, group, getEnclosingFunction, type, memberName,
+                    collectionProperty.getElement());
+        }
+    }
+
+    private void processOptionalProperty(
+            final ArrayDeque<String> currentPath,
+            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
+            final KeyMap<String> defaultValues,
+            final ConfigMappingInterface group,
+            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingFunction,
+            final Class<?> type, final String memberName, final Property nestedProperty) {
+        if (nestedProperty.isGroup()) {
+            GroupProperty nestedGroup = nestedProperty.asGroup();
+            // on match, always create the outermost group, which recursively creates inner groups
+            GetOrCreateEnclosingGroupInGroup matchAction = new GetOrCreateEnclosingGroupInGroup(
+                    getEnclosingFunction, group, nestedGroup);
+            GetFieldOfEnclosing ef = new GetFieldOfEnclosing(
+                    nestedGroup.isParentPropertyName() ? getEnclosingFunction
+                            : new ConsumeOneAndThenFn<>(getEnclosingFunction),
+                    type, memberName);
+            processLazyGroupInGroup(currentPath, matchActions, defaultValues, nestedGroup, ef, matchAction,
+                    new HashSet<>());
+        } else if (nestedProperty.isLeaf()) {
+            LeafProperty leafProperty = nestedProperty.asLeaf();
+            if (leafProperty.hasDefaultValue()) {
+                defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
+            }
+            matchActions.findOrAdd(currentPath).putRootValue(DO_NOTHING);
+        } else if (nestedProperty.isCollection()) {
+            CollectionProperty collectionProperty = nestedProperty.asCollection();
+            currentPath.addLast(currentPath.removeLast() + "[*]");
+            processProperty(currentPath, matchActions, defaultValues, group, getEnclosingFunction, type, memberName,
+                    collectionProperty.getElement());
         }
     }
 
@@ -285,56 +319,8 @@ final class ConfigMappingProvider implements Serializable {
             }
             if (usedProperties.add(property.getMethod().getName())) {
                 boolean optional = property.isOptional();
-                if (optional && property.asOptional().getNestedProperty().isGroup()) {
-                    GroupProperty nestedGroup = property.asOptional().getNestedProperty().asGroup();
-                    GetOrCreateEnclosingGroupInGroup nestedMatchAction = new GetOrCreateEnclosingGroupInGroup(
-                            property.isParentPropertyName() ? getEnclosingFunction
-                                    : new ConsumeOneAndThenFn<>(getEnclosingFunction),
-                            group, nestedGroup);
-                    processLazyGroupInGroup(currentPath, matchActions, defaultValues, nestedGroup, nestedMatchAction,
-                            nestedMatchAction, new HashSet<>());
-                } else if (property.isGroup()) {
-                    GroupProperty asGroup = property.asGroup();
-                    GetOrCreateEnclosingGroupInGroup nestedEnclosingFunction = new GetOrCreateEnclosingGroupInGroup(
-                            property.isParentPropertyName() ? getEnclosingFunction
-                                    : new ConsumeOneAndThenFn<>(getEnclosingFunction),
-                            group, asGroup);
-                    BiConsumer<ConfigMappingContext, NameIterator> nestedMatchAction;
-                    nestedMatchAction = matchAction;
-                    if (!property.isParentPropertyName()) {
-                        nestedMatchAction = new ConsumeOneAndThen(nestedMatchAction);
-                    }
-                    processLazyGroupInGroup(currentPath, matchActions, defaultValues, asGroup, nestedEnclosingFunction,
-                            nestedMatchAction, usedProperties);
-                } else if (property.isLeaf() || property.isPrimitive()
-                        || optional && property.asOptional().getNestedProperty().isLeaf()) {
-                    BiConsumer<ConfigMappingContext, NameIterator> actualAction;
-                    if (!property.isParentPropertyName()) {
-                        actualAction = new ConsumeOneAndThen(matchAction);
-                    } else {
-                        actualAction = matchAction;
-                    }
-                    matchActions.findOrAdd(currentPath).putRootValue(actualAction);
-                    if (property.isPrimitive()) {
-                        PrimitiveProperty primitiveProperty = property.asPrimitive();
-                        if (primitiveProperty.hasDefaultValue()) {
-                            defaultValues.findOrAdd(currentPath).putRootValue(primitiveProperty.getDefaultValue());
-                        }
-                    } else if (property.isLeaf() && optional) {
-                        LeafProperty leafProperty = property.asOptional().getNestedProperty().asLeaf();
-                        if (leafProperty.hasDefaultValue()) {
-                            defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
-                        }
-                    } else {
-                        LeafProperty leafProperty = property.asLeaf();
-                        if (leafProperty.hasDefaultValue()) {
-                            defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
-                        }
-                    }
-                } else if (property.isMap()) {
-                    processLazyMapInGroup(currentPath, matchActions, defaultValues, property.asMap(), getEnclosingFunction,
-                            group);
-                }
+                processLazyPropertyInGroup(currentPath, matchActions, defaultValues, getEnclosingFunction, matchAction,
+                        usedProperties, group, optional, property);
             }
             while (currentPath.size() > pathLen) {
                 currentPath.removeLast();
@@ -344,6 +330,75 @@ final class ConfigMappingProvider implements Serializable {
         for (int i = 0; i < sc; i++) {
             processLazyGroupInGroup(currentPath, matchActions, defaultValues, groupProperty, getEnclosingFunction,
                     matchAction, usedProperties);
+        }
+    }
+
+    private void processLazyPropertyInGroup(
+            final ArrayDeque<String> currentPath,
+            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
+            final KeyMap<String> defaultValues,
+            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingFunction,
+            final BiConsumer<ConfigMappingContext, NameIterator> matchAction,
+            final HashSet<String> usedProperties,
+            final ConfigMappingInterface group,
+            final boolean optional,
+            final Property property) {
+
+        if (optional && property.asOptional().getNestedProperty().isGroup()) {
+            GroupProperty nestedGroup = property.asOptional().getNestedProperty().asGroup();
+            GetOrCreateEnclosingGroupInGroup nestedMatchAction = new GetOrCreateEnclosingGroupInGroup(
+                    property.isParentPropertyName() ? getEnclosingFunction
+                            : new ConsumeOneAndThenFn<>(getEnclosingFunction),
+                    group, nestedGroup);
+            processLazyGroupInGroup(currentPath, matchActions, defaultValues, nestedGroup, nestedMatchAction,
+                    nestedMatchAction, new HashSet<>());
+        } else if (property.isGroup()) {
+            GroupProperty asGroup = property.asGroup();
+            GetOrCreateEnclosingGroupInGroup nestedEnclosingFunction = new GetOrCreateEnclosingGroupInGroup(
+                    property.isParentPropertyName() ? getEnclosingFunction
+                            : new ConsumeOneAndThenFn<>(getEnclosingFunction),
+                    group, asGroup);
+            BiConsumer<ConfigMappingContext, NameIterator> nestedMatchAction;
+            nestedMatchAction = matchAction;
+            if (!property.isParentPropertyName()) {
+                nestedMatchAction = new ConsumeOneAndThen(nestedMatchAction);
+            }
+            processLazyGroupInGroup(currentPath, matchActions, defaultValues, asGroup, nestedEnclosingFunction,
+                    nestedMatchAction, usedProperties);
+        } else if (property.isLeaf() || property.isPrimitive()
+                || optional && property.asOptional().getNestedProperty().isLeaf()) {
+            BiConsumer<ConfigMappingContext, NameIterator> actualAction;
+            if (!property.isParentPropertyName()) {
+                actualAction = new ConsumeOneAndThen(matchAction);
+            } else {
+                actualAction = matchAction;
+            }
+            matchActions.findOrAdd(currentPath).putRootValue(actualAction);
+            if (property.isPrimitive()) {
+                PrimitiveProperty primitiveProperty = property.asPrimitive();
+                if (primitiveProperty.hasDefaultValue()) {
+                    defaultValues.findOrAdd(currentPath).putRootValue(primitiveProperty.getDefaultValue());
+                }
+            } else if (property.isLeaf() && optional) {
+                LeafProperty leafProperty = property.asOptional().getNestedProperty().asLeaf();
+                if (leafProperty.hasDefaultValue()) {
+                    defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
+                }
+            } else {
+                LeafProperty leafProperty = property.asLeaf();
+                if (leafProperty.hasDefaultValue()) {
+                    defaultValues.findOrAdd(currentPath).putRootValue(leafProperty.getDefaultValue());
+                }
+            }
+        } else if (property.isMap()) {
+            processLazyMapInGroup(currentPath, matchActions, defaultValues, property.asMap(), getEnclosingFunction,
+                    group);
+        } else if (property.isCollection() || optional && property.asOptional().getNestedProperty().isCollection()) {
+            CollectionProperty collectionProperty = optional ? property.asOptional().getNestedProperty().asCollection()
+                    : property.asCollection();
+            currentPath.addLast(currentPath.removeLast() + "[*]");
+            processLazyPropertyInGroup(currentPath, matchActions, defaultValues, getEnclosingFunction, matchAction,
+                    usedProperties, group, false, collectionProperty.getElement());
         }
     }
 
@@ -602,7 +657,7 @@ final class ConfigMappingProvider implements Serializable {
         }
 
         Assert.checkNotNullParam("config", config);
-        final ConfigMappingContext context = new ConfigMappingContext(config);
+        ConfigMappingContext context = new ConfigMappingContext(config);
         // eagerly populate roots
         for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
             String path = entry.getKey();
@@ -614,6 +669,7 @@ final class ConfigMappingProvider implements Serializable {
                 context.registerRoot(root, path, group);
             }
         }
+
         // lazily sweep
         for (String name : config.getPropertyNames()) {
             // filter properties in root

--- a/implementation/src/main/java/io/smallrye/config/KeyMap.java
+++ b/implementation/src/main/java/io/smallrye/config/KeyMap.java
@@ -123,7 +123,7 @@ public final class KeyMap<V> extends HashMap<String, KeyMap<V>> {
             return this;
         }
         String seg = iter.next();
-        KeyMap<V> next = seg.equals("*") ? any : getOrDefault(seg, any);
+        KeyMap<V> next = seg.equals("*") || seg.endsWith("[*]") ? any : getOrDefault(seg, any);
         return next == null ? null : next.find(iter);
     }
 
@@ -142,7 +142,8 @@ public final class KeyMap<V> extends HashMap<String, KeyMap<V>> {
         String seg = ni.getNextSegment();
         ni.next();
         try {
-            KeyMap<V> next = seg.equals("*") ? getOrCreateAny() : computeIfAbsent(seg, k -> new KeyMap<>());
+            KeyMap<V> next = seg.equals("*") || seg.endsWith("[*]") ? getOrCreateAny()
+                    : computeIfAbsent(seg, k -> new KeyMap<>());
             return next.findOrAdd(ni);
         } finally {
             ni.previous();
@@ -154,7 +155,7 @@ public final class KeyMap<V> extends HashMap<String, KeyMap<V>> {
             return this;
         }
         String seg = iter.next();
-        KeyMap<V> next = seg.equals("*") ? getOrCreateAny() : computeIfAbsent(seg, k -> new KeyMap<>());
+        KeyMap<V> next = seg.equals("*") || seg.endsWith("[*]") ? getOrCreateAny() : computeIfAbsent(seg, k -> new KeyMap<>());
         return next.findOrAdd(iter);
     }
 
@@ -168,7 +169,7 @@ public final class KeyMap<V> extends HashMap<String, KeyMap<V>> {
 
     public KeyMap<V> findOrAdd(final String[] keys, int off, int len) {
         String seg = keys[off];
-        KeyMap<V> next = seg.equals("*") ? getOrCreateAny() : computeIfAbsent(seg, k -> new KeyMap<>());
+        KeyMap<V> next = seg.equals("*") || seg.endsWith("[*]") ? getOrCreateAny() : computeIfAbsent(seg, k -> new KeyMap<>());
         return off + 1 > len - 1 ? next : next.findOrAdd(keys, off + 1, len);
     }
 

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingCollectionsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingCollectionsTest.java
@@ -1,0 +1,376 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.KeyValuesConfigSource.config;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.ConfigMappingCollectionsTest.ServerCollectionsSet.Environment;
+import io.smallrye.config.ConfigMappingCollectionsTest.ServerCollectionsSet.Environment.App;
+
+public class ConfigMappingCollectionsTest {
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollectionSimple {
+        List<String> environments();
+    }
+
+    @Test
+    void mappingCollectionsSimple() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollectionSimple.class, "server")
+                .withSources(config("server.environments[0]", "dev",
+                        "server.environments[1]", "qa",
+                        "server.environments[2]", "prod"))
+                .build();
+
+        List<String> environments = config.getValues("server.environments", String.class);
+        assertEquals(3, environments.size());
+        assertEquals("dev", environments.get(0));
+        assertEquals("qa", environments.get(1));
+        assertEquals("prod", environments.get(2));
+
+        ServerCollectionSimple configMapping = config.getConfigMapping(ServerCollectionSimple.class);
+        assertEquals(3, configMapping.environments().size());
+        assertEquals("dev", configMapping.environments().get(0));
+        assertEquals("qa", configMapping.environments().get(1));
+        assertEquals("prod", configMapping.environments().get(2));
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollections {
+        List<Environment> environments();
+
+        interface Environment {
+            String name();
+
+            List<App> apps();
+
+            interface App {
+                String name();
+
+                List<String> services();
+
+                Optional<List<String>> databases();
+            }
+        }
+    }
+
+    @Test
+    void mappingCollections() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollections.class, "server")
+                .withSources(config(
+                        "server.environments[0].name", "dev",
+                        "server.environments[0].apps[0].name", "rest",
+                        "server.environments[0].apps[0].services", "a,b,c",
+                        "server.environments[0].apps[0].databases", "pg,h2",
+                        "server.environments[0].apps[1].name", "batch",
+                        "server.environments[0].apps[1].services", "a,b,c",
+                        "server.environments[1].name", "prod",
+                        "server.environments[1].apps[0].name", "web",
+                        "server.environments[1].apps[0].services", "a,b,c",
+                        "server.environments[1].apps[1].name", "rest",
+                        "server.environments[1].apps[1].services", "a,b,c",
+                        "server.environments[1].apps[2].name", "batch",
+                        "server.environments[1].apps[2].services", "a,b,c"))
+                .build();
+        ServerCollections server = config.getConfigMapping(ServerCollections.class);
+
+        assertEquals(2, server.environments().size());
+        assertEquals("dev", server.environments().get(0).name());
+        assertEquals(Stream.of("a", "b", "c").collect(toList()), server.environments().get(0).apps().get(0).services());
+        assertTrue(server.environments().get(0).apps().get(0).databases().isPresent());
+        assertEquals(Stream.of("pg", "h2").collect(toList()), server.environments().get(0).apps().get(0).databases().get());
+        assertEquals(2, server.environments().get(0).apps().size());
+        assertEquals("rest", server.environments().get(0).apps().get(0).name());
+        assertEquals("batch", server.environments().get(0).apps().get(1).name());
+        assertEquals("prod", server.environments().get(1).name());
+        assertEquals(3, server.environments().get(1).apps().size());
+        assertEquals("web", server.environments().get(1).apps().get(0).name());
+        assertEquals("rest", server.environments().get(1).apps().get(1).name());
+        assertEquals("batch", server.environments().get(1).apps().get(2).name());
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollectionName {
+        @WithName("envs")
+        List<Environment> environments();
+
+        interface Environment {
+            String name();
+
+            @WithName("apps")
+            List<App> applications();
+
+            interface App {
+                String name();
+            }
+        }
+    }
+
+    @Test
+    void mappingCollectionsWithName() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollectionName.class, "server")
+                .withSources(config("server.envs[0].name", "dev",
+                        "server.envs[0].apps[0].name", "rest",
+                        "server.envs[0].apps[1].name", "batch",
+                        "server.envs[1].name", "prod",
+                        "server.envs[1].apps[0].name", "web",
+                        "server.envs[1].apps[1].name", "rest",
+                        "server.envs[1].apps[2].name", "batch"))
+                .build();
+        ServerCollectionName server = config.getConfigMapping(ServerCollectionName.class);
+
+        assertEquals(2, server.environments().size());
+        assertEquals("dev", server.environments().get(0).name());
+        assertEquals(2, server.environments().get(0).applications().size());
+        assertEquals("rest", server.environments().get(0).applications().get(0).name());
+        assertEquals("batch", server.environments().get(0).applications().get(1).name());
+        assertEquals("prod", server.environments().get(1).name());
+        assertEquals(3, server.environments().get(1).applications().size());
+        assertEquals("web", server.environments().get(1).applications().get(0).name());
+        assertEquals("rest", server.environments().get(1).applications().get(1).name());
+        assertEquals("batch", server.environments().get(1).applications().get(2).name());
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollectionsDefaults {
+        List<Environment> environments();
+
+        @WithDefault("80,443")
+        List<Integer> ports();
+
+        interface Environment {
+            String name();
+
+            @WithDefault("web,rest")
+            List<String> apps();
+        }
+    }
+
+    @Test
+    void mappingCollectionsWithDefaults() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollectionsDefaults.class, "server")
+                .withSources(config("server.environments[0].name", "dev"))
+                .build();
+
+        ServerCollectionsDefaults server = config.getConfigMapping(ServerCollectionsDefaults.class);
+
+        assertEquals(1, server.environments().size());
+        assertEquals("dev", server.environments().get(0).name());
+        assertEquals(Stream.of("web", "rest").collect(toList()), server.environments().get(0).apps());
+
+        assertEquals(2, server.ports().size());
+        assertEquals(Stream.of(80, 443).collect(toList()), server.ports());
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollectionsOptionals {
+        Optional<Environment> notRequired();
+
+        Optional<Environment> required();
+
+        Optional<List<Environment>> notRequiredEnvs();
+
+        Optional<List<Environment>> requiredEnvs();
+
+        interface Environment {
+            String name();
+
+            Optional<List<String>> notRequiredServices();
+
+            Optional<List<String>> requiredServices();
+
+            Optional<List<String>> indexed();
+        }
+    }
+
+    @Test
+    void mappingCollectionsOptionals() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollectionsOptionals.class, "server")
+                .withSources(config("server.required.name", "dev",
+                        "server.required.required-services", "rest,db",
+                        "server.required.indexed[0]", "rest",
+                        "server.required.indexed[1]", "db",
+                        "server.required-envs[0].name", "dev",
+                        "server.required-envs[1].name", "prod"))
+                .build();
+
+        ServerCollectionsOptionals server = config.getConfigMapping(ServerCollectionsOptionals.class);
+
+        assertFalse(server.notRequired().isPresent());
+        assertTrue(server.required().isPresent());
+        assertEquals("dev", server.required().get().name());
+        assertFalse(server.required().get().notRequiredServices().isPresent());
+        assertTrue(server.required().get().requiredServices().isPresent());
+        assertEquals("rest", server.required().get().requiredServices().get().get(0));
+        assertEquals("db", server.required().get().requiredServices().get().get(1));
+        assertTrue(server.required().get().indexed().isPresent());
+        assertEquals("rest", server.required().get().indexed().get().get(0));
+        assertEquals("db", server.required().get().indexed().get().get(1));
+
+        assertFalse(server.notRequiredEnvs().isPresent());
+        assertTrue(server.requiredEnvs().isPresent());
+        assertEquals("dev", server.requiredEnvs().get().get(0).name());
+        assertEquals("prod", server.requiredEnvs().get().get(1).name());
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollectionsConverters {
+        List<Enviroment> envs();
+
+        interface Enviroment {
+            @WithConverter(HostConverter.class)
+            List<Host> hosts();
+        }
+    }
+
+    static class Host {
+        final String name;
+
+        Host(final String name) {
+            this.name = name;
+        }
+    }
+
+    static class HostConverter implements Converter<Host> {
+        public HostConverter() {
+        }
+
+        @Override
+        public Host convert(final String value) throws IllegalArgumentException, NullPointerException {
+            return new Host(value);
+        }
+    }
+
+    @Test
+    void mappingCollectionsConverters() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollectionsConverters.class, "server")
+                .withSources(config("server.envs[0].hosts[0]", "localhost",
+                        "server.envs[0].hosts[1]", "127.0.0.1"))
+                .build();
+
+        ServerCollectionsConverters server = config.getConfigMapping(ServerCollectionsConverters.class);
+
+        assertEquals(1, server.envs().size());
+        assertEquals(2, server.envs().get(0).hosts().size());
+        assertEquals("localhost", server.envs().get(0).hosts().get(0).name);
+        assertEquals("127.0.0.1", server.envs().get(0).hosts().get(1).name);
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerCollectionsSet {
+        Set<Environment> environments();
+
+        interface Environment {
+            String name();
+
+            Set<App> apps();
+
+            interface App {
+                String name();
+
+                Set<String> services();
+
+                Optional<Set<String>> databases();
+            }
+        }
+    }
+
+    @Test
+    void mappingCollectionsSet() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerCollectionsSet.class, "server")
+                .withSources(config(
+                        "server.environments[0].name", "dev",
+                        "server.environments[0].apps[0].name", "rest",
+                        "server.environments[0].apps[0].services", "a,b,c",
+                        "server.environments[0].apps[0].databases", "pg,h2",
+                        "server.environments[0].apps[1].name", "batch",
+                        "server.environments[0].apps[1].services", "a,b,c",
+                        "server.environments[1].name", "prod",
+                        "server.environments[1].apps[0].name", "web",
+                        "server.environments[1].apps[0].services", "a,b,c",
+                        "server.environments[1].apps[1].name", "rest",
+                        "server.environments[1].apps[1].services", "a,b,c",
+                        "server.environments[1].apps[2].name", "batch",
+                        "server.environments[1].apps[2].services", "a,b,c"))
+                .build();
+        ServerCollectionsSet server = config.getConfigMapping(ServerCollectionsSet.class);
+
+        assertEquals(2, server.environments().size());
+
+        Optional<Environment> dev = server.environments().stream().filter(environment -> environment.name().equals("dev"))
+                .findFirst();
+        assertTrue(dev.isPresent());
+        dev.ifPresent(environment -> {
+            assertEquals(2, environment.apps().size());
+            Optional<App> rest = environment.apps().stream().filter(app -> app.name().equals("rest")).findFirst();
+            assertTrue(rest.isPresent());
+            rest.ifPresent(app -> {
+                assertTrue(Stream.of("a", "b", "c").collect(toSet()).containsAll(app.services()));
+                assertTrue(app.databases().isPresent());
+                assertTrue(Stream.of("pg", "h2").collect(toSet()).containsAll(app.databases().get()));
+            });
+        });
+    }
+
+    @ConfigMapping(prefix = "server")
+    public interface ServerOptionalGroup {
+        Optional<Environment> environment();
+
+        interface Environment {
+            List<String> services();
+
+            List<App> apps();
+
+            interface App {
+                String name();
+            }
+        }
+    }
+
+    @Test
+    void mappingOptionalGroupWithCollection() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerOptionalGroup.class, "server")
+                .withSources(config(
+                        "server.environment.services[0]", "rest",
+                        "server.environment.services[1]", "batch",
+                        "server.environment.apps[0].name", "a"))
+                .build();
+
+        ServerOptionalGroup server = config.getConfigMapping(ServerOptionalGroup.class);
+        assertTrue(server.environment().isPresent());
+        assertEquals("rest", server.environment().get().services().get(0));
+        assertEquals("batch", server.environment().get().services().get(1));
+        assertEquals("a", server.environment().get().apps().get(0).name());
+
+        config = new SmallRyeConfigBuilder()
+                .withMapping(ServerOptionalGroup.class, "server")
+                .withSources(config(
+                        "server.environment.services", "rest,batch",
+                        "server.environment.apps[0].name", "a"))
+                .build();
+
+        server = config.getConfigMapping(ServerOptionalGroup.class);
+        assertTrue(server.environment().isPresent());
+        assertEquals("rest", server.environment().get().services().get(0));
+        assertEquals("batch", server.environment().get().services().get(1));
+        assertEquals("a", server.environment().get().apps().get(0).name());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingLoaderTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingLoaderTest.java
@@ -39,11 +39,12 @@ class ConfigMappingLoaderTest {
     void discoverNested() {
         ConfigMappingInterface mapping = ConfigMappingLoader.getConfigMappingInterface(ServerNested.class);
         List<ConfigMappingInterface> nested = mapping.getNested();
-        assertEquals(3, nested.size());
+        assertEquals(4, nested.size());
         List<Class<?>> types = nested.stream().map(ConfigMappingInterface::getInterfaceType).collect(toList());
         assertTrue(types.contains(ServerNested.Environment.class));
         assertTrue(types.contains(ServerNested.Log.class));
         assertTrue(types.contains(ServerNested.Ssl.class));
+        assertTrue(types.contains(ServerNested.App.class));
     }
 
     @ConfigMapping(prefix = "server")

--- a/implementation/src/test/java/io/smallrye/config/KeyMapTest.java
+++ b/implementation/src/test/java/io/smallrye/config/KeyMapTest.java
@@ -117,4 +117,19 @@ class KeyMapTest {
                 "KeyMap(no value) {root=>KeyMap(no value) {foo=>KeyMap(value=bar) {bar=>KeyMap(value=baz) {(any)=>KeyMap(value=baz) {baz=>KeyMap(value=anything) {}}}}}}",
                 map.toString());
     }
+
+    @Test
+    void indexed() {
+        KeyMap<String> map = new KeyMap<>();
+        map.findOrAdd("root.foo").putRootValue("bar");
+        map.findOrAdd("root.foo[*]").putRootValue("bar");
+        map.findOrAdd("root.foo[1]").putRootValue("baz");
+        map.findOrAdd("root.foo[*].name").putRootValue("baz");
+
+        assertEquals("bar", map.findRootValue("root.foo"));
+        assertEquals("bar", map.findRootValue("root.foo[*]"));
+        assertEquals("baz", map.findRootValue("root.foo[1]"));
+        assertEquals("bar", map.findRootValue("root.foo[2]"));
+        assertEquals("baz", map.findRootValue("root.foo[3].name"));
+    }
 }

--- a/implementation/src/test/java/io/smallrye/config/NameIteratorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/NameIteratorTest.java
@@ -1,0 +1,37 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class NameIteratorTest {
+    @Test
+    void getNextSegment() {
+        NameIterator nameIterator = new NameIterator("foo.bar");
+        assertEquals("foo", nameIterator.getNextSegment());
+        assertEquals("foo", nameIterator.getNextSegment());
+    }
+
+    @Test
+    void next() {
+        NameIterator nameIterator = new NameIterator("foo.bar");
+        nameIterator.next();
+        assertEquals("bar", nameIterator.getNextSegment());
+    }
+
+    @Test
+    void getPreviousSegment() {
+        NameIterator nameIterator = new NameIterator("foo.bar");
+        nameIterator.next();
+        assertEquals("foo", nameIterator.getPreviousSegment());
+        assertEquals("foo", nameIterator.getPreviousSegment());
+    }
+
+    @Test
+    void previous() {
+        NameIterator nameIterator = new NameIterator("foo.bar");
+        nameIterator.next();
+        nameIterator.previous();
+        assertEquals("foo", nameIterator.getNextSegment());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.Config;
@@ -90,5 +91,143 @@ class SmallRyeConfigTest {
 
         assertNotNull(smallRyeConfig);
         assertThrows(IllegalArgumentException.class, () -> config.unwrap(Object.class));
+    }
+
+    @Test
+    void getIndexedValues() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config("server.environments[0]", "dev",
+                        "server.environments[1]", "qa",
+                        "server.environments[2]", "prod"))
+                .build();
+
+        List<String> environments = config.getValues("server.environments", String.class);
+        assertEquals(3, environments.size());
+        assertEquals("dev", environments.get(0));
+        assertEquals("dev", config.getValue("server.environments[0]", String.class));
+        assertEquals("qa", environments.get(1));
+        assertEquals("qa", config.getValue("server.environments[1]", String.class));
+        assertEquals("prod", environments.get(2));
+        assertEquals("prod", config.getValue("server.environments[2]", String.class));
+    }
+
+    @Test
+    void getValuesNotIndexed() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "server.environments", "dev,qa",
+                        "server.environments[0]", "dev",
+                        "server.environments[1]", "qa",
+                        "server.environments[2]", "prod"))
+                .build();
+
+        List<String> environments = config.getValues("server.environments", String.class);
+        assertEquals(2, environments.size());
+        assertEquals("dev", environments.get(0));
+        assertEquals("qa", environments.get(1));
+    }
+
+    @Test
+    void getValuesNotFound() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config("server.environments", ""))
+                .build();
+
+        assertThrows(NoSuchElementException.class, () -> config.getValues("server.environments", String.class));
+
+        SmallRyeConfig configIndexed = new SmallRyeConfigBuilder()
+                .withSources(config("server.environments[0]", ""))
+                .build();
+
+        assertThrows(NoSuchElementException.class, () -> configIndexed.getValues("server.environments", String.class));
+    }
+
+    @Test
+    void getOptionalValuesIndexed() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config("server.environments[0]", "dev",
+                        "server.environments[1]", "qa",
+                        "server.environments[2]", "prod"))
+                .build();
+
+        Optional<List<String>> environments = config.getOptionalValues("server.environments", String.class);
+        assertTrue(environments.isPresent());
+        assertEquals(3, environments.get().size());
+        assertEquals("dev", environments.get().get(0));
+        assertEquals("qa", environments.get().get(1));
+        assertEquals("prod", environments.get().get(2));
+    }
+
+    @Test
+    void getOptionalValuesNotIndexed() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "server.environments", "dev,qa",
+                        "server.environments[0]", "dev",
+                        "server.environments[1]", "qa",
+                        "server.environments[2]", "prod"))
+                .build();
+
+        Optional<List<String>> environments = config.getOptionalValues("server.environments", String.class);
+        assertTrue(environments.isPresent());
+        assertEquals(2, environments.get().size());
+        assertEquals("dev", environments.get().get(0));
+        assertEquals("qa", environments.get().get(1));
+    }
+
+    @Test
+    void getOptionalValuesEmpty() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config("server.environments", ""))
+                .build();
+
+        assertFalse(config.getOptionalValues("server.environments", String.class).isPresent());
+
+        SmallRyeConfig configIndexed = new SmallRyeConfigBuilder()
+                .withSources(config("server.environments[0]", ""))
+                .build();
+
+        assertFalse(configIndexed.getOptionalValues("server.environments", String.class).isPresent());
+    }
+
+    @Test
+    void invalidIndexes() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "dev", "",
+                        "dev[x", "",
+                        "qa", "",
+                        "qa[[1]]", "",
+                        "prod", "",
+                        "prod[x]", "",
+                        "perf", "",
+                        "perf[]", ""))
+                .build();
+
+        assertTrue(config.getIndexedPropertiesIndexes("dev").isEmpty());
+        assertTrue(config.getIndexedPropertiesIndexes("qa").isEmpty());
+        assertTrue(config.getIndexedPropertiesIndexes("prod").isEmpty());
+        assertTrue(config.getIndexedPropertiesIndexes("perf").isEmpty());
+    }
+
+    @Test
+    void overrideIndexedValues() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "config_ordinal", "100",
+                        "server.environments[0]", "dev",
+                        "server.environments[1]", "qa",
+                        "server.environments[2]", "prod"))
+                .withSources(config(
+                        "config_ordinal", "1000",
+                        "server.environments[2]", "prd",
+                        "server.environments[3]", "perf"))
+                .build();
+
+        List<String> values = config.getValues("server.environments", String.class);
+        assertEquals("dev", values.get(0));
+        assertEquals("qa", values.get(1));
+        assertEquals("prd", values.get(2));
+        assertEquals("perf", values.get(3));
     }
 }

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ArrayTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ArrayTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.config.source.yaml;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.Test;
@@ -20,6 +20,9 @@ class ArrayTest {
                 "          uri: \"https://www.google.com\"";
 
         ConfigSource src = new YamlConfigSource("Yaml", yaml);
-        assertNotNull(src.getValue("de.javahippie.mpadmin.instances"));
+        assertEquals("Bing", src.getValue("de.javahippie.mpadmin.instances[0].name"));
+        assertEquals("https://bing.com", src.getValue("de.javahippie.mpadmin.instances[0].uri"));
+        assertEquals("Google", src.getValue("de.javahippie.mpadmin.instances[1].name"));
+        assertEquals("https://www.google.com", src.getValue("de.javahippie.mpadmin.instances[1].uri"));
     }
 }

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlLocationConfigSourceFactoryTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlLocationConfigSourceFactoryTest.java
@@ -36,7 +36,7 @@ class YamlLocationConfigSourceFactoryTest {
 
         assertEquals("1234", config.getRawValue("my.prop"));
         assertEquals("5678", config.getRawValue("more.prop"));
-        assertEquals(7, countSources(config));
+        assertEquals(9, countSources(config));
     }
 
     @Test
@@ -63,7 +63,7 @@ class YamlLocationConfigSourceFactoryTest {
 
         assertEquals("1234", config.getRawValue("my.prop"));
         assertEquals("5678", config.getRawValue("more.prop"));
-        assertEquals(8, countSources(config));
+        assertEquals(10, countSources(config));
     }
 
     @Test

--- a/sources/yaml/src/test/resources/example-collections.yml
+++ b/sources/yaml/src/test/resources/example-collections.yml
@@ -1,0 +1,14 @@
+application:
+  environments:
+    - name: dev
+      services:
+        - name: batch
+        - name: rest
+    - name: prod
+      services:
+        - name: web
+        - name: batch
+        - name: rest
+  images:
+    - base
+    - jdk

--- a/sources/yaml/src/test/resources/optional.yml
+++ b/sources/yaml/src/test/resources/optional.yml
@@ -1,0 +1,16 @@
+---
+"%base":
+  server:
+    name: localhost
+    config:
+      server: localhost
+      port: 1143
+      user: user
+      password: password
+      version:
+        major: 16
+        minor: 0
+---
+"%empty":
+  server:
+    name: localhost


### PR DESCRIPTION
* Fixes #436
* Fixes #447

Mappings of Groups in Collections is done by using the `[I]` index in the property to map. Example:

```properties
server.environments[0].name=dev
```

Maps to:

```java
@ConfigMapping(prefix = "server")
public interface ServerCollectionsSet {
    Set<Environment> environments();

    interface Environment {
        String name();
    }
}
```

In the case of comma separated values that map directly to a Collection type by the MP Config spec, it works as usual, but these can also be defined with indexed properties, but the MP Config way has priority:

```properties
server.environments=dev,prod
server.environments[0]=dev
server.environments[1]=prod
```

This also works for the `YamlConfigSource`, since the `yaml` content is serialized in this format. So, in practice this will work for any `ConfigSource` that provides their values in an indexed fashion.

A cool side effect is that these indexed properties can be overridden as usual in higher ordinal sources, per element.