### PR TITLE
unwrap config instead of just cast

### DIFF
--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigInjectionBean.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigInjectionBean.java
@@ -106,7 +106,7 @@ public class ConfigInjectionBean<T> implements Bean<T>, PassivationCapable {
             } else {
                 Optional<T> optionalValue = (Optional<T>) getConfig().getOptionalValue(key, annotatedTypeClass);
                 return optionalValue.orElseGet(
-                        () -> (T) ((SmallRyeConfig) getConfig()).convert(defaultValue, annotatedTypeClass));
+                        () -> (T) getConfig().unwrap(SmallRyeConfig.class).convert(defaultValue, annotatedTypeClass));
             }
         }
 

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigMappingInjectionBean.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigMappingInjectionBean.java
@@ -57,7 +57,7 @@ public class ConfigMappingInjectionBean<T> implements Bean<T> {
             }
         }
 
-        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig(getContextClassLoader());
+        SmallRyeConfig config = ConfigProvider.getConfig(getContextClassLoader()).unwrap(SmallRyeConfig.class);
         return config.getConfigMapping(getBeanClass(), prefix);
     }
 

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -408,7 +408,8 @@ public final class ConfigProducerUtil {
          */
         private static <K, V> Map<K, V> getValues(String name, Config config, Converter<K> keyConverter,
                 Converter<V> valueConverter) {
-            return SecretKeys.doUnlocked(() -> config.unwrap(SmallRyeConfig.class).getValuesAsMap(name, keyConverter, valueConverter));
+            return SecretKeys
+                    .doUnlocked(() -> config.unwrap(SmallRyeConfig.class).getValuesAsMap(name, keyConverter, valueConverter));
         }
     }
 }

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -231,7 +231,7 @@ public final class ConfigProducerUtil {
 
     /**
      * Indicates whether the given type is a type of Map or is a Supplier or Optional of Map.
-     * 
+     *
      * @param type the type to check
      * @return {@code true} if the given type is a type of Map or is a Supplier or Optional of Map,
      *         {@code false} otherwise.
@@ -408,7 +408,7 @@ public final class ConfigProducerUtil {
          */
         private static <K, V> Map<K, V> getValues(String name, Config config, Converter<K> keyConverter,
                 Converter<V> valueConverter) {
-            return SecretKeys.doUnlocked(() -> ((SmallRyeConfig) config).getValuesAsMap(name, keyConverter, valueConverter));
+            return SecretKeys.doUnlocked(() -> config.unwrap(SmallRyeConfig.class).getValuesAsMap(name, keyConverter, valueConverter));
         }
     }
 }

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigPropertiesInjectionBean.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigPropertiesInjectionBean.java
@@ -52,7 +52,7 @@ public class ConfigPropertiesInjectionBean<T> implements Bean<T> {
             }
         }
 
-        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig(getContextClassLoader());
+        SmallRyeConfig config = ConfigProvider.getConfig(getContextClassLoader()).unwrap(SmallRyeConfig.class);
         return config.getConfigMapping(getBeanClass(), prefix);
     }
 

--- a/examples/mapping/src/main/java/io/smallrye/config/examples/mapping/ServerMapping.java
+++ b/examples/mapping/src/main/java/io/smallrye/config/examples/mapping/ServerMapping.java
@@ -6,7 +6,7 @@ import io.smallrye.config.SmallRyeConfig;
 
 public class ServerMapping {
     public static Server getServer() {
-        SmallRyeConfig config = (SmallRyeConfig) ConfigProvider.getConfig();
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
         return config.getConfigMapping(Server.class);
     }
 }

--- a/implementation/src/test/java/io/smallrye/config/ConfigSourcePropertySubstitutionTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigSourcePropertySubstitutionTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 class ConfigSourcePropertySubstitutionTest {
     @Test
     void interceptor() {
-        SmallRyeConfig config = (SmallRyeConfig) buildConfig("my.prop", "${prop.replace}", "prop.replace", "1234");
+        SmallRyeConfig config = buildConfig("my.prop", "${prop.replace}", "prop.replace", "1234").unwrap(SmallRyeConfig.class);
 
         final String value = config.getValue("my.prop", String.class);
         Assertions.assertEquals("1234", value);

--- a/implementation/src/test/java/io/smallrye/config/ConfigValuePropertiesConfigSourceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigValuePropertiesConfigSourceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class ConfigValuePropertiesConfigSourceTest {
     @Test
     void interceptor() throws Exception {
-        SmallRyeConfig config = (SmallRyeConfig) buildConfig();
+        SmallRyeConfig config = buildConfig().unwrap(SmallRyeConfig.class);
 
         assertEquals("1", config.getValue("my.prop", String.class));
         assertEquals("20", config.getValue("my.prop.20", String.class));

--- a/implementation/src/test/java/io/smallrye/config/CustomConverterTest.java
+++ b/implementation/src/test/java/io/smallrye/config/CustomConverterTest.java
@@ -40,7 +40,7 @@ class CustomConverterTest {
     @Test
     void explicitConverter() {
         // setup
-        SmallRyeConfig config = (SmallRyeConfig) buildConfig("my.prop", "1234");// sanity check
+        SmallRyeConfig config = buildConfig("my.prop", "1234").unwrap(SmallRyeConfig.class);// sanity check
         final Converter<Integer> customConverter = new Converter<Integer>() {
             public Integer convert(final String value) {
                 return Integer.valueOf(Integer.parseInt(value) * 2);
@@ -109,7 +109,7 @@ class CustomConverterTest {
         assertEquals(uuidUUIDTruth, config.getValue("uuid.shouting", UUID.class), "Uppercase UUID incorrectly converted");
 
         // Check UUIDs work fine in arrays
-        ArrayList<UUID> values = ((SmallRyeConfig) config).getValues("uuid.multiple", UUID.class, ArrayList::new);
+        ArrayList<UUID> values = config.unwrap(SmallRyeConfig.class).getValues("uuid.multiple", UUID.class, ArrayList::new);
         assertEquals(uuidUUIDTruth, values.get(0), "Unexpected list item in UUID config");
         assertEquals(secondUuidUUIDTruth, values.get(1), "Unexpected list item in UUID config");
 

--- a/implementation/src/test/java/io/smallrye/config/MultiValueTest.java
+++ b/implementation/src/test/java/io/smallrye/config/MultiValueTest.java
@@ -24,9 +24,10 @@ class MultiValueTest {
         Properties properties = new Properties();
         properties.put("my.pets", "snake,dog,cat,cat");
 
-        config = (SmallRyeConfig) SmallRyeConfigProviderResolver.instance().getBuilder()
+        config = SmallRyeConfigProviderResolver.instance().getBuilder()
                 .withSources(new PropertiesConfigSource(properties, "my properties"))
-                .build();
+                .build()
+                .unwrap(SmallRyeConfig.class);
     }
 
     @Test


### PR DESCRIPTION
My app uses MicroProfile Config generically, and also uses the SmallRye implementation. My config provider returns a class called `SmallRyeAppSettings` which `implements Config`. I think this is valid according to the MP spec. However, when I try to inject config, I end up with a class cast exception.

```
Caused by: java.lang.ClassCastException: class my.app.SmallRyeAppSettings cannot be cast to class io.smallrye.config.SmallRyeConfig (my.app.SmallRyeAppSettings and io.smallrye.config.SmallRyeConfig are in unnamed module of loader 'app')
```

I traced the error to this specific cast. 

Following the docs from both MP and SmallRye, I think we should use `unwrap` when handling results from `ConfigProvider.getConfig()` rather than casting. I added an instanceof shortcut check here to maintain the previous code path. Probably not necessary. 

Alternatively, should this be using the small rye provider directly? Maybe this?

```
SmallRyeConfigProviderResolver.instance().getConfig(getContextClassLoader());
```
I'm not sure if this will create a circular dependency so I went with the more generic unwrap route first.

I tried to write a test, but to register an override for a `ConfigProvider`, you need to create something `ServiceLoader` can pick up. I couldn't find a nice way to do something for just a single test class that didn't impact all the other test classes.