### PR TITLE
Add support of multi valued types to ConfigProperties

### DIFF
--- a/cdi/src/test/java/io/smallrye/config/inject/ConfigPropertiesInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/ConfigPropertiesInjectionTest.java
@@ -3,11 +3,16 @@ package io.smallrye.config.inject;
 import static io.smallrye.config.inject.KeyValuesConfigSource.config;
 import static org.eclipse.microprofile.config.inject.ConfigProperties.UNCONFIGURED_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.CDI;
@@ -16,6 +21,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.weld.junit5.WeldInitiator;
 import org.jboss.weld.junit5.WeldJunit5Extension;
@@ -52,10 +58,25 @@ class ConfigPropertiesInjectionTest {
         assertNotNull(server);
         assertEquals("localhost", server.theHost);
         assertEquals(8080, server.port);
+        assertEquals(1, server.array.length);
+        assertEquals(1, server.list.size());
+        assertEquals(1, server.set.size());
+        assertFalse(server.optionalArray.isPresent());
+        assertFalse(server.optionalList.isPresent());
+        assertFalse(server.optionalSet.isPresent());
 
         assertNotNull(serverCloud);
         assertEquals("cloud", serverCloud.theHost);
         assertEquals(9090, serverCloud.port);
+        assertEquals(2, serverCloud.array.length);
+        assertEquals(2, serverCloud.list.size());
+        assertEquals(2, serverCloud.set.size());
+        assertTrue(serverCloud.optionalArray.isPresent());
+        assertEquals(2, serverCloud.optionalArray.get().length);
+        assertTrue(serverCloud.optionalList.isPresent());
+        assertEquals(2, serverCloud.optionalList.get().size());
+        assertTrue(serverCloud.optionalSet.isPresent());
+        assertEquals(2, serverCloud.optionalSet.get().size());
     }
 
     @Test
@@ -64,11 +85,26 @@ class ConfigPropertiesInjectionTest {
         assertNotNull(server);
         assertEquals("localhost", server.theHost);
         assertEquals(8080, server.port);
+        assertEquals(1, server.array.length);
+        assertEquals(1, server.list.size());
+        assertEquals(1, server.set.size());
+        assertFalse(server.optionalArray.isPresent());
+        assertFalse(server.optionalList.isPresent());
+        assertFalse(server.optionalSet.isPresent());
 
         Server cloud = CDI.current().select(Server.class, ConfigProperties.Literal.of("cloud")).get();
         assertNotNull(cloud);
         assertEquals("cloud", cloud.theHost);
         assertEquals(9090, cloud.port);
+        assertEquals(2, cloud.array.length);
+        assertEquals(2, cloud.list.size());
+        assertEquals(2, cloud.set.size());
+        assertTrue(cloud.optionalArray.isPresent());
+        assertEquals(2, cloud.optionalArray.get().length);
+        assertTrue(cloud.optionalList.isPresent());
+        assertEquals(2, cloud.optionalList.get().size());
+        assertTrue(cloud.optionalSet.isPresent());
+        assertEquals(2, cloud.optionalSet.get().size());
     }
 
     @Test
@@ -87,13 +123,24 @@ class ConfigPropertiesInjectionTest {
     public static class Server {
         public String theHost;
         public int port;
+        @ConfigProperty(defaultValue = "2")
+        public Integer[] array;
+        @ConfigProperty(defaultValue = "3")
+        public List<Integer> list;
+        @ConfigProperty(defaultValue = "4")
+        public Set<Integer> set;
+        public Optional<Integer[]> optionalArray;
+        public Optional<List<Integer>> optionalList;
+        public Optional<Set<Integer>> optionalSet;
     }
 
     @BeforeAll
     static void beforeAll() {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withSources(config("server.theHost", "localhost", "server.port", "8080"))
-                .withSources(config("cloud.theHost", "cloud", "cloud.port", "9090"))
+                .withSources(config("cloud.theHost", "cloud", "cloud.port", "9090", "cloud.array", "2,3",
+                        "cloud.list", "3,4", "cloud.set", "4,5", "cloud.optionalArray", "2,3",
+                        "cloud.optionalList", "3,4", "cloud.optionalSet", "4,5"))
                 .addDefaultInterceptors()
                 .build();
         ConfigProviderResolver.instance().registerConfig(config, Thread.currentThread().getContextClassLoader());

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.IntFunction;
+import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -59,6 +60,10 @@ import io.smallrye.config.ConfigMappingInterface.Property;
 
 public class ConfigMappingGenerator {
     static final boolean usefulDebugInfo;
+    /**
+     * The regular expression allowing to detect arrays in a full type name.
+     */
+    private static final Pattern ARRAY_FORMAT_REGEX = Pattern.compile("([<;])L(.*)\\[];");
 
     static {
         usefulDebugInfo = Boolean.parseBoolean(AccessController.doPrivileged(
@@ -849,7 +854,11 @@ public class ConfigMappingGenerator {
             String signature = "()L" + typeName.replace(".", "/");
             signature = signature.replace("<", "<L");
             signature = signature.replace(", ", ";L");
-            signature = signature.replace(">", ";>;");
+            signature = signature.replace(">", ";>");
+            signature += ";";
+            if (typeName.contains("[]")) {
+                signature = ARRAY_FORMAT_REGEX.matcher(signature).replaceAll("$1[L$2;");
+            }
             return signature;
         }
 


### PR DESCRIPTION
fixes #641

## Motivation

There is no way to use a `Set`, a `List` or an array as type of a class annotated with `ConfigProperties`.

## Modifications:

* Improve the method allowing to generate the signature in "byte-code format" to support properly collections and arrays.
* Force the language at surefire level to ensure that `ValidateConfigTest` will pass whatever the default system language (not related to the issue)