### PR TITLE
Add way to clone a ConfigValue via the corresponding builder

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigValue.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigValue.java
@@ -180,7 +180,7 @@ public class ConfigValue implements org.eclipse.microprofile.config.ConfigValue 
                 '}';
     }
 
-    ConfigValueBuilder from() {
+    public ConfigValueBuilder from() {
         return new ConfigValueBuilder()
                 .withName(name)
                 .withValue(value)

--- a/implementation/src/test/java/io/smallrye/config/ConfigValueTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigValueTest.java
@@ -44,6 +44,19 @@ class ConfigValueTest {
         assertEquals(o2, o1);
     }
 
+    @Test
+    void configValueCloning() {
+        ConfigValue o1 = io.smallrye.config.ConfigValue.builder().withName("my.prop").build();
+        ConfigValue o2 = ((io.smallrye.config.ConfigValue) o1).from().build();
+        assertEquals(o2, o1);
+
+        o1 = io.smallrye.config.ConfigValue.builder().withName("my.prop").withValue("value").build();
+        o2 = ((io.smallrye.config.ConfigValue) o1).from().withName("my.prop.cloned").build();
+        assertNotEquals(o2, o1);
+        assertEquals("my.prop.cloned", o2.getName());
+        assertEquals(o1.getValue(), o2.getValue());
+    }
+
     public static class ConfigValueConfigSource implements ConfigSource {
         private final Map<String, String> properties;
 


### PR DESCRIPTION
This PR fixes #902.
It allows to easily cloning a `ConfigValue` instance by starting from its own builder.
It also adds a corresponding unit test.