### PR TITLE
Half-recursive getProperties

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -773,7 +773,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
             array[ti] = p;
             return array;
         }
-        return NO_PROPERTIES;
+        return ti > 0 ? new Property[ti] : NO_PROPERTIES;
     }
 
     private static Property getPropertyDef(Method method, AnnotatedType type) {


### PR DESCRIPTION
Startup measurement shows that the recursive nature of this method won't be handled nicely by the JIT interpreter: this change save recursion to happen unless more than a single property is found