### PR TITLE
Allow to fetch multiple config parameters as a Map

### DIFF
--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -29,6 +29,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -173,9 +174,10 @@ public class ConfigExtension implements Extension {
 
             // Check if the name is part of the properties first.
             // Since properties can be a subset, then search for the actual property for a value.
+            // Check if it is a map
             // Finally also check if the property is indexed (might be a Collection with indexed properties).
             if ((!configNames.contains(name) && ConfigProducerUtil.getRawValue(name, config) == null)
-                    && !isIndexed(type, name, config)) {
+                    && !isMap(type) && !isIndexed(type, name, config)) {
                 if (configProperty.defaultValue().equals(ConfigProperty.UNCONFIGURED_VALUE)) {
                     adv.addDeploymentProblem(
                             InjectionMessages.msg.noConfigValue(name, formatInjectionPoint(injectionPoint)));
@@ -231,5 +233,16 @@ public class ConfigExtension implements Extension {
                         Set.class.isAssignableFrom((Class<?>) ((ParameterizedType) type).getRawType()))
                 &&
                 !((SmallRyeConfig) config).getIndexedPropertiesIndexes(name).isEmpty();
+    }
+
+    /**
+     * Indicates whether the given type is a type of Map.
+     *
+     * @param type the type to check
+     * @return {@code true} if the given type is a type of Map, {@code false} otherwise.
+     */
+    private static boolean isMap(final Type type) {
+        return type instanceof ParameterizedType &&
+                Map.class.isAssignableFrom((Class<?>) ((ParameterizedType) type).getRawType());
     }
 }

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigProducer.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigProducer.java
@@ -138,6 +138,13 @@ public class ConfigProducer {
     @Dependent
     @Produces
     @ConfigProperty
+    protected <K, V> Map<K, V> producesMapConfigProperty(InjectionPoint ip) {
+        return ConfigProducerUtil.getValue(ip, getConfig(ip));
+    }
+
+    @Dependent
+    @Produces
+    @ConfigProperty
     protected OptionalInt produceOptionalIntConfigProperty(InjectionPoint ip) {
         return ConfigProducerUtil.getValue(ip, getConfig(ip));
     }

--- a/cdi/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
@@ -6,9 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -44,6 +50,38 @@ class ConfigInjectionTest {
 
     @Test
     void inject() {
+        assertEquals(2, configBean.getReasons().size());
+        assertEquals("OK", configBean.getReasons().get(200));
+        assertEquals("Created", configBean.getReasons().get(201));
+        assertEquals(2, configBean.getReasonsSupplier().get().size());
+        assertEquals("OK", configBean.getReasonsSupplier().get().get(200));
+        assertEquals("Created", configBean.getReasonsSupplier().get().get(201));
+        assertFalse(configBean.getReasonsOptional().isPresent());
+        assertEquals(2, configBean.getVersions().size());
+        assertEquals(new Version(1, "The version 1.2.3"), configBean.getVersions().get("v1"));
+        assertEquals(new Version(2, "The version 2.0.0"), configBean.getVersions().get("v2"));
+        assertEquals(2, configBean.getVersionsDefault().size());
+        assertEquals(new Version(1, "The version 1;2;3"), configBean.getVersionsDefault().get("v1=1;2;3"));
+        assertEquals(new Version(2, "The version 2;1;0"), configBean.getVersionsDefault().get("v2=2;1;0"));
+        assertEquals(2, configBean.getNumbersList().size());
+        assertEquals(4, configBean.getNumbersList().get("even").size());
+        assertTrue(configBean.getNumbersList().get("even").containsAll(Arrays.asList(2, 4, 6, 8)));
+        assertEquals(5, configBean.getNumbersList().get("odd").size());
+        assertTrue(configBean.getNumbersList().get("odd").containsAll(Arrays.asList(1, 3, 5, 7, 9)));
+        assertEquals(2, configBean.getNumbersSet().size());
+        assertEquals(4, configBean.getNumbersSet().get("even").size());
+        assertTrue(configBean.getNumbersSet().get("even").containsAll(Arrays.asList(2, 4, 6, 8)));
+        assertEquals(5, configBean.getNumbersSet().get("odd").size());
+        assertTrue(configBean.getNumbersSet().get("odd").containsAll(Arrays.asList(1, 3, 5, 7, 9)));
+        assertEquals(2, configBean.getNumbersArray().size());
+        assertEquals(4, configBean.getNumbersArray().get("even").length);
+        assertTrue(Arrays.asList(configBean.getNumbersArray().get("even")).containsAll(Arrays.asList(2, 4, 6, 8)));
+        assertEquals(5, configBean.getNumbersArray().get("odd").length);
+        assertTrue(Arrays.asList(configBean.getNumbersArray().get("odd")).containsAll(Arrays.asList(1, 3, 5, 7, 9)));
+        assertEquals(3, configBean.getNumbers().size());
+        assertEquals(1, configBean.getNumbers().get("one"));
+        assertEquals(2, configBean.getNumbers().get("two"));
+        assertEquals(3, configBean.getNumbers().get("three"));
         assertEquals("1234", configBean.getMyProp());
         assertEquals("1234", configBean.getExpansion());
         assertEquals("12345678", configBean.getSecret());
@@ -81,6 +119,33 @@ class ConfigInjectionTest {
     @ApplicationScoped
     static class ConfigBean {
         @Inject
+        @ConfigProperty(name = "optional.reasons")
+        Optional<Map<Integer, String>> reasonsOptional;
+        @Inject
+        @ConfigProperty(name = "reasons")
+        Supplier<Map<Integer, String>> reasonsSupplier;
+        @Inject
+        @ConfigProperty(name = "reasons")
+        Map<Integer, String> reasons;
+        @Inject
+        @ConfigProperty(name = "versions")
+        Map<String, Version> versions;
+        @Inject
+        @ConfigProperty(name = "default.versions", defaultValue = "v0.1=0.The version 0;v1\\=1;2;3=1.The version 1\\;2\\;3;v2\\=2;1;0=2.The version 2\\;1\\;0")
+        Map<String, Version> versionsDefault;
+        @Inject
+        @ConfigProperty(name = "nums")
+        Map<String, Integer> numbers;
+        @Inject
+        @ConfigProperty(name = "lnums")
+        Map<String, List<Integer>> numbersList;
+        @Inject
+        @ConfigProperty(name = "snums")
+        Map<String, Set<Integer>> numbersSet;
+        @Inject
+        @ConfigProperty(name = "anums")
+        Map<String, Integer[]> numbersArray;
+        @Inject
         @ConfigProperty(name = "my.prop")
         String myProp;
         @Inject
@@ -106,6 +171,42 @@ class ConfigInjectionTest {
         @Inject
         @ConfigProperty(name = "converted")
         Optional<ConvertedValue> convertedValueOptional;
+
+        Optional<Map<Integer, String>> getReasonsOptional() {
+            return reasonsOptional;
+        }
+
+        Supplier<Map<Integer, String>> getReasonsSupplier() {
+            return reasonsSupplier;
+        }
+
+        Map<Integer, String> getReasons() {
+            return reasons;
+        }
+
+        Map<String, Version> getVersions() {
+            return versions;
+        }
+
+        Map<String, Version> getVersionsDefault() {
+            return versionsDefault;
+        }
+
+        Map<String, List<Integer>> getNumbersList() {
+            return numbersList;
+        }
+
+        Map<String, Set<Integer>> getNumbersSet() {
+            return numbersSet;
+        }
+
+        Map<String, Integer[]> getNumbersArray() {
+            return numbersArray;
+        }
+
+        Map<String, Integer> getNumbers() {
+            return numbers;
+        }
 
         String getMyProp() {
             return myProp;
@@ -149,9 +250,16 @@ class ConfigInjectionTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withSources(config("my.prop", "1234", "expansion", "${my.prop}", "secret", "12345678",
                         "mp.config.profile", "prof", "my.prop.profile", "1234", "%prof.my.prop.profile", "5678",
-                        "bad.property.expression.prop", "${missing.prop}"))
+                        "bad.property.expression.prop", "${missing.prop}", "reasons.200", "OK", "reasons.201", "Created",
+                        "versions.v1", "1.The version 1.2.3", "versions.v1.2", "1.The version 1.2.0", "versions.v2",
+                        "2.The version 2.0.0",
+                        "lnums.even", "2,4,6,8", "lnums.odd", "1,3,5,7,9",
+                        "snums.even", "2,4,6,8", "snums.odd", "1,3,5,7,9",
+                        "anums.even", "2,4,6,8", "anums.odd", "1,3,5,7,9",
+                        "nums.one", "1", "nums.two", "2", "nums.three", "3"))
                 .withSecretKeys("secret")
                 .withConverter(ConvertedValue.class, 100, new ConvertedValueConverter())
+                .withConverter(Version.class, 100, new VersionConverter())
                 .addDefaultInterceptors()
                 .build();
         ConfigProviderResolver.instance().registerConfig(config, Thread.currentThread().getContextClassLoader());
@@ -160,6 +268,39 @@ class ConfigInjectionTest {
     @AfterAll
     static void afterAll() {
         ConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
+    }
+
+    static class Version {
+        int id;
+        String name;
+
+        Version(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Version version = (Version) o;
+            return id == version.id && Objects.equals(name, version.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, name);
+        }
+    }
+
+    static class VersionConverter implements Converter<Version> {
+
+        @Override
+        public Version convert(String value) {
+            return new Version(Integer.parseInt(value.substring(0, 1)), value.substring(2));
+        }
     }
 
     static class ConvertedValue {

--- a/doc/modules/ROOT/pages/config/config.adoc
+++ b/doc/modules/ROOT/pages/config/config.adoc
@@ -6,11 +6,14 @@ include::../attributes.adoc[]
 = Config
 
 * <<indexed-properties>>
+* <<map-support>>
 * <<profiles>>
 * <<locations>>
 * <<secret-keys>>
 
 include::indexed-properties.adoc[]
+
+include::map-support.adoc[]
 
 include::profiles.adoc[]
 

--- a/doc/modules/ROOT/pages/config/indexed-properties.adoc
+++ b/doc/modules/ROOT/pages/config/indexed-properties.adoc
@@ -6,7 +6,7 @@ for simple cases, but it becomes cumbersome and limited for more advanced cases.
 
 Indexed Properties provide a way to use indexes in config property names to map specific elements in a `Collection`
 type. Since the indexed element is part of the property name and not contained in the value, this can also be used to
-map complex object types as `Collectionª elements. Consider:
+map complex object types as `Collection` elements. Consider:
 
 [source,properties]
 ----

--- a/doc/modules/ROOT/pages/config/map-support.adoc
+++ b/doc/modules/ROOT/pages/config/map-support.adoc
@@ -1,0 +1,52 @@
+[[map-support]]
+== Map Support
+
+SmallRye Config allows injecting multiple configuration parameters as a `Map` using the standard annotations (`@ConfigProperty` and `@ConfigProperties`) which can
+be very helpful especially with a dynamic configuration.
+
+For example, let's say that I want to keep in my configuration the custom reason phrases to return to the end user according to the http status code.
+In that particular use case, the configuration could then be something like the following properties file:
+
+[source,properties]
+----
+server.reasons.200=My custom reason phrase for OK
+server.reasons.201=My custom reason phrase for Created
+...
+----
+
+The previous configuration could be injected directly into your bean using the standard annotations as next:
+
+With `@ConfigProperty`
+
+[source,java]
+----
+@ApplicationScoped
+public class ConfigBean {
+
+    @Inject
+    @ConfigProperty(name = "server.reasons") <1>
+    Map<Integer, String> reasons; <2>
+
+}
+----
+<1> Provide the name of the parent configuration property from the annotation `@ConfigProperty`.
+<2> Provide the expected type of `Map`, here the keys will automatically be converted into Integers, and the values into Strings.
+
+With `@ConfigProperties`
+
+[source,java]
+----
+@ConfigProperties(prefix = "server") <1>
+public class Config {
+
+    Map<Integer, String> reasons; <2>
+}
+----
+<1> Provide the prefix of the name of the parent configuration property from the annotation `@ConfigProperties`, here the prefix is `server`.
+<2> Provide the suffix of the name of the parent configuration, and the expected type of `Map`, here the keys will automatically be converted into Integers, and the values into Strings.
+
+NOTE: Only the direct sub properties will be converted into a `Map` and injected into the target bean, the rest will be ignored. In other words, in the previous example, a property whose name is `reasons.200.a` would be ignored as not considered as a direct sub property.
+
+NOTE: The property will be considered as missing if no direct sub properties could be found.
+
+It is also possible to do the exact same thing programmatically by calling the non-standard method `SmallRyeConfig#getValues("server.reasons", Integer.class, String.class)` if the property is mandatory otherwise by calling the method `SmallRyeConfig#getOptionalValues("server.reasons", Integer.class, String.class)`.

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingClass.java
@@ -27,12 +27,26 @@ final class ConfigMappingClass implements ConfigMappingMetadata {
         return new ConfigMappingClass(classType);
     }
 
+    private static String generateInterfaceName(final Class<?> classType) {
+        if (classType.isInterface() && classType.getTypeParameters().length == 0 ||
+                Modifier.isAbstract(classType.getModifiers()) ||
+                classType.isEnum()) {
+            throw new IllegalArgumentException();
+        }
+
+        return classType.getPackage().getName() +
+                "." +
+                classType.getSimpleName() +
+                classType.getName().hashCode() +
+                "I";
+    }
+
     private final Class<?> classType;
     private final String interfaceName;
 
     public ConfigMappingClass(final Class<?> classType) {
         this.classType = classType;
-        this.interfaceName = ConfigMappingGenerator.generateInterfaceName(classType);
+        this.interfaceName = generateInterfaceName(classType);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -352,20 +352,6 @@ public class ConfigMappingGenerator {
         return writer.toByteArray();
     }
 
-    static String generateInterfaceName(final Class<?> classType) {
-        if (classType.isInterface() && classType.getTypeParameters().length == 0 ||
-                Modifier.isAbstract(classType.getModifiers()) ||
-                classType.isEnum()) {
-            throw new IllegalArgumentException();
-        }
-
-        return classType.getPackage().getName() +
-                "." +
-                classType.getSimpleName() +
-                classType.getName().hashCode() +
-                "I";
-    }
-
     private static void addProperties(
             final ClassVisitor cv,
             final MethodVisitor ctor,
@@ -858,6 +844,7 @@ public class ConfigMappingGenerator {
         if (typeName.indexOf('<') != -1 && typeName.indexOf('>') != -1) {
             String signature = "()L" + typeName.replace(".", "/");
             signature = signature.replace("<", "<L");
+            signature = signature.replace(", ", ";L");
             signature = signature.replace(">", ";>;");
             return signature;
         }


### PR DESCRIPTION
fixes #578 

## Motivation

When we need a dynamic configuration, it can be very helpful to use a map. For example, let's say that I want to keep in my configuration the custom reason phrases to return to the enduser according to the http status code.

I would like to have:

The expected code

```
@ConfigProperty(name = "reasons")
Map<Integer, String> reasonPhrases; // or eventually Map<String, String>
```

The expected configuration
```
reasons.200=My custom reason phrase for OK
reasons.201=My custom reason phrase for Created
...
```

## Modifications

* Adds a generic producer for Map
* Adds a MapConverter to convert the content of type `<key1>=<value1>;<key2>=<value2>...` into a `Map`.
* Adds map support to the `ConfigMappingGenerator` 
* Adds related unit tests
* Adds new methods `getValues(String name, Class<K> kClass, Class<V> vClass)` and `getOptionalValues(String name, Class<K> kClass, Class<V> vClass)` to support properly the map from the class `SmallRyeConfig`