### PR TITLE
Use the root locale during the validation tests

### DIFF
--- a/validator/src/test/java/io/smallrye/config/validator/ValidateConfigTest.java
+++ b/validator/src/test/java/io/smallrye/config/validator/ValidateConfigTest.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -25,6 +26,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 
 import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.ConfigMapping;
@@ -34,6 +37,25 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.WithParentName;
 
 public class ValidateConfigTest {
+
+    private static Locale oldDefaultLocale = Locale.getDefault();
+
+    /**
+     * Set the default locale to ROOT before the tests as the validation problem messages are locale-sensitive.
+     */
+    @BeforeAll
+    static void setupMessageLocale() {
+        Locale.setDefault(Locale.ROOT);
+    }
+
+    /**
+     * Restore the old default locale just in case it is needed elsewhere outside this test class.
+     */
+    @AfterAll
+    static void restoreMessageLocale() {
+        Locale.setDefault(oldDefaultLocale);
+    }
+
     @Test
     void validateConfigMapping() {
         SmallRyeConfig config = new SmallRyeConfigBuilder()


### PR DESCRIPTION
The problem messages that get checked in the validation tests are locale-sensitive and therefore, the tests fail on some computers with non-English default locale, e.g., German or French. Setting and restoring the root locale should fix the problem without interfering with other tests / steps in the build process.

Note that I chose to add this directly into the test class such that it works in the IDE without running Maven, too.

Some alternatives would be to extract the logic into a super class or JUnit 5 test extension, but this is the only test in this repository with the problem.

Example errors:
```
// German locale
org.opentest4j.AssertionFailedError: expected: <server.port must be greater than or equal to 8000> but was: <server.port muss größer-gleich 8000 sein>
// French locale
org.opentest4j.AssertionFailedError: expected: <server.port must be greater than or equal to 8000> but was: <server.port doit être supérieur ou égal à 8000>
```