### PR TITLE
provide a way to release config via classloader

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigProviderResolver.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigProviderResolver.java
@@ -130,6 +130,14 @@ public class SmallRyeConfigProviderResolver extends ConfigProviderResolver {
         }
     }
 
+    public void releaseConfig(ClassLoader classLoader) {
+        final ClassLoader realClassLoader = getRealClassLoader(classLoader);
+        final Map<ClassLoader, Config> configsForClassLoader = this.configsForClassLoader;
+        synchronized (configsForClassLoader) {
+            configsForClassLoader.remove(realClassLoader);
+        }
+    }
+
     static ClassLoader getRealClassLoader(ClassLoader classLoader) {
         if (classLoader == null) {
             classLoader = getContextClassLoader();

--- a/implementation/src/test/java/io/smallrye/config/ConfigReleaseTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigReleaseTest.java
@@ -1,0 +1,75 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.KeyValuesConfigSource.config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.NoSuchElementException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConfigReleaseTest {
+
+    private static final Config CONFIG = new SmallRyeConfigBuilder()
+            .withSources(config("server.host", "localhost", "server.port", "8080"))
+            .build();
+
+    private static final ClassLoader THREAD_LOADER = Thread.currentThread().getContextClassLoader();
+    private static final ClassLoader PARENT_LOADER = Thread.currentThread().getContextClassLoader().getParent();
+
+    @BeforeEach
+    void beforeEach() {
+        ConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig(THREAD_LOADER));
+        ConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig(PARENT_LOADER));
+        ConfigProviderResolver.instance().registerConfig(CONFIG, THREAD_LOADER);
+        ConfigProviderResolver.instance().registerConfig(CONFIG, PARENT_LOADER);
+    }
+
+    @Test
+    void releaseWithoutClassloader() {
+        Config fromThreadLoader = ConfigProvider.getConfig(THREAD_LOADER);
+        Config fromPlatformLoader = ConfigProvider.getConfig(PARENT_LOADER);
+
+        assertEquals("localhost", fromThreadLoader.getValue("server.host", String.class));
+        assertEquals("localhost", fromPlatformLoader.getValue("server.host", String.class));
+
+        // this demonstrates the problems highlighted in these issues:
+        // https://github.com/eclipse/microprofile-config/issues/136#issuecomment-535962313
+        // https://github.com/eclipse/microprofile-config/issues/471
+        // When we call release with one of the two class loaders, but they will both be released meaning
+        // the current class loader is removing config from another classloader unexpectedly
+        ConfigProviderResolver.instance().releaseConfig(fromThreadLoader);
+
+        final Config fromThreadLoader2 = ConfigProvider.getConfig(THREAD_LOADER);
+        final Config fromPlatformLoader2 = ConfigProvider.getConfig(PARENT_LOADER);
+
+        assertThrows(NoSuchElementException.class, () -> fromThreadLoader2.getValue("server.host", String.class));
+        assertThrows(NoSuchElementException.class, () -> fromPlatformLoader2.getValue("server.host", String.class));
+    }
+
+    @Test
+    void releaseWithClassLoader() {
+        Config fromThreadLoader = ConfigProvider.getConfig(THREAD_LOADER);
+        Config fromPlatformLoader = ConfigProvider.getConfig(PARENT_LOADER);
+
+        assertEquals("localhost", fromThreadLoader.getValue("server.host", String.class));
+        assertEquals("localhost", fromPlatformLoader.getValue("server.host", String.class));
+
+        // this demonstrates a solution to the problems highlighted in these issues:
+        // https://github.com/eclipse/microprofile-config/issues/136#issuecomment-535962313
+        // https://github.com/eclipse/microprofile-config/issues/471
+        // We can explicitly release the config by class loader, leaving other class loaders untouched
+        ((SmallRyeConfigProviderResolver) ConfigProviderResolver.instance()).releaseConfig(
+                THREAD_LOADER);
+
+        final Config fromThreadLoader2 = ConfigProvider.getConfig(THREAD_LOADER);
+        final Config fromPlatformLoader2 = ConfigProvider.getConfig(PARENT_LOADER);
+
+        assertThrows(NoSuchElementException.class, () -> fromThreadLoader2.getValue("server.host", String.class));
+        assertEquals("localhost", fromPlatformLoader2.getValue("server.host", String.class));
+    }
+}


### PR DESCRIPTION
I ran into problems with config already being registered, presumably due to races related to configs and class loaders. 

Basically, my app has a function like this

(Note: these are just simplified snippets of the code that I think are relevant here)

```java
  private static AppSettings register(SmallRyeAppSettings settings) {
    ConfigProviderResolver.instance().releaseConfig(ConfigProvider.getConfig());
    ConfigProviderResolver.instance().registerConfig(settings, Thread.currentThread()
        .getContextClassLoader());
    return settings;
  }
```

Sometimes I'll get an `IllegalStateException` saying the config is already registered. Even if I update the function to fetch config with the class loader, it doesn't always fix it. 

After doing some looking I noticed a few TODO comments that pointed to seemingly related issues. Most specifically, I think this is the root of the problem: https://github.com/eclipse/microprofile-config/issues/471

It should be reasonable to release some config and then be able to re-register it in a reliable fashion. As pointed out by that issue, you cannot. Registration is done with a given class loader, but releasing is not. The class loader is the key in the underlying map, but release does not use it. Instead, release iterates all the configs and removes any that are the same instance (not even just equivalent to), regardless of class loader. I know that is basically what the spec says, which is what brought me here. 

Does it seem reasonable to add a new public function within smallrye that allows a consumer to release config for a given class loader? To reuse my previous helper function, I think it would be useful to update it to something like this: 

```java
  private static AppSettings register(SmallRyeAppSettings settings) {
    ClassLoader cl = Thread.currentThread().getContextClassLoader();
    ConfigProviderResolver cpr = ConfigProviderResolver.instance();

    if (cpr instanceof SmallRyeConfigProviderResolver) {
      ((SmallRyeConfigProviderResolver) cpr).releaseConfig(settings, cl);
    }
    cpr.releaseConfig(ConfigProvider.getConfig());
    cpr.registerConfig(settings, cl);

    return settings;
  }
```