### PR TITLE
Validate maps and collections completely

### DIFF
--- a/validator/src/main/java/io/smallrye/config/validator/BeanValidationConfigValidator.java
+++ b/validator/src/main/java/io/smallrye/config/validator/BeanValidationConfigValidator.java
@@ -127,10 +127,8 @@ public interface BeanValidationConfigValidator extends ConfigValidator {
                         throw new UndeclaredThrowableException(t2);
                     }
                 }
-            } else if (collectionProperty.getElement().isLeaf()) {
-                validateProperty(collectionProperty.getElement(), currentPath, namingStrategy, mappingObject, optional,
-                        problems);
             }
+            validatePropertyValue(property, currentPath, namingStrategy, mappingObject, problems);
         }
 
         if (property.isMap()) {
@@ -169,8 +167,6 @@ public interface BeanValidationConfigValidator extends ConfigValidator {
                                 i++;
                             }
                         }
-                    } else if (collectionProperty.getElement().isLeaf()) {
-                        validatePropertyValue(property, currentPath, namingStrategy, mappingObject, problems);
                     }
                 } catch (IllegalAccessException e) {
                     throw new IllegalAccessError(e.getMessage());
@@ -183,9 +179,8 @@ public interface BeanValidationConfigValidator extends ConfigValidator {
                         throw new UndeclaredThrowableException(t2);
                     }
                 }
-            } else if (mapProperty.getValueProperty().isLeaf()) {
-                validatePropertyValue(property, currentPath, namingStrategy, mappingObject, problems);
             }
+            validatePropertyValue(property, currentPath, namingStrategy, mappingObject, problems);
         }
     }
 

--- a/validator/src/test/java/io/smallrye/config/validator/ValidateConfigTest.java
+++ b/validator/src/test/java/io/smallrye/config/validator/ValidateConfigTest.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
@@ -296,7 +298,7 @@ public class ValidateConfigTest {
 
     private static void assertValidationsEqual(List<String> validations, String... expectedProblemMessages) {
         List<String> remainingActual = new ArrayList<>(validations);
-        List<String> remainingExpected = new ArrayList<>(List.of(expectedProblemMessages));
+        List<String> remainingExpected = Stream.of(expectedProblemMessages).collect(Collectors.toList());
         computeListDifference(remainingActual, remainingExpected);
         StringBuilder failureMessage = new StringBuilder();
         addFailureToMessage("The following validation problems are missing:", remainingExpected, failureMessage);

--- a/validator/src/test/java/io/smallrye/config/validator/ValidateConfigTest.java
+++ b/validator/src/test/java/io/smallrye/config/validator/ValidateConfigTest.java
@@ -2,15 +2,18 @@ package io.smallrye.config.validator;
 
 import static io.smallrye.config.validator.KeyValuesConfigSource.config;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +25,8 @@ import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
 
 import org.eclipse.microprofile.config.inject.ConfigProperties;
@@ -42,11 +47,16 @@ public class ValidateConfigTest {
                         "server.host", "localhost",
                         "server.port", "8080",
                         "server.log.days", "20",
+                        "server.log.levels.INFO.importance", "1",
+                        "server.log.levels.INFO.description", "just info",
+                        "server.log.levels.ERROR.importance", "-1",
+                        "server.log.levels.ERROR.description", "serious error",
                         "server.proxy.enable", "true",
                         "server.proxy.timeout", "20",
                         "server.form.login-page", "login.html",
                         "server.form.error-page", "error.html",
                         "server.form.landing-page", "index.html",
+                        "server.form.x", "xyz",
                         "server.cors.origins[0].host", "some-server",
                         "server.cors.origins[0].port", "9000",
                         "server.cors.origins[1].host", "localhost",
@@ -69,22 +79,28 @@ public class ValidateConfigTest {
         for (int i = 0; i < validationException.getProblemCount(); i++) {
             validations.add(validationException.getProblem(i).getMessage());
         }
-        assertEquals(15, validations.size());
-        assertTrue(validations.contains("server.port must be less than or equal to 10"));
-        assertTrue(validations.contains("server.log.days must be less than or equal to 15"));
-        assertTrue(validations.contains("server.proxy.timeout must be less than or equal to 10"));
-        assertTrue(validations.contains("server.cors.origins[0].host size must be between 0 and 10"));
-        assertTrue(validations.contains("server.cors.origins[0].port must be less than or equal to 10"));
-        assertTrue(validations.contains("server.cors.methods[1] size must be between 0 and 3"));
-        assertTrue(validations.contains("server.form.login-page size must be between 0 and 3"));
-        assertTrue(validations.contains("server.form.error-page size must be between 0 and 3"));
-        assertTrue(validations.contains("server.form.landing-page size must be between 0 and 3"));
-        assertTrue(validations.contains("server.info.name size must be between 0 and 3"));
-        assertTrue(validations.contains("server.info.code must be less than or equal to 3"));
-        assertTrue(validations.contains("server.info.alias[0] size must be between 0 and 3"));
-        assertTrue(validations.contains("server.info.admins.root[1].username size must be between 0 and 4"));
-        assertTrue(validations.contains("server.info.firewall.accepted[1] size must be between 8 and 15"));
-        assertTrue(validations.contains("server is not prod"));
+        assertValidationsEqual(validations,
+                "server.port must be less than or equal to 10",
+                "server.log.days must be less than or equal to 15",
+                "server.log.levels all identifiers must have the same length",
+                "server.log.levels.ERROR.importance must be greater than or equal to 0",
+                "server.proxy.timeout must be less than or equal to 10",
+                "server.cors.origins size must be between 3 and 2147483647",
+                "server.cors.origins[0].host size must be between 0 and 10",
+                "server.cors.origins[0].port must be less than or equal to 10",
+                "server.cors.methods[1] size must be between 0 and 3",
+                "server.cors.methods size must be between 3 and 2147483647",
+                "server.form.login-page size must be between 0 and 3",
+                "server.form.error-page size must be between 0 and 3",
+                "server.form.landing-page size must be between 0 and 3",
+                "server.form.x size must be between 2 and 2147483647",
+                "server.info.name size must be between 0 and 3",
+                "server.info.code must be less than or equal to 3",
+                "server.info.alias[0] size must be between 0 and 3",
+                "server.info.admins.root[1].username size must be between 0 and 4",
+                "server.info.admins.root size must be between 0 and 1",
+                "server.info.firewall.accepted[1] size must be between 8 and 15",
+                "server is not prod");
     }
 
     @Test
@@ -145,7 +161,7 @@ public class ValidateConfigTest {
         @Max(10)
         int port();
 
-        Map<String, @Size(max = 3) String> form();
+        Map<@Size(min = 2) String, @Size(max = 3) String> form();
 
         Optional<Proxy> proxy();
 
@@ -165,11 +181,25 @@ public class ValidateConfigTest {
         interface Log {
             @Max(15)
             int days();
+
+            @EqualLengthKeys
+            Map<String, LogLevel> levels();
+
+            interface LogLevel {
+
+                @PositiveOrZero
+                int importance();
+
+                @NotBlank
+                String description();
+            }
         }
 
         interface Cors {
+            @Size(min = 3)
             List<Origin> origins();
 
+            @Size(min = 3)
             List<@Size(max = 3) String> methods();
 
             interface Origin {
@@ -189,7 +219,7 @@ public class ValidateConfigTest {
 
             Optional<List<@Size(max = 3) String>> alias();
 
-            Map<String, List<Admin>> admins();
+            Map<String, @Size(max = 1) List<Admin>> admins();
 
             Map<String, List<@Size(min = 8, max = 15) String>> firewall();
 
@@ -218,6 +248,24 @@ public class ValidateConfigTest {
         }
     }
 
+    @Target({ METHOD, ANNOTATION_TYPE })
+    @Retention(RUNTIME)
+    @Constraint(validatedBy = { EqualLengthKeysValidator.class })
+    public @interface EqualLengthKeys {
+        String message() default "all identifiers must have the same length";
+
+        Class<?>[] groups() default {};
+
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    public static class EqualLengthKeysValidator implements ConstraintValidator<EqualLengthKeys, Map<String, ?>> {
+        @Override
+        public boolean isValid(final Map<String, ?> value, final ConstraintValidatorContext context) {
+            return value.keySet().stream().mapToInt(String::length).distinct().count() <= 1;
+        }
+    }
+
     @ConfigMapping(prefix = "server", namingStrategy = ConfigMapping.NamingStrategy.SNAKE_CASE)
     public interface ServerNamingStrategy {
         String theHost();
@@ -243,6 +291,41 @@ public class ValidateConfigTest {
 
             @Min(8000)
             int port();
+        }
+    }
+
+    private static void assertValidationsEqual(List<String> validations, String... expectedProblemMessages) {
+        List<String> remainingActual = new ArrayList<>(validations);
+        List<String> remainingExpected = new ArrayList<>(List.of(expectedProblemMessages));
+        computeListDifference(remainingActual, remainingExpected);
+        StringBuilder failureMessage = new StringBuilder();
+        addFailureToMessage("The following validation problems are missing:", remainingExpected, failureMessage);
+        addFailureToMessage("The following validation problems were not expected:", remainingActual, failureMessage);
+        if (failureMessage.length() > 0) {
+            fail(failureMessage.toString());
+        }
+    }
+
+    private static void computeListDifference(List<String> remainingActual, List<String> remainingExpected) {
+        // Not using removeAll here as that would erase duplicates, whereas this "Removes the first occurrence [..]"
+        Iterator<String> remainingExpectedIterator = remainingExpected.iterator();
+        while (remainingExpectedIterator.hasNext()) {
+            boolean expectedFound = remainingActual.remove(remainingExpectedIterator.next());
+            if (expectedFound) {
+                remainingExpectedIterator.remove();
+            }
+        }
+    }
+
+    private static void addFailureToMessage(String description, List<String> list, StringBuilder failureMessage) {
+        if (!list.isEmpty()) {
+            failureMessage.append("\n");
+            failureMessage.append(description);
+            for (String element : list) {
+                failureMessage.append("\n  \"");
+                failureMessage.append(element);
+                failureMessage.append("\"");
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, validation does not work properly with maps and collections containing groups.
This PR aims to enable the usage of direct validation on the maps and collections containing the groups.

The original problem I had was similar to the example in the tests:
```java
@EqualLengthKeys
Map<String, LogLevel> levels();
```
but just with the map values instead and can be found here: https://github.com/MaisiKoleni/javadoc-search/pull/6.

My current approach for that is to always validate the property value, but keep the traversal of groups.
It appears that we only need an explicit traversal for groups because the validator already seems to traverse the properties 
recursively as desired.

However, I am not experienced or knowledgeable enough to know if this change breaks anything. It looks like everything is caught now and nothing is validated twice.

I also refactored the tests a bit and added five more validation problems, three of which failed without the change. All the 15 old tests still work, but I am not sure how much of all validation possibilities they cover.

The reason for the custom assertion is that the old approach was not as informative, as it already failed at the size check. The new approach also reduces the danger that the size assertion and the number of individual contains checks deviate.
This is already implemented in test frameworks such as AssertJ, but those are not available here, and thus a custom solution is required for now, unless we can add a test dependency.

Please let me know what you think about the change, I might have missed the reasoning for the old validation logic and would be grateful for any counterexample (I wouldn't want to break someone else's configuration with the change).