### PR TITLE
Introduce `smallrye-config-api` module 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-parent</artifactId>
+        <version>3.3.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smallrye-config-api</artifactId>
+    <name>SmallRye Config: API</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/api/src/main/java/io/smallrye/config/api/Config.java
+++ b/api/src/main/java/io/smallrye/config/api/Config.java
@@ -1,0 +1,6 @@
+package io.smallrye.config.api;
+
+import java.io.Serializable;
+
+public interface Config extends org.eclipse.microprofile.config.Config, Serializable {
+}

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -29,8 +29,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntFunction;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
@@ -45,11 +44,12 @@ import org.eclipse.microprofile.config.spi.Converter;
 
 import io.smallrye.common.annotation.Experimental;
 import io.smallrye.config.SmallRyeConfigBuilder.InterceptorWithPriority;
+import io.smallrye.config.api.Config;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
-public class SmallRyeConfig implements Config, Serializable {
+public class SmallRyeConfig implements Config {
     public static final String SMALLRYE_CONFIG_PROFILE = "smallrye.config.profile";
     public static final String SMALLRYE_CONFIG_PROFILE_PARENT = "smallrye.config.profile.parent";
     public static final String SMALLRYE_CONFIG_LOCATIONS = "smallrye.config.locations";
@@ -222,7 +222,8 @@ public class SmallRyeConfig implements Config, Serializable {
 
     /**
      *
-     * This method handles calls from both {@link Config#getValue} and {@link Config#getOptionalValue}.<br>
+     * This method handles calls from both {@link org.eclipse.microprofile.config.Config#getValue} and
+     * {@link org.eclipse.microprofile.config.Config#getOptionalValue}.<br>
      */
     @SuppressWarnings("unchecked")
     public <T> T getValue(String name, Converter<T> converter) {
@@ -524,7 +525,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     @Override
     public <T> T unwrap(final Class<T> type) {
-        if (Config.class.isAssignableFrom(type)) {
+        if (org.eclipse.microprofile.config.Config.class.isAssignableFrom(type)) {
             return type.cast(this);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
   </scm>
 
   <modules>
+    <module>api</module>
     <module>common</module>
     <module>implementation</module>
     <module>cdi</module>
@@ -123,6 +124,11 @@
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-api</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
I went ahead with @dmlloyd's suggestion in https://github.com/smallrye/smallrye-config/issues/981#issuecomment-1702760542 and created the `Config` interface. 

This avoids breaking existing code.

/cc @radcortez @dmlloyd 