### PR TITLE
fix race condition in ConfigMappingLoader

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -81,7 +81,7 @@ public final class ConfigMappingLoader {
         return (Class<? extends ConfigMappingObject>) loadClass(type, mappingMetadata);
     }
 
-    static Class<?> loadClass(final Class<?> parent, final ConfigMappingMetadata configMappingMetadata) {
+    static synchronized Class<?> loadClass(final Class<?> parent, final ConfigMappingMetadata configMappingMetadata) {
         // Check if the interface implementation was already loaded. If not we will load it.
         try {
             final Class<?> klass = parent.getClassLoader().loadClass(configMappingMetadata.getClassName());

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.microprofile.config.inject.ConfigProperties;
 
@@ -13,6 +14,7 @@ import io.smallrye.common.classloader.ClassDefiner;
 
 public final class ConfigMappingLoader {
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final ConcurrentHashMap<String, Object> classLoaderLocks = new ConcurrentHashMap<>();
 
     private static final ClassValue<ConfigMappingObjectHolder> CACHE = new ClassValue<ConfigMappingObjectHolder>() {
         @Override
@@ -81,21 +83,24 @@ public final class ConfigMappingLoader {
         return (Class<? extends ConfigMappingObject>) loadClass(type, mappingMetadata);
     }
 
-    static synchronized Class<?> loadClass(final Class<?> parent, final ConfigMappingMetadata configMappingMetadata) {
-        // Check if the interface implementation was already loaded. If not we will load it.
-        try {
-            final Class<?> klass = parent.getClassLoader().loadClass(configMappingMetadata.getClassName());
-            // Check if this is the right classloader class. If not we will load it.
-            if (parent.isAssignableFrom(klass)) {
-                return klass;
+    static Class<?> loadClass(final Class<?> parent, final ConfigMappingMetadata configMappingMetadata) {
+        // acquire a lock on the class name to prevent race conditions in multithreaded use cases
+        synchronized (getClassLoaderLock(configMappingMetadata.getClassName())) {
+            // Check if the interface implementation was already loaded. If not we will load it.
+            try {
+                final Class<?> klass = parent.getClassLoader().loadClass(configMappingMetadata.getClassName());
+                // Check if this is the right classloader class. If not we will load it.
+                if (parent.isAssignableFrom(klass)) {
+                    return klass;
+                }
+                // ConfigProperties should not have issues with classloader and interfaces.
+                if (configMappingMetadata instanceof ConfigMappingClass) {
+                    return klass;
+                }
+                return defineClass(parent, configMappingMetadata.getClassName(), configMappingMetadata.getClassBytes());
+            } catch (ClassNotFoundException e) {
+                return defineClass(parent, configMappingMetadata.getClassName(), configMappingMetadata.getClassBytes());
             }
-            // ConfigProperties should not have issues with classloader and interfaces.
-            if (configMappingMetadata instanceof ConfigMappingClass) {
-                return klass;
-            }
-            return defineClass(parent, configMappingMetadata.getClassName(), configMappingMetadata.getClassBytes());
-        } catch (ClassNotFoundException e) {
-            return defineClass(parent, configMappingMetadata.getClassName(), configMappingMetadata.getClassBytes());
         }
     }
 
@@ -118,6 +123,10 @@ public final class ConfigMappingLoader {
      */
     private static Class<?> defineClass(final Class<?> parent, final String className, final byte[] classBytes) {
         return ClassDefiner.defineClass(LOOKUP, parent, className, classBytes);
+    }
+
+    private static Object getClassLoaderLock(String className) {
+        return classLoaderLocks.computeIfAbsent(className, c -> new Object());
     }
 
     private static final class ConfigMappingObjectHolder {

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingLoaderParallelTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingLoaderParallelTest.java
@@ -1,10 +1,10 @@
 package io.smallrye.config;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Execution(ExecutionMode.CONCURRENT)
 class ConfigMappingLoaderParallelTest {

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingLoaderParallelTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingLoaderParallelTest.java
@@ -1,0 +1,44 @@
+package io.smallrye.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Execution(ExecutionMode.CONCURRENT)
+class ConfigMappingLoaderParallelTest {
+    @Test
+    void testParallelThreadOne() {
+        loadTestClass();
+    }
+
+    @Test
+    void testParallelThreadTwo() {
+        loadTestClass();
+    }
+
+    @Test
+    void testParallelThreadThree() {
+        loadTestClass();
+    }
+
+    @Test
+    void testParallelThreadFour() {
+        loadTestClass();
+    }
+
+    private void loadTestClass() {
+        ConfigMappingLoader.getImplementationClass(ConfigMappingLoaderTest.Server.class);
+        ConfigMappingLoader.getImplementationClass(ConfigMappingLoaderTest.Server.class);
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withSources(
+                KeyValuesConfigSource.config("server.host", "localhost", "server.port", "8080"))
+                .withMapping(ConfigMappingLoaderTest.Server.class)
+                .build();
+
+        ConfigMappingLoaderTest.Server server = config.getConfigMapping(ConfigMappingLoaderTest.Server.class);
+        assertEquals("localhost", server.host());
+        assertEquals(8080, server.port());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/PropertiesLocationConfigSourceFactoryTest.java
+++ b/implementation/src/test/java/io/smallrye/config/PropertiesLocationConfigSourceFactoryTest.java
@@ -79,7 +79,7 @@ class PropertiesLocationConfigSourceFactoryTest {
 
         assertEquals("1234", config.getRawValue("my.prop"));
         assertEquals("5678", config.getRawValue("more.prop"));
-        assertEquals(3, countSources(config));
+        assertEquals(4, countSources(config));
     }
 
     @Test
@@ -107,7 +107,7 @@ class PropertiesLocationConfigSourceFactoryTest {
 
         assertEquals("1234", config.getRawValue("my.prop"));
         assertEquals("5678", config.getRawValue("more.prop"));
-        assertEquals(4, countSources(config));
+        assertEquals(5, countSources(config));
     }
 
     @Test

--- a/implementation/src/test/resources/junit-platform.properties
+++ b/implementation/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.config.fixed.parallelism = 8
+junit.jupiter.execution.parallel.mode.classes.default = same_thread
+junit.jupiter.execution.parallel.mode.default = same_thread


### PR DESCRIPTION
Hi,

after enabling parallel unit tests on one of my projects I got test failures caused by a non thread safe implementation in ConfigMappingLoader:

```
java.lang.LinkageError: loader 'app' attempted duplicate class definition for io.smallrye.config.ConfigMappingLoaderTest$Server-1289738797Impl. (io.smallrye.config.ConfigMappingLoaderTest$Server-1289738797Impl is in unnamed module of loader 'app')

	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.System$2.defineClass(System.java:2131)
	at java.base/java.lang.invoke.MethodHandles$Lookup.defineClass(MethodHandles.java:962)
	at io.smallrye.common.classloader.ClassDefiner$1.run(ClassDefiner.java:19)
	at io.smallrye.common.classloader.ClassDefiner$1.run(ClassDefiner.java:14)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at io.smallrye.common.classloader.ClassDefiner.defineClass(ClassDefiner.java:14)
	at io.smallrye.config.ConfigMappingLoader.defineClass(ConfigMappingLoader.java:120)
	at io.smallrye.config.ConfigMappingLoader.loadClass(ConfigMappingLoader.java:98)
	at io.smallrye.config.ConfigMappingLoader.getImplementationClass(ConfigMappingLoader.java:81)
	at io.smallrye.config.ConfigMappingLoaderParallelTest.execute(ConfigMappingLoaderParallelTest.java:33)
``` 

PR contains a bit of a "blunt" fix by adding synchronzied modifier to the according method call - not sure if that's acceptable due to the performance penalty.
Furthermore there is a unit test + junit config to enable parallel test execution for this particular test class. If you remove the synchronized modifier the tests should error out.
Second test had to be adapted due to the additional .properties file.