### PR TITLE
Improve way to manage default values in case of a Map

### DIFF
--- a/cdi/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
@@ -63,6 +63,8 @@ class ConfigInjectionTest {
         assertEquals(2, configBean.getVersionsDefault().size());
         assertEquals(new Version(1, "The version 1;2;3"), configBean.getVersionsDefault().get("v1=1;2;3"));
         assertEquals(new Version(2, "The version 2;1;0"), configBean.getVersionsDefault().get("v2=2;1;0"));
+        assertEquals(1, configBean.getVersionDefault().size());
+        assertEquals(new Version(0, "The version 0"), configBean.getVersionDefault().get("v0"));
         assertEquals(2, configBean.getNumbersList().size());
         assertEquals(4, configBean.getNumbersList().get("even").size());
         assertTrue(configBean.getNumbersList().get("even").containsAll(Arrays.asList(2, 4, 6, 8)));
@@ -131,8 +133,11 @@ class ConfigInjectionTest {
         @ConfigProperty(name = "versions")
         Map<String, Version> versions;
         @Inject
-        @ConfigProperty(name = "default.versions", defaultValue = "v0.1=0.The version 0;v1\\=1;2;3=1.The version 1\\;2\\;3;v2\\=2;1;0=2.The version 2\\;1\\;0")
+        @ConfigProperty(name = "default.versions", defaultValue = "v0.1=0.The version 0;v1\\=1\\;2\\;3=1.The version 1\\;2\\;3;v2\\=2\\;1\\;0=2.The version 2\\;1\\;0")
         Map<String, Version> versionsDefault;
+        @Inject
+        @ConfigProperty(name = "default.version", defaultValue = "v0=0.The version 0")
+        Map<String, Version> versionDefault;
         @Inject
         @ConfigProperty(name = "nums")
         Map<String, Integer> numbers;
@@ -190,6 +195,10 @@ class ConfigInjectionTest {
 
         Map<String, Version> getVersionsDefault() {
             return versionsDefault;
+        }
+
+        Map<String, Version> getVersionDefault() {
+            return versionDefault;
         }
 
         Map<String, List<Integer>> getNumbersList() {

--- a/cdi/src/test/java/io/smallrye/config/inject/ValidateInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/ValidateInjectionTest.java
@@ -9,6 +9,7 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.in
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
@@ -272,6 +273,28 @@ public class ValidateInjectionTest {
 
         assertThat(exception.getSuppressed()).hasSize(3);
         assertThat(exception.getSuppressed()).allMatch((e) -> e instanceof ConfigException);
+    }
+
+    @Test
+    void missingSubProperties() {
+        DeploymentException exception = getDeploymentException(MissingSubPropertiesTest.class);
+        assertThat(exception).hasMessageStartingWith(
+                "SRCFG02001: Failed to Inject @ConfigProperty for key missing.sub.properties into io.smallrye.config.inject.ValidateInjectionTest$MissingSubPropertiesTest$MissingSubPropertiesBean.missingSubProps SRCFG00014");
+
+        assertThat(exception.getCause()).isInstanceOf(ConfigException.class);
+        assertThat(exception.getCause()).hasMessageStartingWith(
+                "SRCFG02001: Failed to Inject @ConfigProperty for key missing.sub.properties into io.smallrye.config.inject.ValidateInjectionTest$MissingSubPropertiesTest$MissingSubPropertiesBean.missingSubProps SRCFG00014");
+    }
+
+    @Test
+    void invalidMapFormat() {
+        DeploymentException exception = getDeploymentException(InvalidMapFormatTest.class);
+        assertThat(exception).hasMessageStartingWith(
+                "SRCFG02001: Failed to Inject @ConfigProperty for key missing.sub.properties into io.smallrye.config.inject.ValidateInjectionTest$InvalidMapFormatTest$InvalidMapFormatBean.missingSubProps SRCFG00042");
+
+        assertThat(exception.getCause()).isInstanceOf(ConfigException.class);
+        assertThat(exception.getCause()).hasMessageStartingWith(
+                "SRCFG02001: Failed to Inject @ConfigProperty for key missing.sub.properties into io.smallrye.config.inject.ValidateInjectionTest$InvalidMapFormatTest$InvalidMapFormatBean.missingSubProps SRCFG00042");
     }
 
     @Test
@@ -706,6 +729,58 @@ public class ValidateInjectionTest {
         public static class ServerDetailsBean {
             public String host;
             public int port;
+        }
+    }
+
+    @ExtendWith(WeldJunit5Extension.class)
+    static class InvalidMapFormatTest {
+        @WeldSetup
+        WeldInitiator weld = WeldInitiator
+                .from(ConfigExtension.class, InvalidMapFormatBean.class)
+                .addBeans()
+                .activate(ApplicationScoped.class)
+                .inject(this)
+                .build();
+
+        @Inject
+        InvalidMapFormatBean bean;
+
+        @Test
+        void fail() {
+            Assertions.fail();
+        }
+
+        @ApplicationScoped
+        static class InvalidMapFormatBean {
+            @Inject
+            @ConfigProperty(name = "missing.sub.properties", defaultValue = "bad default value format")
+            Map<String, String> missingSubProps;
+        }
+    }
+
+    @ExtendWith(WeldJunit5Extension.class)
+    static class MissingSubPropertiesTest {
+        @WeldSetup
+        WeldInitiator weld = WeldInitiator
+                .from(ConfigExtension.class, MissingSubPropertiesBean.class)
+                .addBeans()
+                .activate(ApplicationScoped.class)
+                .inject(this)
+                .build();
+
+        @Inject
+        MissingSubPropertiesBean bean;
+
+        @Test
+        void fail() {
+            Assertions.fail();
+        }
+
+        @ApplicationScoped
+        static class MissingSubPropertiesBean {
+            @Inject
+            @ConfigProperty(name = "missing.sub.properties")
+            Map<String, String> missingSubProps;
         }
     }
 

--- a/doc/modules/ROOT/pages/config/map-support.adoc
+++ b/doc/modules/ROOT/pages/config/map-support.adoc
@@ -24,12 +24,12 @@ With `@ConfigProperty`
 public class ConfigBean {
 
     @Inject
-    @ConfigProperty(name = "server.reasons") <1>
+    @ConfigProperty(name = "server.reasons", defaultValue = "200=OK;201=Created") <1>
     Map<Integer, String> reasons; <2>
 
 }
 ----
-<1> Provide the name of the parent configuration property from the annotation `@ConfigProperty`.
+<1> Provide the name of the parent configuration property from the annotation `@ConfigProperty`. Provide also the default values to use in case no direct sub properties could be found, using the syntax `<key1>=<value1>;<key2>=<value2>...`, so here the default values are "OK" for 200 and "Created" for 201.
 <2> Provide the expected type of `Map`, here the keys will automatically be converted into Integers, and the values into Strings.
 
 With `@ConfigProperties`

--- a/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMessages.java
@@ -143,4 +143,7 @@ public interface ConfigMessages {
     @Message(id = 41, value = "The config property %s with the config value \"%s\" was converted to null from the following Converter: %s")
     NoSuchElementException converterReturnedNull(String configPropertyName, String configValue, String converter);
 
+    @Message(id = 42, value = "Value does not match the expected map format \"<key1>=<value1>;<key2>=<value2>...\" (value was \"%s\")")
+    NoSuchElementException valueNotMatchMapFormat(String value);
+
 }


### PR DESCRIPTION
Follow up of #579

## Motivation

The current documentation about the support of Map doesn't describe how to define default values, it needs to be added. Moreover #579 adds a sonar violation , it needs to be fixed. Finally tests on failures are missing.

## Modifications:

* Rewrites the converter to avoid relying on a regular expression with a negative lookbehind to fix the Sonar violation
* Adds a new config message for the MapConverter in case of invalid format
* Adds unit tests to check that errors are properly thrown in case sub properties are missing and default value is not in the expected format.
* Modifies the example for `@ConfigProperty` to set `defaultValue` and describe how to use it properly