### PR TITLE
Do not include a relocation property in getPropertyNames

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/RelocateConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/RelocateConfigSourceInterceptor.java
@@ -34,21 +34,6 @@ public class RelocateConfigSourceInterceptor implements ConfigSourceInterceptor 
     }
 
     @Override
-    public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
-        final Set<String> names = new HashSet<>();
-        final Iterator<String> namesIterator = context.iterateNames();
-        while (namesIterator.hasNext()) {
-            final String name = namesIterator.next();
-            names.add(name);
-            final String mappedName = mapping.apply(name);
-            if (mappedName != null) {
-                names.add(mappedName);
-            }
-        }
-        return names.iterator();
-    }
-
-    @Override
     public Iterator<ConfigValue> iterateValues(final ConfigSourceInterceptorContext context) {
         final Set<ConfigValue> values = new HashSet<>();
         final Iterator<ConfigValue> valuesIterator = context.iterateValues();

--- a/implementation/src/test/java/io/smallrye/config/RelocateConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/RelocateConfigSourceInterceptorTest.java
@@ -4,6 +4,7 @@ import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -111,9 +112,9 @@ class RelocateConfigSourceInterceptorTest {
 
         assertEquals("Authorization", config.getValue("smallrye.jwt.token.header", String.class));
         List<String> names = stream(config.getPropertyNames().spliterator(), false).collect(toList());
-        assertEquals(2, names.size());
+        assertEquals(1, names.size());
         assertTrue(names.contains("smallrye.jwt.token.header"));
-        assertTrue(names.contains("mp.jwt.token.header"));
+        assertFalse(names.contains("mp.jwt.token.header"));
 
         RelocateConfigSourceInterceptor relocateInterceptor = new RelocateConfigSourceInterceptor(
                 s -> s.replaceAll("smallrye\\.jwt\\.token\\.header", "mp.jwt.token.header"));


### PR DESCRIPTION
A relocation property should not be present, because when iterating `getPropertyNames`, it may provide the wrong impression that the relocated property has a value.