### PR TITLE
fix: escapes $$ prior to escaping \$

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java
@@ -98,14 +98,18 @@ public class ExpressionConfigSourceInterceptor implements ConfigSourceIntercepto
      * dollar.
      */
     private String escapeDollarIfExists(final String value) {
-        int index = value.indexOf("\\$");
+        return escapeIfExists(escapeIfExists(value, "$$", "$$$$"), "\\$", "$$");
+    }
+
+    private String escapeIfExists(final String value, final String toEscape, final String escaped) {
+        int index = value.indexOf(toEscape);
         if (index != -1) {
             int start = 0;
             StringBuilder builder = new StringBuilder();
             while (index != -1) {
-                builder.append(value, start, index).append("$$");
-                start = index + 2;
-                index = value.indexOf("\\$", start);
+                builder.append(value, start, index).append(escaped);
+                start = index + toEscape.length();
+                index = value.indexOf(toEscape, start);
             }
             builder.append(value.substring(start));
             return builder.toString();

--- a/implementation/src/test/java/io/smallrye/config/ExpressionConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ExpressionConfigSourceInterceptorTest.java
@@ -119,10 +119,10 @@ class ExpressionConfigSourceInterceptorTest {
 
     @Test
     void escape() {
-        assertEquals("${my.prop}", buildConfig("expression", "$${my.prop}").getRawValue("expression"));
+        assertEquals("$${my.prop}", buildConfig("expression", "$${my.prop}").getRawValue("expression"));
         assertEquals("${my.prop}", buildConfig("expression", "\\${my.prop}").getRawValue("expression"));
 
-        assertEquals("file:target/prices/?fileName=${date:now:yyyyMMddssSS}.txt&charset=utf-8",
+        assertEquals("file:target/prices/?fileName=$${date:now:yyyyMMddssSS}.txt&charset=utf-8",
                 buildConfig("camel.expression",
                         "file:target/prices/?fileName=$${date:now:yyyyMMddssSS}.txt&charset=utf-8")
                         .getRawValue("camel.expression"));


### PR DESCRIPTION
This seems to be the most consistent handling for $ escaping - escape existing instances of $$ before replacing \$ with $$.  This is not of course completely compatible with the existing handling.

closes: #1056