### PR TITLE
Avoid throwing Exception for Optional types and ConfigValue if expression cannot be expanded

### DIFF
--- a/cdi/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/ConfigInjectionTest.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -106,11 +109,21 @@ class ConfigInjectionTest {
         assertEquals("my.prop.missing", configValueMissing.getName());
         assertEquals("default", configValueMissing.getValue());
         assertNull(configValueMissing.getConfigSourceName());
+
+        final ConfigValue badExpansionConfigValue = configBean.getBadExpansionConfigValue();
+        assertNotNull(badExpansionConfigValue);
+        assertEquals("bad.property.expression.prop", badExpansionConfigValue.getName());
+        assertNull(badExpansionConfigValue.getValue());
+        assertNull(badExpansionConfigValue.getConfigSourceName());
     }
 
     @Test
     void optionals() {
         assertFalse(configBean.getUnknown().isPresent());
+        assertFalse(configBean.getBadExpansion().isPresent());
+        assertFalse(configBean.getBadExpansionInt().isPresent());
+        assertFalse(configBean.getBadExpansionDouble().isPresent());
+        assertFalse(configBean.getBadExpansionLong().isPresent());
     }
 
     @Test
@@ -157,6 +170,18 @@ class ConfigInjectionTest {
         @ConfigProperty(name = "expansion")
         String expansion;
         @Inject
+        @ConfigProperty(name = "bad.property.expression.prop")
+        Optional<String> badExpansion;
+        @Inject
+        @ConfigProperty(name = "bad.property.expression.prop")
+        OptionalInt badExpansionInt;
+        @Inject
+        @ConfigProperty(name = "bad.property.expression.prop")
+        OptionalDouble badExpansionDouble;
+        @Inject
+        @ConfigProperty(name = "bad.property.expression.prop")
+        OptionalLong badExpansionLong;
+        @Inject
         @ConfigProperty(name = "secret")
         String secret;
         @Inject
@@ -170,6 +195,9 @@ class ConfigInjectionTest {
         @Inject
         @ConfigProperty(name = "my.prop.missing", defaultValue = "default")
         ConfigValue configValueMissing;
+        @Inject
+        @ConfigProperty(name = "bad.property.expression.prop")
+        ConfigValue badExpansionConfigValue;
         @Inject
         @ConfigProperty(name = "unknown")
         Optional<String> unknown;
@@ -225,6 +253,22 @@ class ConfigInjectionTest {
             return expansion;
         }
 
+        Optional<String> getBadExpansion() {
+            return badExpansion;
+        }
+
+        OptionalInt getBadExpansionInt() {
+            return badExpansionInt;
+        }
+
+        OptionalDouble getBadExpansionDouble() {
+            return badExpansionDouble;
+        }
+
+        public OptionalLong getBadExpansionLong() {
+            return badExpansionLong;
+        }
+
         String getSecret() {
             return secret;
         }
@@ -243,6 +287,10 @@ class ConfigInjectionTest {
 
         ConfigValue getConfigValueMissing() {
             return configValueMissing;
+        }
+
+        ConfigValue getBadExpansionConfigValue() {
+            return badExpansionConfigValue;
         }
 
         Optional<String> getUnknown() {

--- a/implementation/src/test/java/io/smallrye/config/ExpressionConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ExpressionConfigSourceInterceptorTest.java
@@ -1,14 +1,19 @@
 package io.smallrye.config;
 
+import static io.smallrye.common.constraint.Assert.assertNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
 import org.junit.jupiter.api.Test;
 
 class ExpressionConfigSourceInterceptorTest {
@@ -74,12 +79,50 @@ class ExpressionConfigSourceInterceptorTest {
     }
 
     @Test
+    void noExpressionButOptional() {
+        SmallRyeConfig config = buildConfig("expression", "${my.prop}");
+
+        assertEquals(Optional.empty(), config.getOptionalValue("expression", String.class));
+    }
+
+    @Test
+    void noExpressionButConfigValue() {
+        Config config = buildConfig("expression", "${my.prop}");
+
+        ConfigValue configValue = config.getConfigValue("expression");
+        assertNotNull(configValue);
+        assertEquals("expression", configValue.getName());
+        assertNull(configValue.getValue());
+        assertNull(configValue.getSourceName());
+        assertEquals(0, configValue.getSourceOrdinal());
+    }
+
+    @Test
     void noExpressionComposed() {
         SmallRyeConfig config = buildConfig("expression", "${my.prop${compose}}");
 
         final NoSuchElementException exception = assertThrows(NoSuchElementException.class,
                 () -> config.getValue("expression", String.class));
         assertEquals("SRCFG00011: Could not expand value compose in property expression", exception.getMessage());
+    }
+
+    @Test
+    void noExpressionComposedButOptional() {
+        SmallRyeConfig config = buildConfig("expression", "${my.prop${compose}}");
+
+        assertEquals(Optional.empty(), config.getOptionalValue("expression", String.class));
+    }
+
+    @Test
+    void noExpressionComposedButConfigValue() {
+        Config config = buildConfig("expression", "${my.prop${compose}}");
+
+        ConfigValue configValue = config.getConfigValue("expression");
+        assertNotNull(configValue);
+        assertEquals("expression", configValue.getName());
+        assertNull(configValue.getValue());
+        assertNull(configValue.getSourceName());
+        assertEquals(0, configValue.getSourceOrdinal());
     }
 
     @Test


### PR DESCRIPTION
fixes #587

## Motivation

Up to now, when the value of a property could not be expanded, a `NoSuchElementException` is thrown whatever the target type while it should not be thrown for an Optional type or a ConfigValue.

## Modifications:

* Adds the new method `getRawConfigValue` to provide a `ConfigValue` without catching the `NoSuchElementException`
* Modifies the method `getConfigValue` to return an empty `ConfigValue` when a `NoSuchElementException` is caught (not stated into the spec but IMHO it makes more sense than throwing the exception) 
* Adds the new method `noSuchElementExceptionForbidden` to know if a target type accepts or not `NoSuchElementException` if the value of the corresponding property cannot be expanded. (`ConfigValue` is part of it even if it is not stated into the spec but IMHO it makes more sense)
* Removes the annotation `@Experimental` from `getConfigValue` as it is now covered by the spec