### PR TITLE
Add catch block to Injection validation

### DIFF
--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toSet;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashSet;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -164,6 +165,8 @@ public class ConfigExtension implements Extension {
                 ConfigProducerUtil.getValue(injectionPoint, config);
             } catch (IllegalArgumentException e) {
                 adv.addDeploymentProblem(InjectionMessages.msg.illegalConversion(name, type));
+            } catch (NoSuchElementException e) {
+                adv.addDeploymentProblem(e);
             }
         }
 

--- a/cdi/src/test/java/io/smallrye/config/inject/InjectionTestConfigFactory.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/InjectionTestConfigFactory.java
@@ -22,7 +22,8 @@ public class InjectionTestConfigFactory extends SmallRyeConfigFactory {
                 .addDefaultSources()
                 .addDefaultInterceptors()
                 .withSources(config("my.prop", "1234", "expansion", "${my.prop}", "secret", "12345678",
-                        "mp.config.profile", "prof", "my.prop.profile", "1234", "%prof.my.prop.profile", "5678"))
+                        "mp.config.profile", "prof", "my.prop.profile", "1234", "%prof.my.prop.profile", "5678",
+                        "bad.property.expression.prop", "${missing.prop}"))
                 .withSources(new ConfigSource() {
                     int counter = 1;
 

--- a/cdi/src/test/java/io/smallrye/config/inject/ValidateInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/ValidateInjectionTest.java
@@ -100,6 +100,16 @@ public class ValidateInjectionTest {
                 .assertEventsMatchExactly(finishedWithFailure(instanceOf(IllegalArgumentException.class)));
     }
 
+    @Test
+    void missingPropertyExpressionInjection() {
+        JupiterTestEngine engine = new JupiterTestEngine();
+        LauncherDiscoveryRequest request = request().selectors(selectClass(MissingPropertyExpressionInjectionTest.class))
+                .build();
+        EngineExecutionResults results = EngineTestKit.execute(engine, request);
+        results.testEvents().failed().assertEventsMatchExactly(finishedWithFailure(instanceOf(DeploymentException.class),
+                message("SRCFG00011: Could not expand value missing.prop in property bad.property.expression.prop")));
+    }
+
     @ExtendWith(WeldJunit5Extension.class)
     static class MissingPropertyTest {
         @WeldSetup
@@ -271,6 +281,31 @@ public class ValidateInjectionTest {
         public static class Server {
             public String host;
             public int port;
+        }
+    }
+
+    @ExtendWith(WeldJunit5Extension.class)
+    static class MissingPropertyExpressionInjectionTest extends InjectionTest {
+        @WeldSetup
+        WeldInitiator weld = WeldInitiator.from(ConfigExtension.class, MissingPropertyExpressionBean.class)
+                .addBeans()
+                .activate(ApplicationScoped.class)
+                .inject(this)
+                .build();
+
+        @Inject
+        MissingPropertyExpressionBean bean;
+
+        @Test
+        void fail() {
+            Assertions.fail();
+        }
+
+        @ApplicationScoped
+        static class MissingPropertyExpressionBean {
+            @Inject
+            @ConfigProperty(name = "bad.property.expression.prop")
+            String missing;
         }
     }
 }


### PR DESCRIPTION
I tried to add an Injection Message (e.g. SRCFG02008) for bad Property Expression Injections (i.e. Injecting a Config Property where the Property Expression value `${x}` doesn't exist) though I couldn't figure out how to propagate the missing value (`${missing.prop}` in the test) through, so thought throwing `SRCFG00011` would be better. Would be happy to hear what others think and to see whether this is possible and worth it.