### PR TITLE
Ignore Properties that cannot be represented by a String

### DIFF
--- a/common/src/main/java/io/smallrye/config/common/utils/ConfigSourceUtil.java
+++ b/common/src/main/java/io/smallrye/config/common/utils/ConfigSourceUtil.java
@@ -53,8 +53,22 @@ public class ConfigSourceUtil {
     public static Map<String, String> propertiesToMap(Properties properties) {
         Map<String, String> map = new HashMap<>();
         synchronized (properties) {
-            for (Map.Entry<Object, Object> e : properties.entrySet()) {
-                map.put(String.valueOf(e.getKey()), String.valueOf(e.getValue()));
+            for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+                String key;
+                try {
+                    key = String.valueOf(entry.getKey());
+                } catch (Exception e) {
+                    continue;
+                }
+
+                String value;
+                try {
+                    value = String.valueOf(entry.getValue());
+                } catch (Exception e) {
+                    continue;
+                }
+
+                map.put(key, value);
             }
         }
         return map;

--- a/common/src/test/java/io/smallrye/config/common/utils/ConfigSourceUtilTest.java
+++ b/common/src/test/java/io/smallrye/config/common/utils/ConfigSourceUtilTest.java
@@ -16,6 +16,7 @@
 package io.smallrye.config.common.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Properties;
@@ -34,5 +35,21 @@ class ConfigSourceUtilTest {
         assertEquals("my.value1", map.get("my.key1"));
         assertEquals("my.value2", map.get("my.key2"));
         assertEquals("2", map.get("my.key3"));
+    }
+
+    @Test
+    void unableToConvertToString() {
+        Properties properties = new Properties();
+        properties.put("foo.bar", new UnconvertableString());
+
+        Map<String, String> map = ConfigSourceUtil.propertiesToMap(properties);
+        assertTrue(map.isEmpty());
+    }
+
+    private static class UnconvertableString {
+        @Override
+        public String toString() {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
- Fixes #879

I think we need to keep globally converting Properties to their String format if possible. If such conversion is not possible, we just ignore the property.