### PR TITLE
Use ordinal of the original source of `smallrye.config.locations` to load the additional ones.

### DIFF
--- a/doc/modules/ROOT/pages/config/locations.adoc
+++ b/doc/modules/ROOT/pages/config/locations.adoc
@@ -12,9 +12,11 @@ represent a valid `URI`. The supported `URI` schemes are:
 * jar resource
 * http resource
 
-Each `URI` scheme loads all discovered resources in a `ConfigSource`. All sources are loaded with the default ordinal
-`100`. The ordinal may be overridden directly in the resource by setting the `config_ordinal` property. Sources are
-sorted first by their ordinal, then by location order, and finally by loading order.
+Each `URI` scheme loads all discovered resources in a `ConfigSource`. All loaded sources use the same ordinal of the
+source that found the `smallrye.config.locations` configuration property. For instance, if `smallrye.config.locations`
+is set as a system property, then all loaded sources have their ordinals set to `400` (system properties use `400` as
+their ordinal). The ordinal may be overridden directly in the resource by setting the `config_ordinal` property. Sources
+are sorted first by their ordinal, then by location order, and finally by loading order.
 
 If a profile is active, and the `URI` represents a single resource (for instance a file), then resources that match the
 active profile are also loaded. The profile resource name must follow the pattern: `{location}-{profile}`. A profile

--- a/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceFactory.java
+++ b/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceFactory.java
@@ -27,6 +27,7 @@ public abstract class AbstractLocationConfigSourceFactory extends AbstractLocati
             return Collections.emptyList();
         }
 
-        return loadConfigSources(newArrayConverter(STRING_CONVERTER, String[].class).convert(value.getValue()));
+        return loadConfigSources(newArrayConverter(STRING_CONVERTER, String[].class).convert(value.getValue()),
+                value.getConfigSourceOrdinal());
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/DotEnvConfigSourceProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/DotEnvConfigSourceProvider.java
@@ -26,11 +26,6 @@ public class DotEnvConfigSourceProvider extends AbstractLocationConfigSourceLoad
     }
 
     @Override
-    protected ConfigSource loadConfigSource(final URL url) throws IOException {
-        return loadConfigSource(url, 295);
-    }
-
-    @Override
     protected ConfigSource loadConfigSource(final URL url, final int ordinal) throws IOException {
         return new EnvConfigSource(ConfigSourceUtil.urlToMap(url), ordinal) {
             @Override
@@ -42,7 +37,7 @@ public class DotEnvConfigSourceProvider extends AbstractLocationConfigSourceLoad
 
     @Override
     public List<ConfigSource> getConfigSources(final ClassLoader forClassLoader) {
-        return loadConfigSources(location, forClassLoader);
+        return loadConfigSources(location, 295, forClassLoader);
     }
 
     public static List<ConfigSource> dotEnvSources(final ClassLoader classLoader) {

--- a/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceProvider.java
@@ -34,7 +34,7 @@ public class PropertiesConfigSourceProvider extends AbstractLocationConfigSource
     public PropertiesConfigSourceProvider(final String location, final ClassLoader classLoader,
             final boolean includeFileSystem) {
         this.includeFileSystem = includeFileSystem;
-        this.configSources.addAll(loadConfigSources(location, classLoader));
+        this.configSources.addAll(loadConfigSources(location, ConfigSource.DEFAULT_ORDINAL, classLoader));
     }
 
     @Deprecated
@@ -61,9 +61,9 @@ public class PropertiesConfigSourceProvider extends AbstractLocationConfigSource
     }
 
     @Override
-    protected List<ConfigSource> tryFileSystem(final URI uri) {
+    protected List<ConfigSource> tryFileSystem(final URI uri, final int ordinal) {
         if (includeFileSystem) {
-            return super.tryFileSystem(uri);
+            return super.tryFileSystem(uri, ordinal);
         } else {
             return new ArrayList<>();
         }

--- a/implementation/src/main/java/io/smallrye/config/PropertiesLocationConfigSourceFactory.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertiesLocationConfigSourceFactory.java
@@ -12,6 +12,11 @@ public class PropertiesLocationConfigSourceFactory extends AbstractLocationConfi
     }
 
     @Override
+    public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
+        return super.getConfigSources(context);
+    }
+
+    @Override
     protected ConfigSource loadConfigSource(final URL url, final int ordinal) throws IOException {
         return new PropertiesConfigSource(url, ordinal);
     }

--- a/implementation/src/test/java/io/smallrye/config/DotEnvConfigSourceProviderTest.java
+++ b/implementation/src/test/java/io/smallrye/config/DotEnvConfigSourceProviderTest.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -29,6 +30,12 @@ class DotEnvConfigSourceProviderTest {
 
         assertEquals("1234", config.getRawValue("my.prop"));
         assertEquals("1234", config.getRawValue("MY_PROP"));
+
+        for (ConfigSource configSource : config.getConfigSources()) {
+            if (configSource.getName().endsWith(".env]")) {
+                assertEquals(295, configSource.getOrdinal());
+            }
+        }
     }
 
     @Test

--- a/implementation/src/test/java/io/smallrye/config/PropertiesLocationConfigSourceFactoryTest.java
+++ b/implementation/src/test/java/io/smallrye/config/PropertiesLocationConfigSourceFactoryTest.java
@@ -1,6 +1,7 @@
 package io.smallrye.config;
 
 import static io.smallrye.config.AbstractLocationConfigSourceFactory.SMALLRYE_LOCATIONS;
+import static io.smallrye.config.KeyValuesConfigSource.config;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,6 +70,7 @@ class PropertiesLocationConfigSourceFactoryTest {
 
         assertEquals("1234", config.getRawValue("my.prop"));
         assertEquals(1, countSources(config));
+        assertEquals(500, config.getConfigSources().iterator().next().getOrdinal());
     }
 
     @Test
@@ -556,6 +558,18 @@ class PropertiesLocationConfigSourceFactoryTest {
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
         }
+    }
+
+    @Test
+    void ordinal() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDiscoveredSources()
+                .addDefaultInterceptors()
+                .withSources(config(SMALLRYE_LOCATIONS, "more.properties", "config_ordinal", "1000"))
+                .build();
+
+        assertEquals("5678", config.getConfigValue("more.prop").getValue());
+        assertEquals(1000, config.getConfigValue("more.prop").getConfigSourceOrdinal());
     }
 
     private static SmallRyeConfig buildConfig(String... locations) {

--- a/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSourceProvider.java
+++ b/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSourceProvider.java
@@ -27,8 +27,8 @@ public class YamlConfigSourceProvider extends AbstractLocationConfigSourceLoader
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
         final List<ConfigSource> sources = new ArrayList<>();
-        sources.addAll(loadConfigSources("META-INF/microprofile-config.yaml", classLoader));
-        sources.addAll(loadConfigSources("META-INF/microprofile-config.yml", classLoader));
+        sources.addAll(loadConfigSources("META-INF/microprofile-config.yaml", 110, classLoader));
+        sources.addAll(loadConfigSources("META-INF/microprofile-config.yml", 110, classLoader));
         return sources;
     }
 }


### PR DESCRIPTION
- Fixes #532