### PR TITLE
Support for wildcard file locations (#693)

### DIFF
--- a/doc/modules/ROOT/pages/config-sources/filesystem-config-source.adoc
+++ b/doc/modules/ROOT/pages/config-sources/filesystem-config-source.adoc
@@ -8,17 +8,27 @@ For example, if a directory structure looks like:
 
 [source]
 ----
-foo/
-|__num.max
-|__num.size
+conf
+|__foo/
+   |__num.max
+   |__num.size
+|__bar/
+   |__str.val
 ----
 
-A `new FileSystemConfigSource("foo")` will provide 2 properties:
+A `new FileSystemConfigSource("conf/foo")` will provide 2 properties:
 
 * num.max
 * num.size
 
 And their values is the file content.
+
+Wildcard locations at last path segment also supported. A `new FileSystemConfigSource("conf/*/")` will provide 3
+properties:
+
+* num.max
+* num.size
+* str.val
 
 Nested directories are not supported.
 

--- a/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceFactoryTest.java
+++ b/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceFactoryTest.java
@@ -38,6 +38,26 @@ class FileSystemConfigSourceFactoryTest {
         assertEquals(2, StreamSupport.stream(configSources.spliterator(), false).count());
     }
 
+    @Test
+    void testWildcardLocationUri() throws URISyntaxException {
+        FileSystemConfigSourceFactory factory = new FileSystemConfigSourceFactory();
+
+        URL rootConfigDirURL = this.getClass().getResource(".");
+        Iterable<ConfigSource> configSources = factory.getConfigSources(
+                newConfigSourceContext(rootConfigDirURL.toURI() + "*/"));
+        assertEquals(2, StreamSupport.stream(configSources.spliterator(), false).count());
+    }
+
+    @Test
+    void testWildcardLocationPath() {
+        FileSystemConfigSourceFactory factory = new FileSystemConfigSourceFactory();
+
+        String rootConfigDirPath = this.getClass().getResource(".").getPath();
+        Iterable<ConfigSource> configSources = factory.getConfigSources(
+                newConfigSourceContext(rootConfigDirPath + "*/"));
+        assertEquals(2, StreamSupport.stream(configSources.spliterator(), false).count());
+    }
+
     private ConfigSourceContext newConfigSourceContext(String value) {
         return new ConfigSourceContext() {
 


### PR DESCRIPTION
While testing new functionality I've noticed that the current implementation does not support URIs syntax (actual values not read from the filesystem). It is expected behavior or all variations should read URI format (e.g. `file/conf/etc`)?