### PR TITLE
Use the correct annotation name in the error message

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -935,7 +935,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
         WithName annotation = element.getAnnotation(WithName.class);
         if (annotation != null) {
             if (useParent) {
-                throw new IllegalArgumentException("Cannot specify both @ParentConfigName and @ConfigName");
+                throw new IllegalArgumentException("Cannot specify both @WithParentName and @WithName in '" + element + "'");
             }
             String name = annotation.value();
             if (!name.isEmpty()) {


### PR DESCRIPTION
- Also display the offending annotated element