### PR TITLE
Generate all mappings binding code

### DIFF
--- a/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
+++ b/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
@@ -268,7 +268,7 @@ public class StringUtil {
             throw new StringIndexOutOfBoundsException("begin " + begin + ", end " + end + ", length " + name.length());
         }
 
-        if (name.length() < 2) {
+        if (name.length() < 2 || name.length() <= begin) {
             return name;
         }
 
@@ -277,6 +277,16 @@ public class StringUtil {
         } else {
             return name.substring(begin, end);
         }
+    }
+
+    public static int index(final String name) {
+        if (name.charAt(name.length() - 1) == ']') {
+            int start = name.lastIndexOf('[');
+            if (start != -1 && isNumeric(name, start + 1, name.length() - 1)) {
+                return Integer.parseInt(name.substring(start + 1, name.length() - 1));
+            }
+        }
+        throw new IllegalArgumentException();
     }
 
     public static String unindexed(final String name) {
@@ -294,16 +304,30 @@ public class StringUtil {
         return name;
     }
 
+    public static boolean isIndexed(final String name) {
+        if (name.length() < 3) {
+            return false;
+        }
+
+        if (name.charAt(name.length() - 1) == ']') {
+            int begin = name.lastIndexOf('[');
+            return begin != -1 && isNumeric(name, begin + 1, name.length() - 1);
+        }
+
+        return false;
+    }
+
     public static String skewer(String camelHumps) {
         return skewer(camelHumps, '-');
     }
 
     public static String skewer(String camelHumps, char separator) {
+        if (camelHumps.isEmpty()) {
+            return camelHumps;
+        }
+
         int end = camelHumps.length();
         StringBuilder b = new StringBuilder();
-        if (camelHumps.isEmpty()) {
-            throw new IllegalArgumentException("Method seems to have an empty name");
-        }
 
         for (int i = 0; i < end; i++) {
             char c = camelHumps.charAt(i);
@@ -334,6 +358,8 @@ public class StringUtil {
                 }
                 i = j;
             } else if (Character.isDigit(c)) {
+                b.append(c);
+            } else if (c == '.' || c == '*' || c == '[' || c == ']') {
                 b.append(c);
             } else {
                 if (i > 0) {

--- a/common/src/test/java/io/smallrye/config/common/utils/StringUtilTest.java
+++ b/common/src/test/java/io/smallrye/config/common/utils/StringUtilTest.java
@@ -17,7 +17,6 @@ package io.smallrye.config.common.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -100,8 +99,8 @@ class StringUtilTest {
     void skewer() {
         assertEquals("sigusr1", StringUtil.skewer("sigusr1"));
 
-        assertThrows(IllegalArgumentException.class, () -> StringUtil.skewer(""));
-        assertThrows(IllegalArgumentException.class, () -> StringUtil.skewer("", '.'));
+        assertEquals("", StringUtil.skewer(""));
+        assertEquals(".", StringUtil.skewer("."));
 
         assertEquals("my-property", StringUtil.skewer("myProperty"));
         assertEquals("my.property", StringUtil.skewer("myProperty", '.'));
@@ -138,6 +137,11 @@ class StringUtilTest {
         assertEquals("trend-breaker", StringUtil.skewer("TrendBreaker"));
         assertEquals("making-life-difficult", StringUtil.skewer("MAKING_LifeDifficult"));
         assertEquals("making-life-difficult", StringUtil.skewer("makingLifeDifficult"));
+
+        assertEquals("foo.bar", StringUtil.skewer("foo.bar"));
+        assertEquals("foo.bar-baz", StringUtil.skewer("foo.barBaz"));
+        assertEquals("foo.bar-baz[0]", StringUtil.skewer("foo.barBaz[0]"));
+        assertEquals("foo.bar-baz[*]", StringUtil.skewer("foo.barBaz[*]"));
     }
 
     @Test
@@ -186,8 +190,14 @@ class StringUtilTest {
         assertEquals("", StringUtil.unquoted("\"\""));
         assertEquals("a", StringUtil.unquoted("a"));
         assertEquals("unquoted", StringUtil.unquoted("\"unquoted\""));
+        assertEquals("my.\"unquoted\"", StringUtil.unquoted("my.\"unquoted\""));
         assertEquals("unquoted", StringUtil.unquoted("my.\"unquoted\"", 3, 13));
         assertEquals("unquoted", StringUtil.unquoted("my.unquoted", 3, 11));
+    }
+
+    @Test
+    void index() {
+        assertEquals(0, StringUtil.index("foo[0]"));
     }
 
     @Test

--- a/implementation/src/main/java/io/smallrye/config/ConfigMapping.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMapping.java
@@ -8,6 +8,9 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Function;
+
+import io.smallrye.config.common.utils.StringUtil;
 
 /**
  * This annotation may be placed in interfaces to group configuration properties with a common prefix.
@@ -50,14 +53,28 @@ public @interface ConfigMapping {
         /**
          * The method name is used as is to map the configuration property.
          */
-        VERBATIM,
+        VERBATIM(name -> name),
         /**
          * The method name is derived by replacing case changes with a dash to map the configuration property.
          */
-        KEBAB_CASE,
+        KEBAB_CASE(name -> {
+            return StringUtil.skewer(name, '-');
+        }),
         /**
          * The method name is derived by replacing case changes with an underscore to map the configuration property.
          */
-        SNAKE_CASE
+        SNAKE_CASE(name -> {
+            return StringUtil.skewer(name, '_');
+        });
+
+        private final Function<String, String> function;
+
+        private NamingStrategy(Function<String, String> function) {
+            this.function = function;
+        }
+
+        public String apply(final String name) {
+            return function.apply(name);
+        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -1,78 +1,91 @@
 package io.smallrye.config;
 
 import static io.smallrye.config.ConfigValidationException.Problem;
-import static io.smallrye.config.common.utils.StringUtil.replaceNonAlphanumericByUnderscores;
+import static io.smallrye.config.common.utils.StringUtil.unindexed;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.spi.Converter;
 
-import io.smallrye.config.ConfigMappingInterface.NamingStrategy;
+import io.smallrye.config.ConfigMapping.NamingStrategy;
 import io.smallrye.config._private.ConfigMessages;
-import io.smallrye.config.common.utils.StringUtil;
 
 /**
  * A mapping context. This is used by generated classes during configuration mapping, and is released once the configuration
  * mapping has completed.
  */
 public final class ConfigMappingContext {
-    private final Map<Class<?>, Map<String, Map<Object, Object>>> enclosedThings = new IdentityHashMap<>();
+    private final SmallRyeConfig config;
     private final Map<Class<?>, Map<String, ConfigMappingObject>> roots = new IdentityHashMap<>();
     private final Map<Class<?>, Converter<?>> converterInstances = new IdentityHashMap<>();
-    private final List<ConfigMappingObject> allInstances = new ArrayList<>();
-    private final SmallRyeConfig config;
+
+    private NamingStrategy namingStrategy;
     private final StringBuilder stringBuilder = new StringBuilder();
-    private final Set<String> unknownProperties = new HashSet<>();
+    private final Set<String> usedProperties = new HashSet<>();
     private final List<Problem> problems = new ArrayList<>();
-    private NamingStrategy namingStrategy = new ConfigMappingInterface.KebabNamingStrategy();
 
-    ConfigMappingContext(final SmallRyeConfig config) {
+    private final ConfigMappingNames names;
+
+    public ConfigMappingContext(
+            final SmallRyeConfig config,
+            final Map<String, List<Class<?>>> roots,
+            final Map<String, Map<String, Set<String>>> names) {
+
         this.config = config;
+        this.names = new ConfigMappingNames(names);
+
+        for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
+            String path = entry.getKey();
+            for (Class<?> root : entry.getValue()) {
+                registerRoot(root, path);
+            }
+        }
     }
 
-    public ConfigMappingObject getRoot(Class<?> rootType, String rootPath) {
-        return roots.getOrDefault(rootType, Collections.emptyMap()).get(rootPath);
-    }
-
-    public void registerRoot(Class<?> rootType, String rootPath, ConfigMappingObject root) {
-        roots.computeIfAbsent(rootType, x -> new HashMap<>()).put(rootPath, root);
-    }
-
-    public Object getEnclosedField(Class<?> enclosingType, String key, Object enclosingObject) {
-        return enclosedThings
-                .getOrDefault(enclosingType, Collections.emptyMap())
-                .getOrDefault(key, Collections.emptyMap())
-                .get(enclosingObject);
-    }
-
-    public void registerEnclosedField(Class<?> enclosingType, String key, Object enclosingObject, Object value) {
-        enclosedThings
-                .computeIfAbsent(enclosingType, x -> new HashMap<>())
-                .computeIfAbsent(key, x -> new IdentityHashMap<>())
-                .put(enclosingObject, value);
+    private void registerRoot(Class<?> rootType, String rootPath) {
+        roots.computeIfAbsent(rootType, new Function<Class<?>, Map<String, ConfigMappingObject>>() {
+            @Override
+            public Map<String, ConfigMappingObject> apply(final Class<?> mapping) {
+                return new HashMap<>();
+            }
+        }).computeIfAbsent(rootPath, new Function<String, ConfigMappingObject>() {
+            @Override
+            public ConfigMappingObject apply(final String path) {
+                namingStrategy = null;
+                stringBuilder.replace(0, stringBuilder.length(), rootPath);
+                return (ConfigMappingObject) constructRoot(rootType);
+            }
+        });
     }
 
     public <T> T constructRoot(Class<T> interfaceType) {
-        this.namingStrategy = ConfigMappingInterface.getConfigurationInterface(interfaceType).getNamingStrategy();
         return constructGroup(interfaceType);
     }
 
     public <T> T constructGroup(Class<T> interfaceType) {
-        final T mappingObject = ConfigMappingLoader.configMappingObject(interfaceType, this);
-        allInstances.add((ConfigMappingObject) mappingObject);
+        NamingStrategy namingStrategy = this.namingStrategy;
+        T mappingObject = ConfigMappingLoader.configMappingObject(interfaceType, this);
+        this.namingStrategy = applyNamingStrategy(namingStrategy);
         return mappingObject;
+    }
+
+    @SuppressWarnings("unused")
+    public <T> ObjectCreator<T> constructObject(String path) {
+        return new ObjectCreator<>(path);
     }
 
     @SuppressWarnings("unchecked")
@@ -98,79 +111,20 @@ public final class ConfigMappingContext {
         });
     }
 
-    void applyNamingStrategy(final NamingStrategy namingStrategy) {
-        if (!namingStrategy.isDefault()) {
+    public NamingStrategy applyNamingStrategy(NamingStrategy namingStrategy) {
+        if (namingStrategy != null) {
             this.namingStrategy = namingStrategy;
+        } else if (this.namingStrategy == null) {
+            this.namingStrategy = NamingStrategy.KEBAB_CASE;
         }
-    }
-
-    public String applyNamingStrategy(final String name) {
-        return namingStrategy.apply(name);
-    }
-
-    public static <K, V> Map<K, V> createMapWithDefault(final V defaultValue) {
-        return new MapWithDefault<>(defaultValue);
-    }
-
-    public static IntFunction<Collection<?>> createCollectionFactory(final Class<?> type) {
-        if (type == List.class) {
-            return ArrayList::new;
-        }
-
-        if (type == Set.class) {
-            return HashSet::new;
-        }
-
-        throw new IllegalArgumentException();
-    }
-
-    public NoSuchElementException noSuchElement(Class<?> type) {
-        return new NoSuchElementException("A required configuration group of type " + type.getName() + " was not provided");
-    }
-
-    void unknownProperty(final String unknownProperty) {
-        unknownProperties.add(unknownProperty);
-    }
-
-    void reportUnknown() {
-        // an unknown property may still be used if it was coming from the EnvSource
-        for (String unknownProperty : unknownProperties) {
-            boolean found = false;
-            String unknownEnvProperty = replaceNonAlphanumericByUnderscores(unknownProperty);
-            for (String userProperty : config.getPropertyNames()) {
-                if (unknownProperty.equals(userProperty)) {
-                    continue;
-                }
-
-                // Match another property with the same semantic meaning
-                if (StringUtil.equalsIgnoreCaseReplacingNonAlphanumericByUnderscores(unknownEnvProperty, userProperty)) {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
-                ConfigValue configValue = config.getConfigValue(unknownProperty);
-                problems.add(new Problem(
-                        ConfigMessages.msg.propertyDoesNotMapToAnyRoot(unknownProperty, configValue.getLocation())));
-            }
-        }
-    }
-
-    void fillInOptionals() {
-        for (ConfigMappingObject instance : allInstances) {
-            instance.fillInOptionals(this);
-        }
-    }
-
-    public SmallRyeConfig getConfig() {
-        return config;
+        return this.namingStrategy;
     }
 
     public StringBuilder getStringBuilder() {
         return stringBuilder;
     }
 
+    @SuppressWarnings("unused")
     public void reportProblem(RuntimeException problem) {
         problems.add(new Problem(problem.toString()));
     }
@@ -181,6 +135,527 @@ public final class ConfigMappingContext {
 
     Map<Class<?>, Map<String, ConfigMappingObject>> getRootsMap() {
         return roots;
+    }
+
+    void reportUnknown(final List<String[]> ignoredPaths) {
+        KeyMap<Boolean> ignoredProperties = new KeyMap<>();
+        for (String[] ignoredPath : ignoredPaths) {
+            int len = ignoredPath.length;
+            KeyMap<Boolean> found;
+            if (ignoredPath[len - 1].equals("**")) {
+                found = ignoredProperties.findOrAdd(ignoredPath, 0, len - 1);
+                found.putRootValue(Boolean.TRUE);
+                ignoreRecursively(found);
+            } else {
+                found = ignoredProperties.findOrAdd(ignoredPath);
+                found.putRootValue(Boolean.TRUE);
+            }
+        }
+
+        Set<String> roots = new HashSet<>();
+        for (Map<String, ConfigMappingObject> value : this.roots.values()) {
+            roots.addAll(value.keySet());
+        }
+
+        for (String name : filterPropertiesInRoots(config.getPropertyNames(), roots)) {
+            if (usedProperties.contains(name)) {
+                continue;
+            }
+
+            if (!ignoredProperties.hasRootValue(name)) {
+                ConfigValue configValue = config.getConfigValue(name);
+                problems.add(new Problem(
+                        ConfigMessages.msg.propertyDoesNotMapToAnyRoot(name, configValue.getLocation())));
+            }
+        }
+    }
+
+    private static void ignoreRecursively(KeyMap<Boolean> root) {
+        if (root.getRootValue() == null) {
+            root.putRootValue(Boolean.TRUE);
+        }
+
+        if (root.getAny() == null) {
+            //noinspection CollectionAddedToSelf
+            root.putAny(root);
+        } else {
+            var any = root.getAny();
+            if (root != any) {
+                ignoreRecursively(any);
+            }
+        }
+
+        for (var value : root.values()) {
+            ignoreRecursively(value);
+        }
+    }
+
+    /**
+     * Filters the full list of properties names in Config to only the property names that can match any of the
+     * prefixes (namespaces) registered in mappings.
+     *
+     * @param properties the available property names in Config.
+     * @param roots the registered mapping roots.
+     *
+     * @return the property names that match to at least one root.
+     */
+    private static Iterable<String> filterPropertiesInRoots(final Iterable<String> properties, final Set<String> roots) {
+        if (roots.isEmpty()) {
+            return properties;
+        }
+
+        // Will match everything, so no point in filtering
+        if (roots.contains("")) {
+            return properties;
+        }
+
+        List<String> matchedProperties = new ArrayList<>();
+        for (String property : properties) {
+            for (String root : roots) {
+                if (isPropertyInRoot(property, root)) {
+                    matchedProperties.add(property);
+                    break;
+                }
+            }
+        }
+        return matchedProperties;
+    }
+
+    private static boolean isPropertyInRoot(final String property, final String root) {
+        if (property.equals(root)) {
+            return true;
+        }
+
+        // if property is less than the root no way to match
+        if (property.length() <= root.length()) {
+            return false;
+        }
+
+        // foo.bar
+        // foo.bar."baz"
+        // foo.bar[0]
+        char c = property.charAt(root.length());
+        if ((c == '.') || c == '[') {
+            return property.startsWith(root);
+        }
+
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    public class ObjectCreator<T> {
+        private T root;
+        private List<Consumer<Function<String, Object>>> creators;
+
+        public ObjectCreator(final String path) {
+            this.creators = List.of(new Consumer<Function<String, Object>>() {
+                @Override
+                public void accept(Function<String, Object> get) {
+                    root = (T) get.apply(path);
+                }
+            });
+        }
+
+        public <K> ObjectCreator<T> map(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith) {
+            return map(keyRawType, keyConvertWith, null);
+        }
+
+        public <K> ObjectCreator<T> map(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith,
+                final String unnamedKey) {
+            return map(keyRawType, keyConvertWith, unnamedKey, (Class<?>) null);
+        }
+
+        public <K, V> ObjectCreator<T> map(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith,
+                final String unnamedKey,
+                final Class<V> defaultClass) {
+
+            Supplier<V> supplier = null;
+            if (defaultClass != null) {
+                supplier = new Supplier<V>() {
+                    @Override
+                    public V get() {
+                        int length = stringBuilder.length();
+                        stringBuilder.append(".*");
+                        V defaultValue = constructGroup(defaultClass);
+                        stringBuilder.setLength(length);
+                        return defaultValue;
+                    }
+                };
+            }
+
+            return map(keyRawType, keyConvertWith, unnamedKey, supplier);
+        }
+
+        public <K, V> ObjectCreator<T> map(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith,
+                final String unnamedKey,
+                final Supplier<V> defaultValue) {
+            Converter<K> keyConverter = keyConvertWith == null ? config.requireConverter(keyRawType)
+                    : getConverterInstance(keyConvertWith);
+            List<Consumer<Function<String, Object>>> nestedCreators = new ArrayList<>();
+            for (Consumer<Function<String, Object>> creator : this.creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public Object apply(final String path) {
+                        Map<String, String> mapKeys = getMapKeys(path.length() > 0 && path.charAt(path.length() - 1) == '.'
+                                ? path.substring(0, path.length() - 1)
+                                : path);
+                        Map<K, V> map = defaultValue != null ? new MapWithDefault<>(defaultValue.get())
+                                : new HashMap<>(mapKeys.size());
+                        for (Map.Entry<String, String> entry : mapKeys.entrySet()) {
+                            nestedCreators.add(new Consumer<>() {
+                                @Override
+                                public void accept(Function<String, Object> get) {
+                                    V value = (V) get.apply(entry.getValue());
+                                    if (value != null) {
+                                        map.putIfAbsent(keyConverter.convert(entry.getKey()), value);
+                                    }
+                                }
+                            });
+                        }
+
+                        if (unnamedKey != null) {
+                            nestedCreators.add(new Consumer<>() {
+                                @Override
+                                public void accept(Function<String, Object> get) {
+                                    V value = (V) get.apply(path);
+                                    if (value != null) {
+                                        map.putIfAbsent(unnamedKey.equals("") ? null : keyConverter.convert(unnamedKey), value);
+                                    }
+                                }
+                            });
+                        }
+
+                        return map;
+                    }
+                });
+            }
+            this.creators = nestedCreators;
+            return this;
+        }
+
+        public <V, C extends Collection<V>> ObjectCreator<T> collection(
+                final Class<C> collectionRawType) {
+            List<Consumer<Function<String, Object>>> nestedCreators = new ArrayList<>();
+            IntFunction<Collection<?>> collectionFactory = createCollectionFactory(collectionRawType);
+            for (Consumer<Function<String, Object>> creator : this.creators) {
+                Collection<V> collection = (Collection<V>) collectionFactory.apply(0);
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public Object apply(final String path) {
+                        // This is ordered, so it shouldn't require a set by index
+                        for (Integer index : config.getIndexedPropertiesIndexes(path)) {
+                            nestedCreators.add(new Consumer<Function<String, Object>>() {
+                                @Override
+                                public void accept(final Function<String, Object> get) {
+                                    collection.add((V) get.apply(path + "[" + index + "]"));
+                                }
+                            });
+                        }
+                        return collection;
+                    }
+                });
+            }
+            this.creators = nestedCreators;
+            return this;
+        }
+
+        public <V, C extends Collection<V>> ObjectCreator<T> optionalCollection(
+                final Class<C> collectionRawType) {
+            List<Consumer<Function<String, Object>>> nestedCreators = new ArrayList<>();
+            IntFunction<Collection<?>> collectionFactory = createCollectionFactory(collectionRawType);
+            for (Consumer<Function<String, Object>> creator : this.creators) {
+                Collection<V> collection = (Collection<V>) collectionFactory.apply(0);
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public Object apply(final String path) {
+                        // This is ordered, so it shouldn't require a set by index
+                        List<Integer> indexes = config.getIndexedPropertiesIndexes(path);
+                        for (Integer index : indexes) {
+                            nestedCreators.add(new Consumer<Function<String, Object>>() {
+                                @Override
+                                public void accept(final Function<String, Object> get) {
+                                    collection.add((V) get.apply(path + "[" + index + "]"));
+                                }
+                            });
+                        }
+                        return indexes.isEmpty() ? Optional.empty() : Optional.of(collection);
+                    }
+                });
+            }
+            this.creators = nestedCreators;
+            return this;
+        }
+
+        public <G> ObjectCreator<T> group(final Class<G> groupType) {
+            for (Consumer<Function<String, Object>> creator : this.creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public G apply(final String path) {
+                        StringBuilder sb = ConfigMappingContext.this.getStringBuilder();
+                        int length = sb.length();
+                        sb.append(path, length, path.length());
+                        G group = constructGroup(groupType);
+                        sb.setLength(length);
+                        return group;
+                    }
+                });
+            }
+            return this;
+        }
+
+        public <G> ObjectCreator<T> lazyGroup(final Class<G> groupType) {
+            for (Consumer<Function<String, Object>> creator : this.creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public G apply(final String path) {
+                        if (createRequired(groupType, path)) {
+                            StringBuilder sb = ConfigMappingContext.this.getStringBuilder();
+                            int length = sb.length();
+                            sb.append(path, length, path.length());
+                            G group = constructGroup(groupType);
+                            sb.setLength(length);
+                            return group;
+                        } else {
+                            return null;
+                        }
+                    }
+                });
+            }
+            return this;
+        }
+
+        public <G> ObjectCreator<T> optionalGroup(final Class<G> groupType) {
+            for (Consumer<Function<String, Object>> creator : this.creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public Optional<G> apply(final String path) {
+                        if (createRequired(groupType, path)) {
+                            StringBuilder sb = ConfigMappingContext.this.getStringBuilder();
+                            int length = sb.length();
+                            sb.append(path, length, path.length());
+                            G group = constructGroup(groupType);
+                            sb.setLength(length);
+                            return Optional.of(group);
+                        } else {
+                            return Optional.empty();
+                        }
+                    }
+                });
+            }
+            return this;
+        }
+
+        public ObjectCreator<T> value(
+                final Class<T> valueRawType,
+                final Class<? extends Converter<T>> valueConvertWith) {
+            for (Consumer<Function<String, Object>> creator : creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public T apply(final String propertyName) {
+                        usedProperties.add(propertyName);
+                        Converter<T> valueConverter = getConverter(valueRawType, valueConvertWith);
+                        return config.getValue(propertyName, valueConverter);
+                    }
+                });
+            }
+            return this;
+        }
+
+        public <V> ObjectCreator<T> optionalValue(
+                final Class<V> valueRawType,
+                final Class<? extends Converter<V>> valueConvertWith) {
+            for (Consumer<Function<String, Object>> creator : creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public Optional<V> apply(final String propertyName) {
+                        usedProperties.add(propertyName);
+                        Converter<V> valueConverter = getConverter(valueRawType, valueConvertWith);
+                        return config.getOptionalValue(propertyName, valueConverter);
+                    }
+                });
+            }
+            return this;
+        }
+
+        public <V, C extends Collection<V>> ObjectCreator<T> values(
+                final Class<V> itemRawType,
+                final Class<? extends Converter<V>> itemConvertWith,
+                final Class<C> collectionRawType) {
+            for (Consumer<Function<String, Object>> creator : creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public T apply(final String propertyName) {
+                        usedProperties.add(propertyName);
+                        usedProperties.addAll(config.getIndexedProperties(propertyName));
+                        Converter<V> itemConverter = itemConvertWith == null ? config.requireConverter(itemRawType)
+                                : getConverterInstance(itemConvertWith);
+                        IntFunction<C> collectionFactory = (IntFunction<C>) createCollectionFactory(collectionRawType);
+                        return (T) config.getValues(propertyName, itemConverter, collectionFactory);
+                    }
+                });
+            }
+            return this;
+        }
+
+        public <V, C extends Collection<V>> ObjectCreator<T> optionalValues(
+                final Class<V> itemRawType,
+                final Class<? extends Converter<V>> itemConvertWith,
+                final Class<C> collectionRawType) {
+            for (Consumer<Function<String, Object>> creator : creators) {
+                creator.accept(new Function<String, Object>() {
+                    @Override
+                    public T apply(final String propertyName) {
+                        usedProperties.add(propertyName);
+                        usedProperties.addAll(config.getIndexedProperties(propertyName));
+                        Converter<V> itemConverter = getConverter(itemRawType, itemConvertWith);
+                        IntFunction<C> collectionFactory = (IntFunction<C>) createCollectionFactory(collectionRawType);
+                        return (T) config.getOptionalValues(propertyName, itemConverter, collectionFactory);
+                    }
+                });
+            }
+            return this;
+        }
+
+        public <K, V> ObjectCreator<T> values(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith,
+                final Class<V> valueRawType,
+                final Class<? extends Converter<V>> valueConvertWith,
+                final String defaultValue) {
+            for (Consumer<Function<String, Object>> creator : creators) {
+                Function<String, Object> values = new Function<>() {
+                    @Override
+                    public Object apply(final String propertyName) {
+                        usedProperties.add(propertyName);
+                        usedProperties.addAll(config.getMapKeys(propertyName).values());
+                        Converter<K> keyConverter = getConverter(keyRawType, keyConvertWith);
+                        Converter<V> valueConverter = getConverter(valueRawType, valueConvertWith);
+
+                        if (defaultValue == null) {
+                            // TODO - We should use getValues here, but this makes the Map to be required. This is a breaking change
+                            return config.getOptionalValues(propertyName, keyConverter, valueConverter, HashMap::new)
+                                    .orElse(new HashMap<>());
+                        } else {
+                            IntFunction<Map<K, V>> mapFactory = new IntFunction<>() {
+                                @Override
+                                public Map<K, V> apply(final int value) {
+                                    return new MapWithDefault<>(valueConverter.convert(defaultValue));
+                                }
+                            };
+                            return config.getOptionalValues(propertyName, keyConverter, valueConverter, mapFactory)
+                                    .orElse(mapFactory.apply(0));
+                        }
+                    }
+                };
+                creator.accept(values);
+            }
+            return this;
+        }
+
+        public <K, V, C extends Collection<V>> ObjectCreator<T> values(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith,
+                final Class<V> valueRawType,
+                final Class<? extends Converter<V>> valueConvertWith,
+                final Class<C> collectionRawType,
+                final String defaultValue) {
+            for (Consumer<Function<String, Object>> creator : creators) {
+                Function<String, Object> values = new Function<>() {
+                    @Override
+                    public Object apply(final String propertyName) {
+                        usedProperties.add(propertyName);
+                        for (String mapKey : config.getMapKeys(propertyName).values()) {
+                            usedProperties.add(mapKey);
+                            usedProperties.addAll(config.getIndexedProperties(mapKey));
+                        }
+                        Converter<K> keyConverter = getConverter(keyRawType, keyConvertWith);
+                        Converter<V> valueConverter = getConverter(valueRawType, valueConvertWith);
+
+                        IntFunction<C> collectionFactory = (IntFunction<C>) createCollectionFactory(collectionRawType);
+
+                        if (defaultValue == null) {
+                            // TODO - We should use getValues here, but this makes the Map to be required. This is a breaking change
+                            return config.getOptionalValues(propertyName, keyConverter, valueConverter, HashMap::new,
+                                    collectionFactory).orElse(new HashMap<>());
+                        } else {
+                            IntFunction<Map<K, C>> mapFactory = new IntFunction<>() {
+                                @Override
+                                public Map<K, C> apply(final int value) {
+                                    return new MapWithDefault<>(
+                                            Converters.newCollectionConverter(valueConverter, collectionFactory)
+                                                    .convert(defaultValue));
+                                }
+                            };
+
+                            return config.getOptionalValues(propertyName, keyConverter, valueConverter, mapFactory,
+                                    collectionFactory).orElse(mapFactory.apply(0));
+                        }
+                    }
+                };
+                creator.accept(values);
+            }
+            return this;
+        }
+
+        public T get() {
+            return root;
+        }
+
+        private <V> Converter<V> getConverter(final Class<V> rawType, final Class<? extends Converter<V>> convertWith) {
+            return convertWith == null ? config.requireConverter(rawType) : getConverterInstance(convertWith);
+        }
+
+        private Map<String, String> getMapKeys(final String name) {
+            Map<String, String> mapKeys = new HashMap<>();
+            for (String propertyName : config.getPropertyNames()) {
+                if (propertyName.length() > name.length() + 1
+                        && (name.length() == 0 || propertyName.charAt(name.length()) == '.')
+                        && propertyName.startsWith(name)) {
+                    // Start at the map root name
+                    NameIterator key = name.length() > 0 ? new NameIterator(unindexed(propertyName), name.length())
+                            : new NameIterator(unindexed(propertyName));
+                    // Move to the next key
+                    key.next();
+                    // Record key and map root name plus key
+                    mapKeys.put(unindexed(key.getPreviousSegment()), unindexed(propertyName.substring(0, key.getPosition())));
+                }
+            }
+            return mapKeys;
+        }
+
+        private <G> boolean createRequired(final Class<G> groupType, final String path) {
+            Set<PropertyName> names = ConfigMappingContext.this.names.get(groupType.getName(), path);
+            if (names == null) {
+                return false;
+            }
+
+            for (String propertyName : config.getPropertyNames()) {
+                if (propertyName.startsWith(path) && names.contains(new PropertyName(propertyName))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private IntFunction<Collection<?>> createCollectionFactory(final Class<?> type) {
+            if (type == List.class) {
+                return ArrayList::new;
+            }
+
+            if (type == Set.class) {
+                return HashSet::new;
+            }
+
+            throw new IllegalArgumentException();
+        }
     }
 
     static class MapWithDefault<K, V> extends HashMap<K, V> {

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingNames.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingNames.java
@@ -1,0 +1,51 @@
+package io.smallrye.config;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+class ConfigMappingNames {
+    private final Map<String, Names> names;
+
+    public ConfigMappingNames(final Map<String, Map<String, Set<String>>> names) {
+        this.names = new HashMap<>(names.size());
+        for (Map.Entry<String, Map<String, Set<String>>> entry : names.entrySet()) {
+            this.names.put(entry.getKey(), new Names(entry.getValue()));
+        }
+    }
+
+    Set<PropertyName> get(String mapping, String name) {
+        return names.get(mapping).get(name);
+    }
+
+    private static class Names {
+        private final Map<PropertyName, Set<PropertyName>> names;
+        private final Map<PropertyName, Set<PropertyName>> anys;
+
+        Names(Map<String, Set<String>> names) {
+            this.names = new HashMap<>();
+            this.anys = new HashMap<>();
+            for (Map.Entry<String, Set<String>> entry : names.entrySet()) {
+                if (entry.getKey().indexOf('*') == -1) {
+                    this.names.put(new PropertyName(entry.getKey()), toMappingNameSet(entry.getValue()));
+                } else {
+                    this.anys.put(new PropertyName(entry.getKey()), toMappingNameSet(entry.getValue()));
+                }
+            }
+        }
+
+        Set<PropertyName> get(String name) {
+            PropertyName mappingName = new PropertyName(name);
+            return names.getOrDefault(mappingName, anys.get(mappingName));
+        }
+
+        private static Set<PropertyName> toMappingNameSet(Set<String> names) {
+            Set<PropertyName> mappingNames = new HashSet<>(names.size());
+            for (String name : names) {
+                mappingNames.add(new PropertyName(name));
+            }
+            return mappingNames;
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingObject.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingObject.java
@@ -4,5 +4,4 @@ package io.smallrye.config;
  * An interface implemented internally by configuration object implementations.
  */
 public interface ConfigMappingObject {
-    void fillInOptionals(ConfigMappingContext context);
 }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingProvider.java
@@ -1,40 +1,27 @@
 package io.smallrye.config;
 
-import static io.smallrye.config.ConfigMappingContext.createCollectionFactory;
-import static io.smallrye.config.ConfigMappingInterface.GroupProperty;
-import static io.smallrye.config.ConfigMappingInterface.LeafProperty;
-import static io.smallrye.config.ConfigMappingInterface.MapProperty;
-import static io.smallrye.config.ConfigMappingInterface.PrimitiveProperty;
-import static io.smallrye.config.ConfigMappingInterface.Property;
-import static io.smallrye.config.ConfigMappingLoader.getConfigMapping;
 import static io.smallrye.config.ConfigMappingLoader.getConfigMappingClass;
+import static io.smallrye.config.ConfigMappings.getDefaults;
+import static io.smallrye.config.ConfigMappings.getNames;
+import static io.smallrye.config.ConfigMappings.getProperties;
+import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
 import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN;
-import static io.smallrye.config.common.utils.StringUtil.replaceNonAlphanumericByUnderscores;
-import static io.smallrye.config.common.utils.StringUtil.toLowerCaseAndDotted;
-import static java.lang.Integer.parseInt;
 
 import java.io.Serializable;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.IntFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.config.spi.Converter;
 
 import io.smallrye.common.constraint.Assert;
-import io.smallrye.common.function.Functions;
-import io.smallrye.config.ConfigMappingInterface.CollectionProperty;
-import io.smallrye.config.ConfigMappingInterface.NamingStrategy;
-import io.smallrye.config._private.ConfigMessages;
-import io.smallrye.config.common.utils.StringUtil;
+import io.smallrye.config.ConfigMappings.ConfigClassWithPrefix;
 
 /**
  *
@@ -42,1128 +29,59 @@ import io.smallrye.config.common.utils.StringUtil;
 final class ConfigMappingProvider implements Serializable {
     private static final long serialVersionUID = 3977667610888849912L;
 
-    /**
-     * The do-nothing action is used when the matched property is eager.
-     */
-    private static final BiConsumer<ConfigMappingContext, NameIterator> DO_NOTHING = Functions.discardingBiConsumer();
-    private static final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> IGNORE_EVERYTHING;
-
-    static {
-        KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> map = new KeyMap<>();
-        map.putRootValue(DO_NOTHING);
-        //noinspection CollectionAddedToSelf
-        map.putAny(map);
-        IGNORE_EVERYTHING = map;
-    }
-
     private final Map<String, List<Class<?>>> roots;
-    private final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions;
-    private final Map<String, Property> properties;
-    private final Map<String, String> defaultValues;
+    private final Set<String> keys;
+    private final Map<String, Map<String, Set<String>>> names;
+    private final List<String[]> ignoredPaths;
     private final boolean validateUnknown;
 
     ConfigMappingProvider(final Builder builder) {
         this.roots = new HashMap<>(builder.roots);
-        this.matchActions = new KeyMap<>();
-        this.properties = new HashMap<>();
-        this.defaultValues = new HashMap<>();
+        this.keys = builder.keys;
+        this.names = builder.names;
+        this.ignoredPaths = builder.ignoredPaths;
         this.validateUnknown = builder.validateUnknown;
-
-        final ArrayDeque<String> currentPath = new ArrayDeque<>();
-        for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
-            NameIterator rootNi = new NameIterator(entry.getKey());
-            while (rootNi.hasNext()) {
-                final String nextSegment = rootNi.getNextSegment();
-                if (!nextSegment.isEmpty()) {
-                    currentPath.add(nextSegment);
-                }
-                rootNi.next();
-            }
-            List<Class<?>> roots = entry.getValue();
-            for (Class<?> root : roots) {
-                // construct the lazy match actions for each group
-                BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> ef = new GetRootAction(root,
-                        entry.getKey());
-                ConfigMappingInterface mapping = getConfigMapping(root);
-                processEagerGroup(currentPath, matchActions, defaultValues, mapping.getNamingStrategy(), mapping, ef);
-            }
-            currentPath.clear();
-        }
-        for (String[] ignoredPath : builder.ignored) {
-            int len = ignoredPath.length;
-            KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> found;
-            if (ignoredPath[len - 1].equals("**")) {
-                found = matchActions.findOrAdd(ignoredPath, 0, len - 1);
-                found.putRootValue(DO_NOTHING);
-                ignoreRecursively(found);
-            } else {
-                found = matchActions.findOrAdd(ignoredPath);
-                found.putRootValue(DO_NOTHING);
-            }
-        }
-    }
-
-    static void ignoreRecursively(KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> root) {
-        if (root.getRootValue() == null) {
-            root.putRootValue(DO_NOTHING);
-        }
-
-        if (root.getAny() == null) {
-            root.putAny(IGNORE_EVERYTHING);
-        } else {
-            var any = root.getAny();
-            if (root != any) {
-                ignoreRecursively(any);
-            }
-        }
-
-        for (var value : root.values()) {
-            ignoreRecursively(value);
-        }
-    }
-
-    static final class ConsumeOneAndThen implements BiConsumer<ConfigMappingContext, NameIterator> {
-        private final BiConsumer<ConfigMappingContext, NameIterator> delegate;
-
-        ConsumeOneAndThen(final BiConsumer<ConfigMappingContext, NameIterator> delegate) {
-            this.delegate = delegate;
-        }
-
-        public void accept(final ConfigMappingContext context, final NameIterator nameIterator) {
-            nameIterator.previous();
-            delegate.accept(context, nameIterator);
-            nameIterator.next();
-        }
-    }
-
-    static final class ConsumeOneAndThenFn<T> implements BiFunction<ConfigMappingContext, NameIterator, T> {
-        private final BiFunction<ConfigMappingContext, NameIterator, T> delegate;
-
-        ConsumeOneAndThenFn(final BiFunction<ConfigMappingContext, NameIterator, T> delegate) {
-            this.delegate = delegate;
-        }
-
-        public T apply(final ConfigMappingContext context, final NameIterator nameIterator) {
-            nameIterator.previous();
-            T result = delegate.apply(context, nameIterator);
-            nameIterator.next();
-            return result;
-        }
-    }
-
-    private void processEagerGroup(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface group,
-            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingFunction) {
-
-        // Register super types first. The main mapping will override methods from the super types
-        int sc = group.getSuperTypeCount();
-        for (int i = 0; i < sc; i++) {
-            processEagerGroup(currentPath, matchActions, defaultValues, namingStrategy, group.getSuperType(i),
-                    getEnclosingFunction);
-        }
-
-        Class<?> type = group.getInterfaceType();
-        for (int i = 0; i < group.getPropertyCount(); i++) {
-            Property property = group.getProperty(i);
-            ArrayDeque<String> propertyPath = new ArrayDeque<>(currentPath);
-            // process by property type
-            if (!property.isParentPropertyName()) {
-                NameIterator ni = new NameIterator(property.hasPropertyName() ? property.getPropertyName()
-                        : propertyName(property, group, namingStrategy));
-                while (ni.hasNext()) {
-                    propertyPath.add(ni.getNextSegment());
-                    ni.next();
-                }
-            }
-            processProperty(propertyPath, matchActions, defaultValues, namingStrategy, group, getEnclosingFunction, type,
-                    property);
-        }
-    }
-
-    private void processProperty(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface group,
-            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingFunction,
-            final Class<?> type,
-            final Property property) {
-
-        if (property.isOptional()) {
-            // switch to lazy mode
-            Property nestedProperty = property.asOptional().getNestedProperty();
-            processOptionalProperty(currentPath, matchActions, defaultValues, namingStrategy, group, getEnclosingFunction, type,
-                    nestedProperty);
-        } else if (property.isGroup()) {
-            GroupProperty nestedGroup = property.asGroup();
-            GetOrCreateEnclosingGroupInGroup enclosingFunction = new GetOrCreateEnclosingGroupInGroup(getEnclosingFunction,
-                    nestedGroup.getGroupType().getInterfaceType(),
-                    nestedGroup.getMemberName(),
-                    currentPath,
-                    nestedGroup.getGroupType().getNamingStrategy(),
-                    group.getInterfaceType(),
-                    namingStrategy);
-            processEagerGroup(currentPath, matchActions, defaultValues, namingStrategy, property.asGroup().getGroupType(),
-                    enclosingFunction);
-        } else if (property.isPrimitive()) {
-            // already processed eagerly
-            PrimitiveProperty primitiveProperty = property.asPrimitive();
-            if (primitiveProperty.hasDefaultValue()) {
-                addDefault(currentPath, primitiveProperty.getDefaultValue());
-                // collections may also be represented without [] so we need to register both paths
-                if (isCollection(currentPath)) {
-                    addDefault(inlineCollectionPath(currentPath), primitiveProperty.getDefaultValue());
-                }
-            }
-            addAction(currentPath, property, DO_NOTHING);
-            // collections may also be represented without [] so we need to register both paths
-            if (isCollection(currentPath)) {
-                addAction(inlineCollectionPath(currentPath), property, DO_NOTHING);
-            }
-        } else if (property.isLeaf()) {
-            // already processed eagerly
-            LeafProperty leafProperty = property.asLeaf();
-            if (leafProperty.hasDefaultValue()) {
-                addDefault(currentPath, leafProperty.getDefaultValue());
-                // collections may also be represented without [] so we need to register both paths
-                if (isCollection(currentPath)) {
-                    addDefault(inlineCollectionPath(currentPath), leafProperty.getDefaultValue());
-                }
-            }
-            // ignore with no error message
-            addAction(currentPath, property, DO_NOTHING);
-            // collections may also be represented without [] so we need to register both paths
-            if (isCollection(currentPath)) {
-                addAction(inlineCollectionPath(currentPath), property, DO_NOTHING);
-            }
-        } else if (property.isMap()) {
-            // the enclosure of the map is this group
-            processLazyMapInGroup(currentPath, matchActions, defaultValues, property.asMap(), getEnclosingFunction,
-                    namingStrategy, group);
-        } else if (property.isCollection()) {
-            CollectionProperty collectionProperty = property.asCollection();
-            currentPath.addLast(currentPath.removeLast() + "[*]");
-            processProperty(currentPath, matchActions, defaultValues, namingStrategy, group, getEnclosingFunction, type,
-                    collectionProperty.getElement());
-        }
-    }
-
-    private void processOptionalProperty(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface group,
-            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingFunction,
-            final Class<?> type,
-            final Property property) {
-
-        if (property.isGroup()) {
-            GroupProperty nestedGroup = property.asGroup();
-            // on match, always create the outermost group, which recursively creates inner groups
-            GetOrCreateEnclosingGroupInGroup enclosingFunction = new GetOrCreateEnclosingGroupInGroup(getEnclosingFunction,
-                    nestedGroup.getGroupType().getInterfaceType(),
-                    nestedGroup.getMemberName(),
-                    currentPath,
-                    nestedGroup.getGroupType().getNamingStrategy(),
-                    group.getInterfaceType(),
-                    namingStrategy);
-            processLazyGroupInGroup(currentPath, matchActions, defaultValues, namingStrategy, nestedGroup.getGroupType(),
-                    enclosingFunction);
-        } else if (property.isLeaf()) {
-            LeafProperty leafProperty = property.asLeaf();
-            if (leafProperty.hasDefaultValue()) {
-                addDefault(currentPath, leafProperty.getDefaultValue());
-                // collections may also be represented without [] so we need to register both paths
-                if (isCollection(currentPath)) {
-                    addDefault(inlineCollectionPath(currentPath), leafProperty.getDefaultValue());
-                }
-            }
-            addAction(currentPath, property, DO_NOTHING);
-            // collections may also be represented without [] so we need to register both paths
-            if (isCollection(currentPath)) {
-                addAction(inlineCollectionPath(currentPath), property, DO_NOTHING);
-            }
-        } else if (property.isCollection()) {
-            CollectionProperty collectionProperty = property.asCollection();
-            currentPath.addLast(currentPath.removeLast() + "[*]");
-            processProperty(currentPath, matchActions, defaultValues, namingStrategy, group, getEnclosingFunction, type,
-                    collectionProperty.getElement());
-        }
-    }
-
-    private void processLazyGroupInGroup(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface group,
-            final BiConsumer<ConfigMappingContext, NameIterator> matchAction) {
-        int pc = group.getPropertyCount();
-        int pathLen = currentPath.size();
-        for (int i = 0; i < pc; i++) {
-            Property property = group.getProperty(i);
-            if (!property.isParentPropertyName()) {
-                NameIterator ni = new NameIterator(property.hasPropertyName() ? property.getPropertyName()
-                        : propertyName(property, group, namingStrategy));
-                while (ni.hasNext()) {
-                    currentPath.add(ni.getNextSegment());
-                    ni.next();
-                }
-            }
-            boolean optional = property.isOptional();
-            processLazyPropertyInGroup(currentPath, matchActions, defaultValues, matchAction, namingStrategy, group, optional,
-                    property);
-            while (currentPath.size() > pathLen) {
-                currentPath.removeLast();
-            }
-        }
-        int sc = group.getSuperTypeCount();
-        for (int i = 0; i < sc; i++) {
-            processLazyGroupInGroup(currentPath, matchActions, defaultValues, namingStrategy, group.getSuperType(i),
-                    matchAction);
-        }
-    }
-
-    private void processLazyPropertyInGroup(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final BiConsumer<ConfigMappingContext, NameIterator> matchAction,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface group,
-            final boolean optional,
-            final Property property) {
-
-        if (property.isGroup() || optional && property.asOptional().getNestedProperty().isGroup()) {
-            BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate = property.isParentPropertyName()
-                    ? new GetNestedEnclosing(matchAction)
-                    : new ConsumeOneAndThenFn<>(new GetNestedEnclosing(matchAction));
-            GroupProperty nestedGroup = property.isGroup() ? property.asGroup()
-                    : property.asOptional().getNestedProperty().asGroup();
-            GetOrCreateEnclosingGroupInGroup enclosingFunction = new GetOrCreateEnclosingGroupInGroup(delegate,
-                    nestedGroup.getGroupType().getInterfaceType(),
-                    nestedGroup.getMemberName(),
-                    currentPath,
-                    nestedGroup.getGroupType().getNamingStrategy(),
-                    group.getInterfaceType(),
-                    namingStrategy);
-            processLazyGroupInGroup(currentPath, matchActions, defaultValues, namingStrategy, nestedGroup.getGroupType(),
-                    enclosingFunction);
-        } else if (property.isGroup()) {
-            GroupProperty nestedGroup = property.asGroup();
-            BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate = property.isParentPropertyName()
-                    ? new GetNestedEnclosing(matchAction)
-                    : new ConsumeOneAndThenFn<>(new GetNestedEnclosing(matchAction));
-            GetOrCreateEnclosingGroupInGroup enclosingFunction = new GetOrCreateEnclosingGroupInGroup(delegate,
-                    nestedGroup.getGroupType().getInterfaceType(),
-                    nestedGroup.getMemberName(),
-                    currentPath,
-                    nestedGroup.getGroupType().getNamingStrategy(),
-                    group.getInterfaceType(),
-                    namingStrategy);
-            processLazyGroupInGroup(currentPath, matchActions, defaultValues, namingStrategy, nestedGroup.getGroupType(),
-                    enclosingFunction);
-        } else if (property.isLeaf() || property.isPrimitive()
-                || optional && property.asOptional().getNestedProperty().isLeaf()) {
-            BiConsumer<ConfigMappingContext, NameIterator> actualAction = property.isParentPropertyName() ? matchAction
-                    : new ConsumeOneAndThen(matchAction);
-            addAction(currentPath, property, actualAction);
-            // collections may also be represented without [] so we need to register both paths
-            if (isCollection(currentPath)) {
-                addAction(inlineCollectionPath(currentPath), property, actualAction);
-            }
-            if (property.isPrimitive()) {
-                PrimitiveProperty primitiveProperty = property.asPrimitive();
-                if (primitiveProperty.hasDefaultValue()) {
-                    addDefault(currentPath, primitiveProperty.getDefaultValue());
-                    // collections may also be represented without [] so we need to register both paths
-                    if (isCollection(currentPath)) {
-                        addDefault(inlineCollectionPath(currentPath), primitiveProperty.getDefaultValue());
-                    }
-                }
-            } else if (property.isLeaf() && optional) {
-                LeafProperty leafProperty = property.asOptional().getNestedProperty().asLeaf();
-                if (leafProperty.hasDefaultValue()) {
-                    addDefault(currentPath, leafProperty.getDefaultValue());
-                    // collections may also be represented without [] so we need to register both paths
-                    if (isCollection(currentPath)) {
-                        addDefault(inlineCollectionPath(currentPath), leafProperty.getDefaultValue());
-                    }
-                }
-            } else {
-                LeafProperty leafProperty = property.asLeaf();
-                if (leafProperty.hasDefaultValue()) {
-                    addDefault(currentPath, leafProperty.getDefaultValue());
-                    // collections may also be represented without [] so we need to register both paths
-                    if (isCollection(currentPath)) {
-                        addDefault(inlineCollectionPath(currentPath), leafProperty.getDefaultValue());
-                    }
-                }
-            }
-        } else if (property.isMap()) {
-            GetNestedEnclosing nestedMatchAction = new GetNestedEnclosing(matchAction);
-            processLazyMapInGroup(currentPath, matchActions, defaultValues, property.asMap(), nestedMatchAction, namingStrategy,
-                    group);
-        } else if (property.isCollection() || optional && property.asOptional().getNestedProperty().isCollection()) {
-            CollectionProperty collectionProperty = optional ? property.asOptional().getNestedProperty().asCollection()
-                    : property.asCollection();
-            currentPath.addLast(currentPath.removeLast() + "[*]");
-            processLazyPropertyInGroup(currentPath, matchActions, defaultValues, matchAction, namingStrategy, group, false,
-                    collectionProperty.getElement());
-        }
-    }
-
-    private void processLazyMapInGroup(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final MapProperty mapProperty,
-            final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> getEnclosingGroup,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface enclosingGroup) {
-
-        BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate = mapProperty.isParentPropertyName()
-                ? getEnclosingGroup
-                : new ConsumeOneAndThenFn<>(getEnclosingGroup);
-        GetOrCreateEnclosingMapInGroup getEnclosingMap = new GetOrCreateEnclosingMapInGroup(delegate,
-                mapProperty.getMemberName(), currentPath, enclosingGroup.getInterfaceType(),
-                enclosingGroup.getNamingStrategy());
-        processLazyMap(currentPath, matchActions, defaultValues, mapProperty, getEnclosingMap, namingStrategy, enclosingGroup);
-    }
-
-    private void processLazyMap(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final MapProperty property,
-            final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> getEnclosingMap,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface enclosingGroup) {
-
-        Property valueProperty = property.getValueProperty();
-        ArrayDeque<String> unnamedPath = new ArrayDeque<>(currentPath);
-        currentPath.addLast("*");
-        processLazyMapValue(currentPath, matchActions, defaultValues, property, valueProperty, false, getEnclosingMap,
-                namingStrategy, enclosingGroup);
-        if (property.hasKeyUnnamed()) {
-            processLazyMapValue(unnamedPath, matchActions, defaultValues, property, valueProperty, true, getEnclosingMap,
-                    namingStrategy, enclosingGroup);
-        }
-    }
-
-    private void processLazyMapValue(
-            final ArrayDeque<String> currentPath,
-            final KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> matchActions,
-            final Map<String, String> defaultValues,
-            final MapProperty mapProperty,
-            final Property mapValueProperty,
-            final boolean keyUnnamed,
-            final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> getEnclosingMap,
-            final NamingStrategy namingStrategy,
-            final ConfigMappingInterface enclosingGroup) {
-
-        if (mapValueProperty.isLeaf()) {
-            LeafProperty leafProperty = mapValueProperty.asLeaf();
-            String mapPath = String.join(".", currentPath);
-
-            CreateValueInMap matchAction = new CreateValueInMap(
-                    getEnclosingMap,
-                    mapPath,
-                    mapProperty.getKeyRawType(), mapProperty.hasKeyConvertWith() ? mapProperty.getKeyConvertWith() : null,
-                    leafProperty.getValueRawType(),
-                    leafProperty.getConvertWith(),
-                    mapProperty.getValueProperty().isCollection(),
-                    mapProperty.getValueProperty().isCollection()
-                            ? mapProperty.getValueProperty().asCollection().getCollectionRawType()
-                            : null);
-
-            addAction(currentPath, mapProperty, matchAction);
-
-            // action to match all segments of a key after the map path
-            KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> mapAction = matchActions.find(mapPath);
-            if (mapAction != null) {
-                mapAction.putAny(matchActions.find(mapPath));
-            }
-            // collections may also be represented without [] so we need to register both paths
-            if (isCollection(currentPath)) {
-                addAction(inlineCollectionPath(currentPath), leafProperty, DO_NOTHING);
-            }
-        } else if (mapValueProperty.isMap()) {
-            GetOrCreateEnclosingMapInMap getNestedEnclosingMap = new GetOrCreateEnclosingMapInMap(
-                    getEnclosingMap,
-                    mapProperty.getKeyRawType(),
-                    keyUnnamed,
-                    mapProperty.getKeyUnnamed(),
-                    mapProperty.hasKeyConvertWith() ? mapProperty.getKeyConvertWith() : null);
-            processLazyMap(currentPath, matchActions, defaultValues, mapValueProperty.asMap(), getNestedEnclosingMap,
-                    namingStrategy, enclosingGroup);
-        } else if (mapValueProperty.isGroup()) {
-            GetOrCreateEnclosingGroupInMap ef = new GetOrCreateEnclosingGroupInMap(
-                    getEnclosingMap,
-                    currentPath,
-                    mapProperty.getKeyRawType(),
-                    keyUnnamed,
-                    mapProperty.getKeyUnnamed(),
-                    mapProperty.hasKeyConvertWith() ? mapProperty.getKeyConvertWith() : null,
-                    mapProperty.getValueProperty().isCollection()
-                            ? mapProperty.getValueProperty().asCollection().getCollectionRawType()
-                            : null,
-                    mapProperty.getValueProperty().isCollection(),
-                    mapValueProperty.asGroup().getGroupType().getInterfaceType(),
-                    mapValueProperty.asGroup().getGroupType().getNamingStrategy(),
-                    enclosingGroup.getInterfaceType(),
-                    enclosingGroup.getNamingStrategy());
-            processLazyGroupInGroup(currentPath, matchActions, defaultValues, namingStrategy,
-                    mapValueProperty.asGroup().getGroupType(), ef);
-        } else if (mapValueProperty.isCollection()) {
-            CollectionProperty collectionProperty = mapValueProperty.asCollection();
-            Property element = collectionProperty.getElement();
-            if (!element.hasConvertWith() && !keyUnnamed && !element.isLeaf()) {
-                currentPath.addLast(currentPath.removeLast() + "[*]");
-            }
-            processLazyMapValue(currentPath, matchActions, defaultValues, mapProperty, element, keyUnnamed, getEnclosingMap,
-                    namingStrategy, enclosingGroup);
-        }
-    }
-
-    private void addAction(
-            final ArrayDeque<String> currentPath,
-            final Property property,
-            final BiConsumer<ConfigMappingContext, NameIterator> action) {
-        KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> current = matchActions.findOrAdd(currentPath);
-        Property previous = properties.put(String.join(".", currentPath), property);
-        if (current.hasRootValue() && current.getRootValue() != action && previous != null && !previous.equals(property)) {
-            throw ConfigMessages.msg.ambiguousMapping(String.join(".", currentPath), property.getMemberName(),
-                    previous.getMemberName());
-        }
-        current.putRootValue(action);
-    }
-
-    private static boolean isCollection(final ArrayDeque<String> currentPath) {
-        return !currentPath.isEmpty() && currentPath.getLast().endsWith("[*]");
-    }
-
-    private static ArrayDeque<String> inlineCollectionPath(final ArrayDeque<String> currentPath) {
-        ArrayDeque<String> inlineCollectionPath = new ArrayDeque<>(currentPath);
-        String last = inlineCollectionPath.removeLast();
-        inlineCollectionPath.addLast(last.substring(0, last.length() - 3));
-        return inlineCollectionPath;
-    }
-
-    // This will add the property index (if exists) to the name
-    private static String indexName(final String name, final String groupPath, final NameIterator nameIterator) {
-        String group = new NameIterator(groupPath, true).getPreviousSegment();
-        String property = nameIterator.getAllPreviousSegments();
-        int start = property.lastIndexOf(normalizeIfIndexed(group));
-        if (start != -1) {
-            int i = start + normalizeIfIndexed(group).length();
-            if (i < property.length() && property.charAt(i) == '[') {
-                for (;;) {
-                    if (property.charAt(i) == ']') {
-                        try {
-                            int index = parseInt(
-                                    property.substring(start + normalizeIfIndexed(group).length() + 1, i));
-                            return name + "[" + index + "]";
-                        } catch (NumberFormatException e) {
-                            //NOOP
-                        }
-                        break;
-                    } else if (i < property.length() - 1) {
-                        i++;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-        return name;
-    }
-
-    private static NameIterator mapPath(final String mapPath, final NameIterator propertyName) {
-        int segments = 0;
-        NameIterator countSegments = new NameIterator(mapPath);
-        while (countSegments.hasNext()) {
-            segments++;
-            countSegments.next();
-        }
-
-        // We don't want the key; keys only exist when the map ends with '*'; else it is an unnamed key
-        if (mapPath.endsWith("*") || mapPath.endsWith("*[*]")) {
-            segments = segments - 1;
-        }
-
-        NameIterator propertyMap = new NameIterator(propertyName.getName());
-        propertyMap.next(segments);
-        return propertyMap;
-    }
-
-    private static String propertyName(final Property property, final ConfigMappingInterface group,
-            final NamingStrategy namingStrategy) {
-        return namingStrategy(namingStrategy, group.getNamingStrategy()).apply(property.getPropertyName());
-    }
-
-    private static NamingStrategy namingStrategy(NamingStrategy enclosing, NamingStrategy enclosed) {
-        // if enclosed element is using default, then use the enclosing naming strategy
-        if (enclosed.isDefault()) {
-            return enclosing;
-        } else {
-            return enclosed;
-        }
-    }
-
-    static class GetRootAction implements BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> {
-        private final Class<?> root;
-        private final String rootPath;
-
-        GetRootAction(final Class<?> root, final String rootPath) {
-            this.root = root;
-            this.rootPath = rootPath;
-        }
-
-        @Override
-        public ConfigMappingObject apply(final ConfigMappingContext mc, final NameIterator ni) {
-            return mc.getRoot(root, rootPath);
-        }
-    }
-
-    static class GetOrCreateEnclosingGroupInGroup
-            implements BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject>,
-            BiConsumer<ConfigMappingContext, NameIterator> {
-        private final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate;
-        private final Class<?> groupType;
-        private final String groupName;
-        private final String groupPath;
-        private final int groupDepth;
-        private final NamingStrategy groupNaming;
-        private final Class<?> enclosingGroupType;
-        private final NamingStrategy enclosingGroupNaming;
-
-        public GetOrCreateEnclosingGroupInGroup(
-                final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate,
-                final Class<?> groupType,
-                final String groupName,
-                final ArrayDeque<String> groupPath,
-                final NamingStrategy groupNaming,
-                final Class<?> enclosingGroupType,
-                final NamingStrategy enclosingGroupNaming) {
-
-            this.delegate = delegate;
-            this.groupType = groupType;
-            this.groupName = groupName;
-            this.groupPath = String.join(".", groupPath);
-            this.groupDepth = groupPath.size();
-            this.groupNaming = groupNaming;
-            this.enclosingGroupType = enclosingGroupType;
-            this.enclosingGroupNaming = enclosingGroupNaming;
-        }
-
-        @Override
-        public ConfigMappingObject apply(final ConfigMappingContext context, final NameIterator ni) {
-            ConfigMappingObject ourEnclosing = delegate.apply(context, ni);
-            String key = indexName(groupName, groupPath, ni);
-            ConfigMappingObject val = (ConfigMappingObject) context.getEnclosedField(enclosingGroupType, key, ourEnclosing);
-            context.applyNamingStrategy(namingStrategy(enclosingGroupNaming, groupNaming));
-            if (val == null) {
-                NameIterator groupNi = new NameIterator(ni.getName());
-                groupNi.next(groupDepth);
-                StringBuilder sb = context.getStringBuilder();
-                sb.replace(0, sb.length(), groupNi.getAllPreviousSegments());
-                val = (ConfigMappingObject) context.constructGroup(groupType);
-                context.registerEnclosedField(enclosingGroupType, key, ourEnclosing, val);
-            }
-            return val;
-        }
-
-        @Override
-        public void accept(final ConfigMappingContext context, final NameIterator nameIterator) {
-            apply(context, nameIterator);
-        }
-    }
-
-    static class GetOrCreateEnclosingGroupInMap implements BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject>,
-            BiConsumer<ConfigMappingContext, NameIterator> {
-        private final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> delegate;
-
-        private final String mapPath;
-        private final Class<?> mapKeyRawType;
-        private final boolean mapKeyUnnamed;
-        private final String mapKeyUnnamedKey;
-        private final Class<? extends Converter<?>> mapKeyConverter;
-        private final Class<?> mapValueRawType;
-        private final boolean mapValueCollection;
-        private final Class<?> groupType;
-        private final NamingStrategy groupNaming;
-        private final Class<?> enclosingGroupType;
-        private final NamingStrategy enclosingGroupNaming;
-
-        public GetOrCreateEnclosingGroupInMap(
-                final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> delegate,
-                final ArrayDeque<String> mapPath,
-                final Class<?> mapKeyRawType,
-                final boolean mapKeyUnnamed,
-                final String mapKeyUnnamedKey,
-                final Class<? extends Converter<?>> mapKeyConverter,
-                final Class<?> mapValueRawType,
-                final boolean mapValueCollection,
-                final Class<?> groupType,
-                final NamingStrategy groupNaming,
-                final Class<?> enclosingGroupType,
-                final NamingStrategy enclosingGroupNaming) {
-
-            this.delegate = delegate;
-            this.mapPath = String.join(".", mapPath);
-            this.mapKeyRawType = mapKeyRawType;
-            this.mapKeyUnnamed = mapKeyUnnamed;
-            this.mapKeyUnnamedKey = mapKeyUnnamedKey;
-            this.mapKeyConverter = mapKeyConverter;
-            this.mapValueRawType = mapValueRawType;
-            this.mapValueCollection = mapValueCollection;
-            this.groupType = groupType;
-            this.groupNaming = groupNaming;
-            this.enclosingGroupType = enclosingGroupType;
-            this.enclosingGroupNaming = enclosingGroupNaming;
-        }
-
-        @Override
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        public ConfigMappingObject apply(final ConfigMappingContext context, final NameIterator ni) {
-            NameIterator niMapPath = mapPath(mapPath, ni);
-            MapKey mapKey = mapKey(context, ni, niMapPath);
-            Map<?, ?> ourEnclosing = delegate.apply(context, niMapPath);
-            ConfigMappingObject val = (ConfigMappingObject) context.getEnclosedField(enclosingGroupType, mapKey.getKey(),
-                    ourEnclosing);
-            if (val == null) {
-                StringBuilder sb = context.getStringBuilder();
-                sb.replace(0, sb.length(), mapKeyUnnamed ? niMapPath.getAllPreviousSegments()
-                        : niMapPath.getAllPreviousSegmentsWith(mapKey.getKey()));
-                context.applyNamingStrategy(namingStrategy(enclosingGroupNaming, groupNaming));
-                val = (ConfigMappingObject) context.constructGroup(groupType);
-                context.registerEnclosedField(enclosingGroupType, mapKey.getKey(), ourEnclosing, val);
-                if (mapValueCollection) {
-                    Collection collection = (Collection) ourEnclosing.get(mapKey.getConvertedKey());
-                    if (collection == null) {
-                        // Create the Collection in the Map does not have it
-                        IntFunction<Collection<?>> collectionFactory = createCollectionFactory(mapValueRawType);
-                        // Get all the available indexes
-                        List<Integer> indexes = mapKeyUnnamed ? List.of(0)
-                                : context.getConfig()
-                                        .getIndexedPropertiesIndexes(niMapPath.getAllPreviousSegmentsWith(mapKey.getNameKey()));
-                        collection = collectionFactory.apply(indexes.size());
-                        // Initialize all expected elements in the list
-                        if (collection instanceof List) {
-                            for (Integer index : indexes) {
-                                ((List<?>) collection).add(index, null);
-                            }
-                        }
-                        ((Map) ourEnclosing).put(mapKey.getConvertedKey(), collection);
-                    }
-
-                    if (collection instanceof List) {
-                        // We don't know the order in which the properties will be processed, so we set it manually
-                        ((List) collection).set(mapKey.getIndex(), val);
-                    } else {
-                        collection.add(val);
-                    }
-                } else {
-                    ((Map) ourEnclosing).put(mapKey.getConvertedKey(), val);
-                }
-            }
-            return val;
-        }
-
-        @Override
-        public void accept(final ConfigMappingContext context, final NameIterator ni) {
-            apply(context, ni);
-        }
-
-        private MapKey mapKey(final ConfigMappingContext context, final NameIterator ni, final NameIterator mapPath) {
-            if (mapKeyUnnamed && mapKeyUnnamedKey == null) {
-                return new MapKey(null, null, null, 0);
-            }
-
-            String rawKey = mapKeyUnnamed ? mapKeyUnnamedKey : mapPath.getNextSegment();
-            mapPath.next();
-            String pathKey = mapPath.getAllPreviousSegments();
-            mapPath.previous();
-            Converter<?> converterKey;
-            if (mapKeyConverter != null) {
-                converterKey = context.getConverterInstance(mapKeyConverter);
-            } else {
-                converterKey = context.getConfig().requireConverter(mapKeyRawType);
-            }
-
-            // This will be the key to use to store the value in the map
-            String nameKey = normalizeIfIndexed(rawKey);
-            Object convertedKey = converterKey.convert(rawKey);
-            if (convertedKey.equals(rawKey)) {
-                convertedKey = nameKey;
-            }
-
-            int index = -1;
-            if (mapValueCollection) {
-                index = mapKeyUnnamed ? 0 : getIndex(rawKey);
-            }
-
-            // NameIterator#getNextSegment() returns the name without quotes. We need add them if they exist for lookups to work properly
-            if (pathKey.charAt(pathKey.length() - 1 - rawKey.length() + nameKey.length()) == '"'
-                    && pathKey.charAt(pathKey.length() - 1 - rawKey.length() - 1) == '"') {
-                nameKey = "\"" + nameKey + "\"";
-                rawKey = mapValueCollection ? nameKey + "[" + index + "]" : nameKey;
-            }
-
-            if (!mapKeyUnnamed && (index >= 0 ? rawKey : nameKey).equals(mapKeyUnnamedKey)) {
-                throw ConfigMessages.msg.explicitNameInUnnamed(ni.getName(), rawKey);
-            }
-
-            return new MapKey(rawKey, nameKey, convertedKey, index);
-        }
-
-        static class MapKey {
-            private final String rawKey;
-            private final String nameKey;
-            private final Object convertedKey;
-            private final int index;
-
-            public MapKey(final String rawKey, final String nameKey, final Object convertedKey, final int index) {
-                this.rawKey = rawKey;
-                this.nameKey = nameKey;
-                this.convertedKey = convertedKey;
-                this.index = index;
-            }
-
-            public String getKey() {
-                return index >= 0 ? rawKey : nameKey;
-            }
-
-            public String getNameKey() {
-                return nameKey;
-            }
-
-            public Object getConvertedKey() {
-                return convertedKey;
-            }
-
-            public int getIndex() {
-                return index;
-            }
-        }
-    }
-
-    static class GetOrCreateEnclosingMapInGroup implements BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>>,
-            BiConsumer<ConfigMappingContext, NameIterator> {
-        private final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate;
-        private final String mapName;
-        private final String mapPath;
-        private final Class<?> enclosingGroupType;
-        private final NamingStrategy enclosingGroupNaming;
-
-        public GetOrCreateEnclosingMapInGroup(
-                final BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> delegate,
-                final String mapName,
-                final ArrayDeque<String> mapPath,
-                final Class<?> enclosingGroupType,
-                final NamingStrategy enclosingGroupNaming) {
-
-            this.delegate = delegate;
-            this.mapName = mapName;
-            this.mapPath = String.join(".", mapPath);
-            this.enclosingGroupType = enclosingGroupType;
-            this.enclosingGroupNaming = enclosingGroupNaming;
-        }
-
-        @Override
-        public Map<?, ?> apply(final ConfigMappingContext context, final NameIterator ni) {
-            ConfigMappingObject ourEnclosing = delegate.apply(context, ni);
-            String key = indexName(mapName, mapPath, ni);
-            Map<?, ?> val = (Map<?, ?>) context.getEnclosedField(enclosingGroupType, key, ourEnclosing);
-            context.applyNamingStrategy(enclosingGroupNaming);
-            if (val == null) {
-                // map is not yet constructed
-                val = new HashMap<>();
-                context.registerEnclosedField(enclosingGroupType, key, ourEnclosing, val);
-            }
-            return val;
-        }
-
-        @Override
-        public void accept(final ConfigMappingContext context, final NameIterator ni) {
-            apply(context, ni);
-        }
-    }
-
-    static class CreateValueInMap implements BiConsumer<ConfigMappingContext, NameIterator> {
-        private final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> delegate;
-        private final String mapPath;
-        private final Class<?> mapKeyRawType;
-        private final Class<? extends Converter<?>> mapKeyConverter;
-        private final Class<?> mapValueRawType;
-        private final Class<? extends Converter<?>> mapValueConverter;
-        private final boolean mapValueCollection;
-        private final Class<?> mapValueCollectionRawType;
-
-        public CreateValueInMap(
-                final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> delegate,
-                final String mapPath,
-                final Class<?> mapKeyRawType,
-                final Class<? extends Converter<?>> mapKeyConverter,
-                final Class<?> mapValueRawType,
-                final Class<? extends Converter<?>> mapValueConverter,
-                final boolean mapValueCollection,
-                final Class<?> mapValueCollectionRawType) {
-
-            this.delegate = delegate;
-            this.mapPath = mapPath;
-            this.mapKeyRawType = mapKeyRawType;
-            this.mapKeyConverter = mapKeyConverter;
-            this.mapValueRawType = mapValueRawType;
-            this.mapValueConverter = mapValueConverter;
-            this.mapValueCollection = mapValueCollection;
-            this.mapValueCollectionRawType = mapValueCollectionRawType;
-        }
-
-        @Override
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        public void accept(final ConfigMappingContext context, final NameIterator ni) {
-            // Place the cursor at the map path
-            NameIterator niMapPath = mapPath(mapPath, ni);
-            Map<?, ?> map = delegate.apply(context, niMapPath);
-
-            String rawMapKey;
-            String configKey;
-            boolean indexed = isIndexed(ni.getPreviousSegment());
-            if (indexed && ni.hasPrevious()) {
-                rawMapKey = normalizeIfIndexed(niMapPath.getName().substring(niMapPath.getPosition() + 1));
-                configKey = niMapPath.getAllPreviousSegmentsWith(rawMapKey);
-            } else {
-                rawMapKey = niMapPath.getName().substring(niMapPath.getPosition() + 1);
-                configKey = ni.getAllPreviousSegments();
-            }
-
-            // Remove quotes if exists
-            if (rawMapKey.length() > 1 && rawMapKey.charAt(0) == '"' && rawMapKey.charAt(rawMapKey.length() - 1) == '"') {
-                rawMapKey = rawMapKey.substring(1, rawMapKey.length() - 1);
-            }
-
-            Converter<?> keyConv;
-            SmallRyeConfig config = context.getConfig();
-            if (mapKeyConverter != null) {
-                keyConv = context.getConverterInstance(mapKeyConverter);
-            } else {
-                keyConv = config.requireConverter(mapKeyRawType);
-            }
-            Converter<?> valueConv;
-            if (mapValueConverter != null) {
-                valueConv = context.getConverterInstance(mapValueConverter);
-            } else {
-                valueConv = config.requireConverter(mapValueRawType);
-            }
-
-            if (mapValueCollection && mapValueConverter == null) {
-                IntFunction collectionFactory = createCollectionFactory(mapValueCollectionRawType);
-                ((Map) map).put(keyConv.convert(rawMapKey), config.getValues(configKey, valueConv, collectionFactory));
-            } else {
-                ((Map) map).put(keyConv.convert(rawMapKey), config.getValue(configKey, valueConv));
-            }
-        }
-    }
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    static class GetOrCreateEnclosingMapInMap implements BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>>,
-            BiConsumer<ConfigMappingContext, NameIterator> {
-        private final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> delegate;
-        private final Class<?> mapKeyRawType;
-        private final boolean mapKeyUnnamed;
-        private final String mapKeyUnnamedKey;
-        private final Class<? extends Converter<?>> mapKeyConverter;
-
-        public GetOrCreateEnclosingMapInMap(
-                final BiFunction<ConfigMappingContext, NameIterator, Map<?, ?>> delegate,
-                final Class<?> mapKeyRawType,
-                final boolean mapKeyUnnamed,
-                final String mapKeyUnnamedKey,
-                final Class<? extends Converter<?>> mapKeyConverter) {
-
-            this.delegate = delegate;
-            this.mapKeyRawType = mapKeyRawType;
-            this.mapKeyUnnamed = mapKeyUnnamed;
-            this.mapKeyUnnamedKey = mapKeyUnnamedKey;
-            this.mapKeyConverter = mapKeyConverter;
-        }
-
-        @Override
-        public Map<?, ?> apply(final ConfigMappingContext context, final NameIterator ni) {
-            if (!mapKeyUnnamed) {
-                ni.previous();
-            }
-            Map<?, ?> enclosingMap = delegate.apply(context, ni);
-            if (!mapKeyUnnamed) {
-                ni.next();
-            }
-            String rawMapKey = mapKeyUnnamed ? mapKeyUnnamedKey : ni.getPreviousSegment();
-            Converter<?> keyConv;
-            SmallRyeConfig config = context.getConfig();
-            if (mapKeyConverter != null) {
-                keyConv = context.getConverterInstance(mapKeyConverter);
-            } else {
-                keyConv = config.requireConverter(mapKeyRawType);
-            }
-            Object key = rawMapKey != null ? keyConv.convert(rawMapKey) : null;
-            return (Map) ((Map) enclosingMap).computeIfAbsent(key, map -> new HashMap<>());
-        }
-
-        @Override
-        public void accept(final ConfigMappingContext context, final NameIterator ni) {
-            apply(context, ni);
-        }
-    }
-
-    // To recursively create Optional nested groups
-    static class GetNestedEnclosing implements BiFunction<ConfigMappingContext, NameIterator, ConfigMappingObject> {
-        private final BiConsumer<ConfigMappingContext, NameIterator> matchAction;
-
-        public GetNestedEnclosing(final BiConsumer<ConfigMappingContext, NameIterator> matchAction) {
-            this.matchAction = matchAction;
-        }
-
-        @Override
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        public ConfigMappingObject apply(final ConfigMappingContext configMappingContext, final NameIterator nameIterator) {
-            if (matchAction instanceof BiFunction) {
-                return (ConfigMappingObject) ((BiFunction) matchAction).apply(configMappingContext, nameIterator);
-            }
-            return null;
-        }
     }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    KeyMap<BiConsumer<ConfigMappingContext, NameIterator>> getMatchActions() {
-        return matchActions;
-    }
-
-    Map<String, Property> getProperties() {
-        return properties;
-    }
-
-    Map<String, String> getDefaultValues() {
-        return defaultValues;
-    }
-
-    private void addDefault(ArrayDeque<String> path, String value) {
-        defaultValues.put(String.join(".", path), value);
-    }
-
-    ConfigMappingContext mapConfiguration(SmallRyeConfig config) throws ConfigValidationException {
-        // We need to set defaults from mappings here, because in a CDI environment mappings are added on an existent Config instance
-        ConfigSource configSource = config.getDefaultValues();
-        if (configSource instanceof DefaultValuesConfigSource) {
-            DefaultValuesConfigSource defaultValuesConfigSource = (DefaultValuesConfigSource) configSource;
-            defaultValuesConfigSource.addDefaults(defaultValues);
-        }
-        matchPropertiesWithEnv(config, roots.keySet(), getProperties().keySet());
-        return SecretKeys.doUnlocked(() -> mapConfigurationInternal(config));
-    }
-
-    private ConfigMappingContext mapConfigurationInternal(SmallRyeConfig config) throws ConfigValidationException {
-        Assert.checkNotNullParam("config", config);
-        ConfigMappingContext context = new ConfigMappingContext(config);
-
+    Map<Class<?>, Map<String, ConfigMappingObject>> mapConfiguration(final SmallRyeConfig config)
+            throws ConfigValidationException {
         if (roots.isEmpty()) {
-            return context;
+            return Collections.emptyMap();
         }
 
-        // eagerly populate roots
-        for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
-            String path = entry.getKey();
-            List<Class<?>> roots = entry.getValue();
-            for (Class<?> root : roots) {
-                StringBuilder sb = context.getStringBuilder();
-                sb.replace(0, sb.length(), path);
-                ConfigMappingObject group = (ConfigMappingObject) context.constructRoot(root);
-                context.registerRoot(root, path, group);
+        // Register additional dissabiguation property names comparing mapped keys and env names
+        matchPropertiesWithEnv(config, roots.keySet(), keys);
+
+        // Perform the config mapping
+        ConfigMappingContext context = SecretKeys.doUnlocked(new Supplier<ConfigMappingContext>() {
+            @Override
+            public ConfigMappingContext get() {
+                return new ConfigMappingContext(config, roots, names);
             }
-        }
+        });
 
-        // lazily sweep
-        for (String name : filterPropertiesInRoots(config.getPropertyNames(), roots.keySet())) {
-            NameIterator ni = new NameIterator(name);
-            BiConsumer<ConfigMappingContext, NameIterator> action = matchActions.findRootValue(ni);
-            if (action != null) {
-                action.accept(context, ni);
-            } else {
-                context.unknownProperty(name);
-            }
-        }
-
-        boolean validateUnknown = config.getOptionalValue(SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN, boolean.class)
-                .orElse(this.validateUnknown);
-        if (validateUnknown) {
-            context.reportUnknown();
+        if (config.getOptionalValue(SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN, boolean.class).orElse(this.validateUnknown)) {
+            context.reportUnknown(ignoredPaths);
         }
 
         List<ConfigValidationException.Problem> problems = context.getProblems();
         if (!problems.isEmpty()) {
             throw new ConfigValidationException(problems.toArray(ConfigValidationException.Problem.NO_PROBLEMS));
         }
-        context.fillInOptionals();
 
-        return context;
+        return context.getRootsMap();
     }
 
-    /**
-     * Filters the full list of properties names in Config to only the property names that can match any of the
-     * prefixes (namespaces) registered in mappings.
-     *
-     * @param properties the available property names in Config.
-     * @param roots the registered mapping roots.
-     *
-     * @return the property names that match to at least one root.
-     */
-    private static Iterable<String> filterPropertiesInRoots(final Iterable<String> properties, final Set<String> roots) {
-        if (roots.isEmpty()) {
-            return properties;
-        }
-
-        // Will match everything, so no point in filtering
-        if (roots.contains("")) {
-            return properties;
-        }
-
-        List<String> matchedProperties = new ArrayList<>();
-        for (String property : properties) {
-            for (String root : roots) {
-                if (isPropertyInRoot(property, root)) {
-                    matchedProperties.add(property);
-                    break;
-                }
-            }
-        }
-        return matchedProperties;
-    }
-
-    private static void matchPropertiesWithEnv(final SmallRyeConfig config, final Set<String> roots,
+    private static void matchPropertiesWithEnv(
+            final SmallRyeConfig config,
+            final Set<String> roots,
             final Set<String> mappedProperties) {
         // TODO - We shouldn't be mutating the EnvSource.
-        // We should do the calculation when creating the EnvSource, but right mappings and sources are not well integrated.
-
-        // Collect properties from all sources except Env
-        List<String> configuredProperties = new ArrayList<>();
-        for (ConfigSource configSource : config.getConfigSources()) {
-            if (!(configSource instanceof EnvConfigSource)) {
-                Set<String> propertyNames = configSource.getPropertyNames();
-                if (propertyNames != null) {
-                    configuredProperties.addAll(propertyNames);
-                }
-            }
-        }
+        // We should do the calculation when creating the EnvSource, but right now mappings and sources are not well integrated.
 
         // Check Env properties
         StringBuilder sb = new StringBuilder();
@@ -1204,40 +122,7 @@ final class ConfigMappingProvider implements Serializable {
                     }
                 }
             }
-
-            // Match configured properties with Env with the same semantic meaning and use that one
-            for (String configuredProperty : configuredProperties) {
-                Set<String> envNames = envConfigSource.getPropertyNames();
-                if (envConfigSource.hasPropertyName(configuredProperty)) {
-                    if (!envNames.contains(configuredProperty)) {
-                        // this may be expensive, but it shouldn't happend that often
-                        envNames.remove(toLowerCaseAndDotted(replaceNonAlphanumericByUnderscores(configuredProperty)));
-                        envNames.add(configuredProperty);
-                    }
-                }
-            }
         }
-    }
-
-    private static boolean isPropertyInRoot(final String property, final String root) {
-        if (property.equals(root)) {
-            return true;
-        }
-
-        // if property is less than the root no way to match
-        if (property.length() <= root.length()) {
-            return false;
-        }
-
-        // foo.bar
-        // foo.bar."baz"
-        // foo.bar[0]
-        char c = property.charAt(root.length());
-        if ((c == '.') || c == '[') {
-            return property.startsWith(root);
-        }
-
-        return false;
     }
 
     /**
@@ -1337,79 +222,65 @@ final class ConfigMappingProvider implements Serializable {
         return dashesPosition;
     }
 
-    private static String normalizeIfIndexed(final String propertyName) {
-        int indexStart = propertyName.indexOf("[");
-        int indexEnd = propertyName.indexOf("]");
-        if (indexStart != -1 && indexEnd != -1) {
-            String index = propertyName.substring(indexStart + 1, indexEnd);
-            if (index.equals("*")) {
-                return propertyName.substring(0, indexStart);
-            }
-            try {
-                Integer.parseInt(index);
-                return propertyName.substring(0, indexStart);
-            } catch (NumberFormatException e) {
-                return propertyName;
-            }
-        }
-        return propertyName;
-    }
-
-    private static boolean isIndexed(final String propertyName) {
-        int indexStart = propertyName.indexOf('[');
-        int indexEnd = propertyName.indexOf(']');
-        if (indexStart != -1 && indexEnd != -1) {
-            int indexLength = indexEnd - (indexStart + 1);
-            if (indexLength == 1 && ((CharSequence) propertyName).charAt(indexStart + 1) == '*') {
-                return true;
-            }
-            return StringUtil.isNumeric(propertyName, indexStart + 1, indexEnd);
-        }
-        return false;
-    }
-
-    private static int getIndex(final String propertyName) {
-        int indexStart = propertyName.indexOf('[');
-        int indexEnd = propertyName.indexOf(']');
-        if (indexStart != -1 && indexEnd != -1) {
-            try {
-                return Integer.parseInt(propertyName.substring(indexStart + 1, indexEnd));
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException();
-            }
-        }
-        throw new IllegalArgumentException();
-    }
-
-    public static final class Builder {
-        final Set<Class<?>> types = new HashSet<>();
-        final Map<String, List<Class<?>>> roots = new HashMap<>();
-        final List<String[]> ignored = new ArrayList<>();
+    static final class Builder {
+        Set<Class<?>> types = new HashSet<>();
+        Map<String, List<Class<?>>> roots = new HashMap<>();
+        Set<String> keys = new HashSet<>();
+        Map<String, Map<String, Set<String>>> names = new HashMap<>();
+        List<String[]> ignoredPaths = new ArrayList<>();
         boolean validateUnknown = true;
+        SmallRyeConfigBuilder configBuilder = null;
 
         Builder() {
         }
 
-        public Builder addRoot(String path, Class<?> type) {
-            Assert.checkNotNullParam("path", path);
+        Builder addRoot(String prefix, Class<?> type) {
+            Assert.checkNotNullParam("path", prefix);
             Assert.checkNotNullParam("type", type);
             types.add(type);
-            roots.computeIfAbsent(path, k -> new ArrayList<>(4)).add(getConfigMappingClass(type));
+            roots.computeIfAbsent(prefix, k -> new ArrayList<>(4)).add(getConfigMappingClass(type));
             return this;
         }
 
-        public Builder addIgnored(String path) {
-            Assert.checkNotNullParam("path", path);
-            ignored.add(path.split("\\."));
+        Builder keys(Set<String> keys) {
+            Assert.checkNotNullParam("keys", keys);
+            this.keys.addAll(keys);
             return this;
         }
 
-        public Builder validateUnknown(boolean validateUnknown) {
+        Builder names(Map<String, Map<String, Set<String>>> names) {
+            Assert.checkNotNullParam("names", names);
+            for (Map.Entry<String, Map<String, Set<String>>> entry : names.entrySet()) {
+                Map<String, Set<String>> groupNames = this.names.computeIfAbsent(entry.getKey(),
+                        new Function<String, Map<String, Set<String>>>() {
+                            @Override
+                            public Map<String, Set<String>> apply(
+                                    final String s) {
+                                return new HashMap<>();
+                            }
+                        });
+                groupNames.putAll(entry.getValue());
+            }
+            return this;
+        }
+
+        Builder ignoredPath(String ignoredPath) {
+            Assert.checkNotNullParam("ignoredPath", ignoredPath);
+            ignoredPaths.add(ignoredPath.split("\\."));
+            return this;
+        }
+
+        Builder validateUnknown(boolean validateUnknown) {
             this.validateUnknown = validateUnknown;
             return this;
         }
 
-        public ConfigMappingProvider build() {
+        Builder registerDefaults(SmallRyeConfigBuilder configBuilder) {
+            this.configBuilder = configBuilder;
+            return this;
+        }
+
+        ConfigMappingProvider build() {
             // We don't validate for MP ConfigProperties, so if all classes are MP ConfigProperties disable validation.
             boolean allConfigurationProperties = true;
             for (Class<?> type : types) {
@@ -1420,7 +291,37 @@ final class ConfigMappingProvider implements Serializable {
             }
 
             if (allConfigurationProperties) {
-                this.validateUnknown = false;
+                validateUnknown = false;
+            }
+
+            if (keys.isEmpty()) {
+                for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
+                    for (Class<?> root : entry.getValue()) {
+                        ConfigClassWithPrefix configClass = configClassWithPrefix(root, entry.getKey());
+                        keys(getProperties(configClass).get(configClass.getKlass()).get(configClass.getPrefix()).keySet());
+                    }
+                }
+            }
+
+            if (names.isEmpty()) {
+                for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
+                    for (Class<?> root : entry.getValue()) {
+                        ConfigClassWithPrefix configClass = configClassWithPrefix(root, entry.getKey());
+                        names(getNames(configClass));
+                    }
+                }
+            }
+
+            if (configBuilder != null) {
+                Map<String, String> defaultValues = configBuilder.getDefaultValues();
+                for (Map.Entry<String, List<Class<?>>> entry : roots.entrySet()) {
+                    for (Class<?> root : entry.getValue()) {
+                        for (Map.Entry<String, String> defaultEntry : getDefaults(configClassWithPrefix(root, entry.getKey()))
+                                .entrySet()) {
+                            defaultValues.putIfAbsent(defaultEntry.getKey(), defaultEntry.getValue());
+                        }
+                    }
+                }
             }
 
             return new ConfigMappingProvider(this);

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -1,33 +1,26 @@
 package io.smallrye.config;
 
 import static io.smallrye.config.ConfigMappingLoader.getConfigMappingClass;
+import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
 import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN;
 import static java.lang.Boolean.TRUE;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
-import org.eclipse.microprofile.config.inject.ConfigProperties;
-
+import io.smallrye.config.ConfigMapping.NamingStrategy;
+import io.smallrye.config.ConfigMappingInterface.CollectionProperty;
+import io.smallrye.config.ConfigMappingInterface.GroupProperty;
+import io.smallrye.config.ConfigMappingInterface.LeafProperty;
 import io.smallrye.config.ConfigMappingInterface.Property;
-import io.smallrye.config._private.ConfigMessages;
 
 public final class ConfigMappings implements Serializable {
     private static final long serialVersionUID = -7790784345796818526L;
-
-    private final ConfigValidator configValidator;
-    private final ConcurrentMap<Class<?>, Map<String, ConfigMappingObject>> mappings;
-
-    ConfigMappings(final ConfigValidator configValidator) {
-        this.configValidator = configValidator;
-        this.mappings = new ConcurrentHashMap<>();
-    }
 
     public static void registerConfigMappings(final SmallRyeConfig config, final Set<ConfigClassWithPrefix> configClasses)
             throws ConfigValidationException {
@@ -45,86 +38,247 @@ public final class ConfigMappings implements Serializable {
         }
     }
 
-    public static Map<String, Property> getProperties(final ConfigClassWithPrefix configClass) {
-        ConfigMappingProvider provider = ConfigMappingProvider.builder()
-                .validateUnknown(false)
-                .addRoot(configClass.getPrefix(), configClass.getKlass())
-                .build();
+    public static Map<Class<?>, Map<String, Map<String, Property>>> getProperties(final ConfigClassWithPrefix configClass) {
+        Map<Class<?>, Map<String, Map<String, Property>>> properties = new HashMap<>();
+        Function<String, String> path = new Function<>() {
+            @Override
+            public String apply(final String path) {
+                return configClass.getPrefix().isEmpty() && !path.isEmpty() ? path.substring(1)
+                        : configClass.getPrefix() + path;
+            }
+        };
+        ConfigMappingInterface configMapping = ConfigMappingLoader.getConfigMapping(configClass.getKlass());
+        for (ConfigMappingInterface superType : configMapping.getSuperTypes()) {
+            getProperties(new GroupProperty(null, null, superType), configMapping.getNamingStrategy(), path, properties);
+        }
+        getProperties(new GroupProperty(null, null, configMapping), configMapping.getNamingStrategy(), path, properties);
+        return properties;
+    }
 
-        return provider.getProperties();
+    public static Map<String, Map<String, Set<String>>> getNames(final ConfigClassWithPrefix configClass) {
+        Map<String, Map<String, Set<String>>> names = new HashMap<>();
+        Map<Class<?>, Map<String, Map<String, Property>>> properties = getProperties(configClass);
+        for (Map.Entry<Class<?>, Map<String, Map<String, Property>>> entry : properties.entrySet()) {
+            Map<String, Set<String>> groups = new HashMap<>();
+            for (Map.Entry<String, Map<String, Property>> group : entry.getValue().entrySet()) {
+                groups.put(group.getKey(), group.getValue().keySet());
+            }
+            names.put(entry.getKey().getName(), groups);
+        }
+        return names;
+    }
+
+    public static Set<String> getKeys(final ConfigClassWithPrefix configClass) {
+        return getProperties(configClass).get(configClass.getKlass()).get(configClass.getPrefix()).keySet();
+    }
+
+    public static Map<String, String> getDefaults(final ConfigClassWithPrefix configClass) {
+        Function<String, String> path = new Function<>() {
+            @Override
+            public String apply(final String path) {
+                return configClass.getPrefix().isEmpty() && !path.isEmpty() ? path.substring(1)
+                        : configClass.getPrefix() + path;
+            }
+        };
+        ConfigMappingInterface configMapping = ConfigMappingLoader.getConfigMapping(configClass.getKlass());
+        Map<String, String> defaults = new HashMap<>();
+
+        for (ConfigMappingInterface superType : configMapping.getSuperTypes()) {
+            Map<Class<?>, Map<String, Map<String, Property>>> properties = new HashMap<>();
+            getProperties(new GroupProperty(null, null, superType), configMapping.getNamingStrategy(), path, properties);
+            for (Map.Entry<Class<?>, Map<String, Map<String, Property>>> mappingEntry : properties.entrySet()) {
+                for (Map.Entry<String, Map<String, Property>> prefixEntry : mappingEntry.getValue().entrySet()) {
+                    for (Map.Entry<String, Property> propertyEntry : prefixEntry.getValue().entrySet()) {
+                        if (propertyEntry.getValue().hasDefaultValue()) {
+                            defaults.put(propertyEntry.getKey(), propertyEntry.getValue().getDefaultValue());
+                        }
+                    }
+                }
+            }
+        }
+
+        Map<Class<?>, Map<String, Map<String, Property>>> properties = getProperties(configClass);
+        for (Map.Entry<String, Property> entry : properties.get(configClass.getKlass()).get(configClass.getPrefix())
+                .entrySet()) {
+            if (entry.getValue().hasDefaultValue()) {
+                defaults.put(entry.getKey(), entry.getValue().getDefaultValue());
+            }
+        }
+        return defaults;
     }
 
     public static Set<String> mappedProperties(final ConfigClassWithPrefix configClass, final Set<String> properties) {
-        ConfigMappingProvider provider = ConfigMappingProvider.builder()
-                .validateUnknown(false)
-                .addRoot(configClass.getPrefix(), configClass.getKlass())
-                .build();
-
+        Set<PropertyName> names = new ConfigMappingNames(getNames(configClass))
+                .get(configClass.getKlass().getName(), configClass.getPrefix());
         Set<String> mappedProperties = new HashSet<>();
         for (String property : properties) {
-            if (provider.getMatchActions().findRootValue(new NameIterator(property)) != null) {
+            if (names.contains(new PropertyName(property))) {
                 mappedProperties.add(property);
             }
         }
         return mappedProperties;
     }
 
-    static void mapConfiguration(
-            final SmallRyeConfig config,
-            final ConfigMappingProvider.Builder builder)
-            throws ConfigValidationException {
-        mapConfiguration(config, builder, new HashSet<>());
-    }
-
-    static void mapConfiguration(
+    private static void mapConfiguration(
             final SmallRyeConfig config,
             final ConfigMappingProvider.Builder builder,
             final Set<ConfigClassWithPrefix> configClasses)
             throws ConfigValidationException {
+        DefaultValuesConfigSource defaultValues = (DefaultValuesConfigSource) config.getDefaultValues();
         for (ConfigClassWithPrefix configClass : configClasses) {
             builder.addRoot(configClass.getPrefix(), configClass.getKlass());
+            defaultValues.addDefaults(
+                    getDefaults(configClassWithPrefix(getConfigMappingClass(configClass.getKlass()), configClass.getPrefix())));
         }
-        ConfigMappingProvider mappingProvider = builder.build();
-        mapConfiguration(config, mappingProvider);
+        config.getMappings().putAll(builder.build().mapConfiguration(config));
     }
 
-    static void mapConfiguration(SmallRyeConfig config, ConfigMappingProvider mappingProvider) {
-        ConfigMappingContext mappingContext = mappingProvider.mapConfiguration(config);
-        config.getConfigMappings().mappings.putAll(mappingContext.getRootsMap());
+    private static void getProperties(
+            final GroupProperty groupProperty,
+            final NamingStrategy namingStrategy,
+            final Function<String, String> path,
+            final Map<Class<?>, Map<String, Map<String, Property>>> properties) {
+
+        ConfigMappingInterface groupType = groupProperty.getGroupType();
+        Map<String, Property> groupProperties = properties
+                .computeIfAbsent(groupType.getInterfaceType(), group -> new HashMap<>())
+                .computeIfAbsent(path.apply(""), s -> new HashMap<>());
+
+        getProperties(groupProperty, namingStrategy, path, properties, groupProperties);
     }
 
-    <T> T getConfigMapping(Class<T> type) {
-        final String prefix = Optional.ofNullable(type.getAnnotation(ConfigMapping.class))
-                .map(ConfigMapping::prefix)
-                .orElseGet(() -> Optional.ofNullable(type.getAnnotation(ConfigProperties.class)).map(ConfigProperties::prefix)
-                        .orElse(""));
+    private static void getProperties(
+            final GroupProperty groupProperty,
+            final NamingStrategy namingStrategy,
+            final Function<String, String> path,
+            final Map<Class<?>, Map<String, Map<String, Property>>> properties,
+            final Map<String, Property> groupProperties) {
 
-        return getConfigMapping(type, prefix);
+        for (Property property : groupProperty.getGroupType().getProperties()) {
+            getProperty(property, namingStrategy, path, properties, groupProperties);
+        }
     }
 
-    <T> T getConfigMapping(Class<T> type, String prefix) {
-        if (prefix == null) {
-            return getConfigMapping(type);
+    private static void getProperty(
+            final Property property,
+            final NamingStrategy namingStrategy,
+            final Function<String, String> path,
+            final Map<Class<?>, Map<String, Map<String, Property>>> properties,
+            final Map<String, Property> groupProperties) {
+
+        if (property.isLeaf()) {
+            groupProperties.put(
+                    path.apply(property.isParentPropertyName() ? "" : "." + property.getPropertyName(namingStrategy)),
+                    property);
+        } else if (property.isPrimitive()) {
+            groupProperties.put(
+                    path.apply(property.isParentPropertyName() ? "" : "." + property.getPropertyName(namingStrategy)),
+                    property);
+        } else if (property.isGroup()) {
+            GroupProperty groupProperty = property.asGroup();
+            NamingStrategy groupNamingStrategy = groupProperty.hasNamingStrategy() ? groupProperty.getNamingStrategy()
+                    : namingStrategy;
+            Function<String, String> groupPath = new Function<>() {
+                @Override
+                public String apply(final String name) {
+                    return property.isParentPropertyName() ? path.apply("") + name
+                            : path.apply("." + property.getPropertyName(namingStrategy)) + name;
+                }
+            };
+            getProperties(groupProperty, groupNamingStrategy, groupPath, properties);
+            getProperties(groupProperty, groupNamingStrategy, groupPath, properties, groupProperties);
+        } else if (property.isMap()) {
+            ConfigMappingInterface.MapProperty mapProperty = property.asMap();
+            if (mapProperty.getValueProperty().isLeaf()) {
+                groupProperties.put(property.isParentPropertyName() ? path.apply(".*")
+                        : path.apply("." + property.getPropertyName(namingStrategy) + ".*"), mapProperty);
+                if (mapProperty.hasKeyUnnamed()) {
+                    groupProperties.put(property.isParentPropertyName() ? path.apply("")
+                            : path.apply("." + property.getPropertyName(namingStrategy)), mapProperty);
+                }
+            } else if (mapProperty.getValueProperty().isGroup()) {
+                GroupProperty groupProperty = mapProperty.getValueProperty().asGroup();
+                NamingStrategy groupNamingStrategy = groupProperty.hasNamingStrategy() ? groupProperty.getNamingStrategy()
+                        : namingStrategy;
+                Function<String, String> groupPath = new Function<>() {
+                    @Override
+                    public String apply(final String name) {
+                        return property.isParentPropertyName() ? path.apply(".*") + name
+                                : path.apply("." + mapProperty.getPropertyName(namingStrategy) + ".*") + name;
+                    }
+                };
+                getProperties(groupProperty, groupNamingStrategy, groupPath, properties);
+                getProperties(groupProperty, groupNamingStrategy, groupPath, properties, groupProperties);
+                if (mapProperty.hasKeyUnnamed()) {
+                    Function<String, String> unnamedGroupPath = new Function<>() {
+                        @Override
+                        public String apply(final String name) {
+                            return property.isParentPropertyName() ? path.apply(name)
+                                    : path.apply("." + mapProperty.getPropertyName(namingStrategy)) + name;
+                        }
+                    };
+                    getProperties(groupProperty, groupNamingStrategy, unnamedGroupPath, properties);
+                    getProperties(groupProperty, groupNamingStrategy, unnamedGroupPath, properties, groupProperties);
+                }
+            } else if (mapProperty.getValueProperty().isCollection()) {
+                CollectionProperty collectionProperty = mapProperty.getValueProperty().asCollection();
+                Property element = collectionProperty.getElement();
+                if (element.isLeaf()) {
+                    LeafProperty leafProperty = new LeafProperty(element.getMethod(), element.getPropertyName(),
+                            element.asLeaf().getValueType(), element.asLeaf().getConvertWith(), null);
+                    getProperty(leafProperty, namingStrategy, new Function<String, String>() {
+                        @Override
+                        public String apply(final String name) {
+                            return path.apply(name + ".*");
+                        }
+                    }, properties, groupProperties);
+                }
+                getProperty(element, namingStrategy, new Function<String, String>() {
+                    @Override
+                    public String apply(final String name) {
+                        return path.apply(name + ".*[*]");
+                    }
+                }, properties, groupProperties);
+                if (mapProperty.hasKeyUnnamed()) {
+                    getProperty(element, namingStrategy, new Function<String, String>() {
+                        @Override
+                        public String apply(final String name) {
+                            return path.apply(name + "[*]");
+                        }
+                    }, properties, groupProperties);
+                }
+            } else if (mapProperty.getValueProperty().isMap()) {
+                getProperty(mapProperty.getValueProperty(), namingStrategy,
+                        new Function<String, String>() {
+                            @Override
+                            public String apply(final String name) {
+                                return path.apply(name + ".*");
+                            }
+                        }, properties, groupProperties);
+                if (mapProperty.hasKeyUnnamed()) {
+                    getProperty(mapProperty.getValueProperty(), namingStrategy,
+                            new Function<String, String>() {
+                                @Override
+                                public String apply(final String name) {
+                                    return path.apply(name);
+                                }
+                            }, properties, groupProperties);
+                }
+            }
+        } else if (property.isCollection()) {
+            CollectionProperty collectionProperty = property.asCollection();
+            if (collectionProperty.getElement().isLeaf()) {
+                getProperty(collectionProperty.getElement(), namingStrategy, path, properties, groupProperties);
+            }
+            getProperty(collectionProperty.getElement(), namingStrategy, new Function<String, String>() {
+                @Override
+                public String apply(final String name) {
+                    return path.apply(name.endsWith(".*") ? name.substring(0, name.length() - 2) + "[*].*" : name + "[*]");
+                }
+            }, properties, groupProperties);
+        } else if (property.isOptional()) {
+            getProperty(property.asOptional().getNestedProperty(), namingStrategy, path, properties, groupProperties);
         }
-
-        final Map<String, ConfigMappingObject> mappingsForType = mappings.get(getConfigMappingClass(type));
-        if (mappingsForType == null) {
-            throw ConfigMessages.msg.mappingNotFound(type.getName());
-        }
-
-        final ConfigMappingObject configMappingObject = mappingsForType.get(prefix);
-        if (configMappingObject == null) {
-            throw ConfigMessages.msg.mappingPrefixNotFound(type.getName(), prefix);
-        }
-
-        Object value = configMappingObject;
-        if (configMappingObject instanceof ConfigMappingClassMapper) {
-            value = ((ConfigMappingClassMapper) configMappingObject).map();
-        }
-
-        configValidator.validateMapping(type, prefix, value);
-
-        return type.cast(value);
     }
 
     static String getPrefix(Class<?> type) {

--- a/implementation/src/main/java/io/smallrye/config/DefaultValuesConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/DefaultValuesConfigSource.java
@@ -11,7 +11,7 @@ public final class DefaultValuesConfigSource extends AbstractConfigSource {
 
     private final Map<String, String> properties;
 
-    private final KeyMap<String> wildcards;
+    private final Map<PropertyName, String> wildcards;
 
     public DefaultValuesConfigSource(final Map<String, String> properties) {
         this(properties, "DefaultValuesConfigSource", Integer.MIN_VALUE);
@@ -20,7 +20,7 @@ public final class DefaultValuesConfigSource extends AbstractConfigSource {
     public DefaultValuesConfigSource(final Map<String, String> properties, final String name, final int ordinal) {
         super(name, ordinal);
         this.properties = new HashMap<>();
-        this.wildcards = new KeyMap<>();
+        this.wildcards = new HashMap<>();
         addDefaults(properties);
     }
 
@@ -30,20 +30,20 @@ public final class DefaultValuesConfigSource extends AbstractConfigSource {
     }
 
     public String getValue(final String propertyName) {
-        String value = properties.get(propertyName);
-        return value == null && !wildcards.isEmpty() ? wildcards.findRootValue(propertyName) : value;
+        return properties.getOrDefault(propertyName, wildcards.get(new PropertyName(propertyName)));
     }
 
     void addDefaults(final Map<String, String> properties) {
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-            if (entry.getKey().indexOf('*') == -1) {
-                this.properties.putIfAbsent(entry.getKey(), entry.getValue());
-            } else {
-                KeyMap<String> key = this.wildcards.findOrAdd(entry.getKey());
-                if (!key.hasRootValue()) {
-                    key.putRootValue(entry.getValue());
-                }
-            }
+            addDefault(entry.getKey(), entry.getValue());
+        }
+    }
+
+    void addDefault(final String name, final String value) {
+        if (name.indexOf('*') == -1) {
+            this.properties.putIfAbsent(name, value);
+        } else {
+            this.wildcards.put(new PropertyName(name), value);
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/PropertyName.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertyName.java
@@ -1,0 +1,107 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.common.utils.StringUtil.isNumeric;
+
+public class PropertyName {
+    private final String name;
+
+    public PropertyName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PropertyName that = (PropertyName) o;
+        return equals(this.name, that.name) || equals(that.name, this.name);
+    }
+
+    static boolean equals(final String name, final String other) {
+        //noinspection StringEquality
+        if (name == other) {
+            return true;
+        }
+
+        char n;
+        char o;
+
+        int matchPosition = name.length() - 1;
+        for (int i = other.length() - 1; i >= 0; i--) {
+            if (matchPosition == -1) {
+                return false;
+            }
+
+            o = other.charAt(i);
+            n = name.charAt(matchPosition);
+
+            if (n == '*') {
+                if (o == ']') {
+                    return false;
+                } else if (o == '"') {
+                    int beginQuote = other.lastIndexOf('"', i - 1);
+                    if (beginQuote != -1 && beginQuote != 0 && other.charAt(beginQuote - 1) == '.') {
+                        i = beginQuote;
+                    }
+                } else {
+                    int previousDot = other.lastIndexOf('.', i);
+                    if (previousDot != -1) {
+                        i = previousDot + 1;
+                    } else {
+                        i = 0;
+                    }
+                }
+            } else if (n == ']' && o == ']') {
+                if (name.length() >= 3 && other.length() >= 3
+                        && name.charAt(matchPosition - 1) == '*' && name.charAt(matchPosition - 2) == '['
+                        && other.charAt(i - 1) == '*' && other.charAt(i - 2) == '[') {
+                    matchPosition = matchPosition - 2;
+                    i = i - 1;
+                    continue;
+                } else {
+                    int beginIndexed = other.lastIndexOf('[', i);
+                    if (beginIndexed != -1) {
+                        int range = i - beginIndexed - 1;
+                        if (isNumeric(other, beginIndexed + range, i)) {
+                            matchPosition = matchPosition - 3;
+                            i = i - range - 1;
+                            continue;
+                        }
+                    }
+                }
+                return false;
+            } else if (o != n) {
+                return false;
+            }
+            matchPosition--;
+        }
+        return matchPosition <= 0;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 0;
+        int length = name.length();
+        boolean quotesOpen = false;
+        for (int i = 0; i < length; i++) {
+            char c = name.charAt(i);
+            if (quotesOpen) {
+                if (c == '"') {
+                    quotesOpen = false;
+                }
+                continue;
+            } else if (c == '"') {
+                quotesOpen = true;
+                continue;
+            } else if (c != '.' && c != '[' && c != ']') {
+                continue;
+            }
+            h = 31 * h + c;
+        }
+        return h;
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -15,36 +15,36 @@ import org.junit.jupiter.api.Test;
 class ConfigMappingClassTest {
     @Test
     void toClass() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerClass.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerClass.class)
                 .withDefaultValue("host", "localhost")
                 .withDefaultValue("port", "8080")
                 .build();
 
-        final ServerClass server = config.getConfigMapping(ServerClass.class);
+        ServerClass server = config.getConfigMapping(ServerClass.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
 
     @Test
     void privateFields() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerPrivate.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerPrivate.class)
                 .withDefaultValue("host", "localhost")
                 .withDefaultValue("port", "8080")
                 .build();
 
-        final ServerPrivate server = config.getConfigMapping(ServerPrivate.class);
+        ServerPrivate server = config.getConfigMapping(ServerPrivate.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
 
     @Test
     void optionals() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerOptional.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerOptional.class)
                 .withDefaultValue("host", "localhost")
                 .withDefaultValue("port", "8080")
                 .build();
 
-        final ServerOptional server = config.getConfigMapping(ServerOptional.class);
+        ServerOptional server = config.getConfigMapping(ServerOptional.class);
         assertTrue(server.getHost().isPresent());
         assertEquals("localhost", server.getHost().get());
         assertTrue(server.getPort().isPresent());
@@ -53,38 +53,38 @@ class ConfigMappingClassTest {
 
     @Test
     void names() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerNames.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerNames.class)
                 .withDefaultValue("h", "localhost")
                 .withDefaultValue("p", "8080")
                 .build();
-        final ServerNames server = config.getConfigMapping(ServerNames.class);
+        ServerNames server = config.getConfigMapping(ServerNames.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
 
     @Test
     void defaults() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerDefaults.class).build();
-        final ServerDefaults server = config.getConfigMapping(ServerDefaults.class);
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerDefaults.class).build();
+        ServerDefaults server = config.getConfigMapping(ServerDefaults.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
 
     @Test
     void converters() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerConverters.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerConverters.class)
                 .withConverters(new Converter[] { new ServerPortConverter() }).build();
-        final ServerConverters server = config.getConfigMapping(ServerConverters.class);
+        ServerConverters server = config.getConfigMapping(ServerConverters.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort().getPort());
     }
 
     @Test
     void initialized() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerInitialized.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerInitialized.class)
                 .withDefaultValue("host", "localhost")
                 .build();
-        final ServerInitialized server = config.getConfigMapping(ServerInitialized.class);
+        ServerInitialized server = config.getConfigMapping(ServerInitialized.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
@@ -96,10 +96,10 @@ class ConfigMappingClassTest {
 
     @Test
     void mpConfig20() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerMPConfig20.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerMPConfig20.class)
                 .withDefaultValue("name", "localhost")
                 .build();
-        final ServerMPConfig20 server = config.getConfigMapping(ServerMPConfig20.class);
+        ServerMPConfig20 server = config.getConfigMapping(ServerMPConfig20.class);
         assertEquals("localhost", server.getHost());
         assertEquals(8080, server.getPort());
     }
@@ -115,12 +115,12 @@ class ConfigMappingClassTest {
 
     @Test
     void camelCase() {
-        final SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerCamelCase.class)
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerCamelCase.class)
                 .withDefaultValue("theHost", "localhost")
                 .withDefaultValue("thePort", "8080")
                 .build();
 
-        final ServerCamelCase server = config.getConfigMapping(ServerCamelCase.class);
+        ServerCamelCase server = config.getConfigMapping(ServerCamelCase.class);
         assertEquals("localhost", server.getTheHost());
         assertEquals(8080, server.getThePort());
     }
@@ -213,7 +213,7 @@ class ConfigMappingClassTest {
     static class ServerPort {
         private int port;
 
-        public ServerPort(final String port) {
+        public ServerPort(String port) {
             this.port = Integer.parseInt(port);
         }
 

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingDefaultsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingDefaultsTest.java
@@ -1,0 +1,604 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.ConfigMappings.getDefaults;
+import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
+import static io.smallrye.config.KeyValuesConfigSource.config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.ConfigMappingDefaultsTest.DataSourcesJdbcBuildTimeConfig.DataSourceJdbcOuterNamedBuildTimeConfig;
+
+public class ConfigMappingDefaultsTest {
+    @Test
+    void defaults() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "defaults.list-nested[0].value", "value",
+                        "defaults.parent.list-nested[0].value", "value"))
+                .withMapping(Defaults.class)
+                .build();
+
+        Defaults mapping = config.getConfigMapping(Defaults.class);
+
+        assertEquals("value", mapping.value());
+        assertEquals(10, mapping.primitive());
+        assertTrue(mapping.optional().isPresent());
+        assertEquals("value", mapping.optional().get());
+        assertTrue(mapping.optionalPrimitive().isPresent());
+        assertEquals(10, mapping.optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.list());
+        assertEquals("value", mapping.map().get("default"));
+
+        assertEquals("value", mapping.nested().value());
+        assertEquals(10, mapping.nested().primitive());
+        assertTrue(mapping.nested().optional().isPresent());
+        assertEquals("value", mapping.nested().optional().get());
+        assertTrue(mapping.nested().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.nested().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.nested().list());
+        assertEquals("value", mapping.nested().map().get("default"));
+
+        assertTrue(mapping.optionalNested().isPresent());
+        assertEquals("value", mapping.optionalNested().get().value());
+        assertEquals(10, mapping.optionalNested().get().primitive());
+        assertTrue(mapping.optionalNested().get().optional().isPresent());
+        assertEquals("value", mapping.optionalNested().get().optional().get());
+        assertTrue(mapping.optionalNested().get().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.optionalNested().get().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.optionalNested().get().list());
+        assertEquals("value", mapping.optionalNested().get().map().get("default"));
+
+        assertEquals("value", mapping.listNested().get(0).value());
+        assertEquals(10, mapping.listNested().get(0).primitive());
+        assertTrue(mapping.listNested().get(0).optional().isPresent());
+        assertEquals("value", mapping.listNested().get(0).optional().get());
+        assertTrue(mapping.listNested().get(0).optionalPrimitive().isPresent());
+        assertEquals(10, mapping.listNested().get(0).optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.listNested().get(0).list());
+        assertEquals("value", mapping.listNested().get(0).map().get("default"));
+
+        assertEquals("value", mapping.mapNested().get("default").value());
+        assertEquals(10, mapping.mapNested().get("default").primitive());
+        assertTrue(mapping.mapNested().get("default").optional().isPresent());
+        assertEquals("value", mapping.mapNested().get("default").optional().get());
+        assertTrue(mapping.mapNested().get("default").optionalPrimitive().isPresent());
+        assertEquals(10, mapping.mapNested().get("default").optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.mapNested().get("default").list());
+        assertEquals("value", mapping.mapNested().get("default").map().get("default"));
+
+        assertEquals("value", mapping.parent().child().nested().value());
+        assertEquals(10, mapping.parent().child().nested().primitive());
+        assertTrue(mapping.parent().child().nested().optional().isPresent());
+        assertEquals("value", mapping.parent().child().nested().optional().get());
+        assertTrue(mapping.parent().child().nested().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().nested().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().nested().list());
+        assertEquals("value", mapping.parent().child().nested().map().get("default"));
+
+        assertTrue(mapping.parent().child().optionalNested().isPresent());
+        assertEquals("value", mapping.parent().child().optionalNested().get().value());
+        assertEquals(10, mapping.parent().child().optionalNested().get().primitive());
+        assertTrue(mapping.parent().child().optionalNested().get().optional().isPresent());
+        assertEquals("value", mapping.parent().child().optionalNested().get().optional().get());
+        assertTrue(mapping.parent().child().optionalNested().get().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().optionalNested().get().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().optionalNested().get().list());
+        assertEquals("value", mapping.parent().child().optionalNested().get().map().get("default"));
+
+        assertEquals("value", mapping.parent().child().listNested().get(0).value());
+        assertEquals(10, mapping.parent().child().listNested().get(0).primitive());
+        assertTrue(mapping.parent().child().listNested().get(0).optional().isPresent());
+        assertEquals("value", mapping.parent().child().listNested().get(0).optional().get());
+        assertTrue(mapping.parent().child().listNested().get(0).optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().listNested().get(0).optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().listNested().get(0).list());
+        assertEquals("value", mapping.parent().child().listNested().get(0).map().get("default"));
+
+        assertEquals("value", mapping.parent().child().mapNested().get("default").value());
+        assertEquals(10, mapping.parent().child().mapNested().get("default").primitive());
+        assertTrue(mapping.parent().child().mapNested().get("default").optional().isPresent());
+        assertEquals("value", mapping.parent().child().mapNested().get("default").optional().get());
+        assertTrue(mapping.parent().child().mapNested().get("default").optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().mapNested().get("default").optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().mapNested().get("default").list());
+        assertEquals("value", mapping.parent().child().mapNested().get("default").map().get("default"));
+    }
+
+    @Test
+    void emptyPrefix() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "list-nested[0].value", "value",
+                        "parent.list-nested[0].value", "value"))
+                .withMapping(Defaults.class, "")
+                .build();
+
+        Defaults mapping = config.getConfigMapping(Defaults.class, "");
+
+        assertEquals("value", mapping.value());
+        assertEquals(10, mapping.primitive());
+        assertTrue(mapping.optional().isPresent());
+        assertEquals("value", mapping.optional().get());
+        assertTrue(mapping.optionalPrimitive().isPresent());
+        assertEquals(10, mapping.optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.list());
+        assertEquals("value", mapping.map().get("default"));
+
+        assertEquals("value", mapping.nested().value());
+        assertEquals(10, mapping.nested().primitive());
+        assertTrue(mapping.nested().optional().isPresent());
+        assertEquals("value", mapping.nested().optional().get());
+        assertTrue(mapping.nested().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.nested().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.nested().list());
+        assertEquals("value", mapping.nested().map().get("default"));
+
+        assertTrue(mapping.optionalNested().isPresent());
+        assertEquals("value", mapping.optionalNested().get().value());
+        assertEquals(10, mapping.optionalNested().get().primitive());
+        assertTrue(mapping.optionalNested().get().optional().isPresent());
+        assertEquals("value", mapping.optionalNested().get().optional().get());
+        assertTrue(mapping.optionalNested().get().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.optionalNested().get().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.optionalNested().get().list());
+        assertEquals("value", mapping.optionalNested().get().map().get("default"));
+
+        assertEquals("value", mapping.listNested().get(0).value());
+        assertEquals(10, mapping.listNested().get(0).primitive());
+        assertTrue(mapping.listNested().get(0).optional().isPresent());
+        assertEquals("value", mapping.listNested().get(0).optional().get());
+        assertTrue(mapping.listNested().get(0).optionalPrimitive().isPresent());
+        assertEquals(10, mapping.listNested().get(0).optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.listNested().get(0).list());
+        assertEquals("value", mapping.listNested().get(0).map().get("default"));
+
+        assertEquals("value", mapping.mapNested().get("default").value());
+        assertEquals(10, mapping.mapNested().get("default").primitive());
+        assertTrue(mapping.mapNested().get("default").optional().isPresent());
+        assertEquals("value", mapping.mapNested().get("default").optional().get());
+        assertTrue(mapping.mapNested().get("default").optionalPrimitive().isPresent());
+        assertEquals(10, mapping.mapNested().get("default").optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.mapNested().get("default").list());
+        assertEquals("value", mapping.mapNested().get("default").map().get("default"));
+
+        assertEquals("value", mapping.parent().child().nested().value());
+        assertEquals(10, mapping.parent().child().nested().primitive());
+        assertTrue(mapping.parent().child().nested().optional().isPresent());
+        assertEquals("value", mapping.parent().child().nested().optional().get());
+        assertTrue(mapping.parent().child().nested().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().nested().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().nested().list());
+        assertEquals("value", mapping.parent().child().nested().map().get("default"));
+
+        assertTrue(mapping.parent().child().optionalNested().isPresent());
+        assertEquals("value", mapping.parent().child().optionalNested().get().value());
+        assertEquals(10, mapping.parent().child().optionalNested().get().primitive());
+        assertTrue(mapping.parent().child().optionalNested().get().optional().isPresent());
+        assertEquals("value", mapping.parent().child().optionalNested().get().optional().get());
+        assertTrue(mapping.parent().child().optionalNested().get().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().optionalNested().get().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().optionalNested().get().list());
+        assertEquals("value", mapping.parent().child().optionalNested().get().map().get("default"));
+
+        assertEquals("value", mapping.parent().child().listNested().get(0).value());
+        assertEquals(10, mapping.parent().child().listNested().get(0).primitive());
+        assertTrue(mapping.parent().child().listNested().get(0).optional().isPresent());
+        assertEquals("value", mapping.parent().child().listNested().get(0).optional().get());
+        assertTrue(mapping.parent().child().listNested().get(0).optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().listNested().get(0).optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().listNested().get(0).list());
+        assertEquals("value", mapping.parent().child().listNested().get(0).map().get("default"));
+
+        assertEquals("value", mapping.parent().child().mapNested().get("default").value());
+        assertEquals(10, mapping.parent().child().mapNested().get("default").primitive());
+        assertTrue(mapping.parent().child().mapNested().get("default").optional().isPresent());
+        assertEquals("value", mapping.parent().child().mapNested().get("default").optional().get());
+        assertTrue(mapping.parent().child().mapNested().get("default").optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().mapNested().get("default").optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().mapNested().get("default").list());
+        assertEquals("value", mapping.parent().child().mapNested().get("default").map().get("default"));
+    }
+
+    @ConfigMapping(prefix = "defaults")
+    interface Defaults {
+        @WithDefault("value")
+        String value();
+
+        @WithDefault("10")
+        int primitive();
+
+        @WithDefault("value")
+        Optional<String> optional();
+
+        @WithDefault("10")
+        OptionalInt optionalPrimitive();
+
+        @WithDefault("one,two")
+        List<String> list();
+
+        @WithDefault("value")
+        Map<String, String> map();
+
+        Nested nested();
+
+        Optional<Nested> optionalNested();
+
+        List<Nested> listNested();
+
+        @WithDefaults
+        Map<String, Nested> mapNested();
+
+        Parent parent();
+
+        interface Nested {
+            @WithDefault("value")
+            String value();
+
+            @WithDefault("10")
+            int primitive();
+
+            @WithDefault("value")
+            Optional<String> optional();
+
+            @WithDefault("10")
+            OptionalInt optionalPrimitive();
+
+            @WithDefault("one,two")
+            List<String> list();
+
+            @WithDefault("value")
+            Map<String, String> map();
+        }
+
+        interface Parent {
+            @WithParentName
+            Child child();
+        }
+
+        interface Child {
+            Nested nested();
+
+            Optional<Nested> optionalNested();
+
+            List<Nested> listNested();
+
+            @WithDefaults
+            Map<String, Nested> mapNested();
+        }
+    }
+
+    @Test
+    void defaultsNamingStrategy() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "defaults.listNested[0].value", "value",
+                        "defaults.parent.listNested[0].value", "value"))
+                .withMapping(DefaultsWithNamingStrategy.class)
+                .build();
+
+        DefaultsWithNamingStrategy mapping = config.getConfigMapping(DefaultsWithNamingStrategy.class);
+
+        assertEquals("value", mapping.value());
+        assertEquals(10, mapping.primitive());
+        assertTrue(mapping.optional().isPresent());
+        assertEquals("value", mapping.optional().get());
+        assertTrue(mapping.optionalPrimitive().isPresent());
+        assertEquals(10, mapping.optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.list());
+        assertEquals("value", mapping.map().get("default"));
+
+        assertEquals("value", mapping.nested().value());
+        assertEquals(10, mapping.nested().primitive());
+        assertTrue(mapping.nested().optional().isPresent());
+        assertEquals("value", mapping.nested().optional().get());
+        assertTrue(mapping.nested().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.nested().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.nested().list());
+        assertEquals("value", mapping.nested().map().get("default"));
+
+        assertTrue(mapping.optionalNested().isPresent());
+        assertEquals("value", mapping.optionalNested().get().value());
+        assertEquals(10, mapping.optionalNested().get().primitive());
+        assertTrue(mapping.optionalNested().get().optional().isPresent());
+        assertEquals("value", mapping.optionalNested().get().optional().get());
+        assertTrue(mapping.optionalNested().get().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.optionalNested().get().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.optionalNested().get().list());
+        assertEquals("value", mapping.optionalNested().get().map().get("default"));
+
+        assertEquals("value", mapping.listNested().get(0).value());
+        assertEquals(10, mapping.listNested().get(0).primitive());
+        assertTrue(mapping.listNested().get(0).optional().isPresent());
+        assertEquals("value", mapping.listNested().get(0).optional().get());
+        assertTrue(mapping.listNested().get(0).optionalPrimitive().isPresent());
+        assertEquals(10, mapping.listNested().get(0).optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.listNested().get(0).list());
+        assertEquals("value", mapping.listNested().get(0).map().get("default"));
+
+        assertEquals("value", mapping.mapNested().get("default").value());
+        assertEquals(10, mapping.mapNested().get("default").primitive());
+        assertTrue(mapping.mapNested().get("default").optional().isPresent());
+        assertEquals("value", mapping.mapNested().get("default").optional().get());
+        assertTrue(mapping.mapNested().get("default").optionalPrimitive().isPresent());
+        assertEquals(10, mapping.mapNested().get("default").optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.mapNested().get("default").list());
+        assertEquals("value", mapping.mapNested().get("default").map().get("default"));
+
+        assertEquals("value", mapping.parent().child().nested().value());
+        assertEquals(10, mapping.parent().child().nested().primitive());
+        assertTrue(mapping.parent().child().nested().optional().isPresent());
+        assertEquals("value", mapping.parent().child().nested().optional().get());
+        assertTrue(mapping.parent().child().nested().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().nested().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().nested().list());
+        assertEquals("value", mapping.parent().child().nested().map().get("default"));
+
+        assertTrue(mapping.parent().child().optionalNested().isPresent());
+        assertEquals("value", mapping.parent().child().optionalNested().get().value());
+        assertEquals(10, mapping.parent().child().optionalNested().get().primitive());
+        assertTrue(mapping.parent().child().optionalNested().get().optional().isPresent());
+        assertEquals("value", mapping.parent().child().optionalNested().get().optional().get());
+        assertTrue(mapping.parent().child().optionalNested().get().optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().optionalNested().get().optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().optionalNested().get().list());
+        assertEquals("value", mapping.parent().child().optionalNested().get().map().get("default"));
+
+        assertEquals("value", mapping.parent().child().listNested().get(0).value());
+        assertEquals(10, mapping.parent().child().listNested().get(0).primitive());
+        assertTrue(mapping.parent().child().listNested().get(0).optional().isPresent());
+        assertEquals("value", mapping.parent().child().listNested().get(0).optional().get());
+        assertTrue(mapping.parent().child().listNested().get(0).optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().listNested().get(0).optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().listNested().get(0).list());
+        assertEquals("value", mapping.parent().child().listNested().get(0).map().get("default"));
+
+        assertEquals("value", mapping.parent().child().mapNested().get("default").value());
+        assertEquals(10, mapping.parent().child().mapNested().get("default").primitive());
+        assertTrue(mapping.parent().child().mapNested().get("default").optional().isPresent());
+        assertEquals("value", mapping.parent().child().mapNested().get("default").optional().get());
+        assertTrue(mapping.parent().child().mapNested().get("default").optionalPrimitive().isPresent());
+        assertEquals(10, mapping.parent().child().mapNested().get("default").optionalPrimitive().getAsInt());
+        assertIterableEquals(List.of("one", "two"), mapping.parent().child().mapNested().get("default").list());
+        assertEquals("value", mapping.parent().child().mapNested().get("default").map().get("default"));
+    }
+
+    @ConfigMapping(prefix = "defaults", namingStrategy = ConfigMapping.NamingStrategy.VERBATIM)
+    interface DefaultsWithNamingStrategy {
+        @WithDefault("value")
+        String value();
+
+        @WithDefault("10")
+        int primitive();
+
+        @WithDefault("value")
+        Optional<String> optional();
+
+        @WithDefault("10")
+        OptionalInt optionalPrimitive();
+
+        @WithDefault("one,two")
+        List<String> list();
+
+        @WithDefault("value")
+        Map<String, String> map();
+
+        Nested nested();
+
+        Optional<Nested> optionalNested();
+
+        List<Nested> listNested();
+
+        @WithDefaults
+        Map<String, Nested> mapNested();
+
+        Parent parent();
+
+        interface Nested {
+            @WithDefault("value")
+            String value();
+
+            @WithDefault("10")
+            int primitive();
+
+            @WithDefault("value")
+            Optional<String> optional();
+
+            @WithDefault("10")
+            OptionalInt optionalPrimitive();
+
+            @WithDefault("one,two")
+            List<String> list();
+
+            @WithDefault("value")
+            Map<String, String> map();
+        }
+
+        interface Parent {
+            @WithParentName
+            Child child();
+        }
+
+        interface Child {
+            Nested nested();
+
+            Optional<Nested> optionalNested();
+
+            List<Nested> listNested();
+
+            @WithDefaults
+            Map<String, Nested> mapNested();
+        }
+    }
+
+    @Test
+    void defaultsParentName() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(DefaultsParentName.class)
+                .build();
+
+        // TODO - Complete
+    }
+
+    @ConfigMapping(prefix = "defaults")
+    interface DefaultsParentName {
+        @WithParentName
+        @WithDefault("value")
+        String value();
+    }
+
+    @Test
+    void moreDefaults() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(DataSourcesJdbcBuildTimeConfig.class)
+                .withMapping(DataSourcesJdbcRuntimeConfig.class)
+                .build();
+
+        DataSourcesJdbcBuildTimeConfig mapping = config.getConfigMapping(DataSourcesJdbcBuildTimeConfig.class);
+        DataSourceJdbcOuterNamedBuildTimeConfig mapDefault = mapping.dataSources().get("<default>");
+        assertNotNull(mapDefault);
+        assertTrue(mapDefault.jdbc().enabled());
+        assertFalse(mapDefault.jdbc().tracing());
+        assertFalse(mapDefault.jdbc().telemetry());
+    }
+
+    @ConfigMapping(prefix = "quarkus.datasource")
+    public interface DataSourcesJdbcBuildTimeConfig {
+
+        @WithParentName
+        @WithDefaults
+        @WithUnnamedKey("<default>")
+        Map<String, DataSourceJdbcOuterNamedBuildTimeConfig> dataSources();
+
+        interface DataSourceJdbcOuterNamedBuildTimeConfig {
+            DataSourceJdbcBuildTimeConfig jdbc();
+        }
+
+        interface DataSourceJdbcBuildTimeConfig {
+            @WithParentName
+            @WithDefault("true")
+            boolean enabled();
+
+            Optional<String> driver();
+
+            Optional<Boolean> enableMetrics();
+
+            @WithDefault("false")
+            boolean tracing();
+
+            @WithDefault("false")
+            boolean telemetry();
+        }
+    }
+
+    @ConfigMapping(prefix = "quarkus.datasource")
+    public interface DataSourcesJdbcRuntimeConfig {
+
+        DataSourceJdbcRuntimeConfig jdbc();
+
+        @WithParentName
+        @WithDefaults
+        Map<String, DataSourceJdbcOuterNamedRuntimeConfig> namedDataSources();
+
+        interface DataSourceJdbcOuterNamedRuntimeConfig {
+            DataSourceJdbcRuntimeConfig jdbc();
+        }
+
+        interface DataSourceJdbcRuntimeConfig {
+            @WithDefault("0")
+            int minSize();
+
+            @WithDefault("20")
+            int maxSize();
+
+            @WithDefault("2M")
+            String backgroundValidationInterval();
+
+            @WithDefault("5S")
+            Optional<String> acquisitionTimeout();
+
+            @WithDefault("5M")
+            String idleRemovalInterval();
+
+            @WithDefault("false")
+            boolean extendedLeakReport();
+
+            @WithDefault("false")
+            boolean flushOnClose();
+
+            @WithDefault("true")
+            boolean detectStatementLeaks();
+
+            @WithDefault("true")
+            boolean poolingEnabled();
+
+            DataSourceJdbcTracingRuntimeConfig tracing();
+
+            interface DataSourceJdbcTracingRuntimeConfig {
+                @WithDefault("false")
+                boolean traceWithActiveSpanOnly();
+            }
+        }
+    }
+
+    @Test
+    void parentDefaults() {
+        Map<String, String> defaults = getDefaults(configClassWithPrefix(ExtendsBase.class));
+        assertEquals(2, defaults.size());
+        assertEquals("default", defaults.get("base.base"));
+        assertEquals("default", defaults.get("base.my-prop"));
+    }
+
+    public interface Base {
+        @WithDefault("default")
+        String base();
+    }
+
+    @ConfigMapping(prefix = "base")
+    public interface ExtendsBase extends Base {
+        @WithDefault("default")
+        String myProp();
+    }
+
+    @Test
+    void mapDefaults() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(MapDefaults.class)
+                .build();
+
+        MapDefaults mapping = config.getConfigMapping(MapDefaults.class);
+        assertIterableEquals(List.of("foo", "bar"), mapping.map().get("any"));
+
+        config = new SmallRyeConfigBuilder()
+                .withSources(config("map.defaults.any", "one,two"))
+                .withMapping(MapDefaults.class)
+                .build();
+
+        mapping = config.getConfigMapping(MapDefaults.class);
+        assertIterableEquals(List.of("one", "two"), mapping.map().get("any"));
+
+        config = new SmallRyeConfigBuilder()
+                .withSources(config("map.defaults.any[0]", "one", "map.defaults.any[1]", "two"))
+                .withMapping(MapDefaults.class)
+                .build();
+
+        mapping = config.getConfigMapping(MapDefaults.class);
+        assertIterableEquals(List.of("one", "two"), mapping.map().get("any"));
+    }
+
+    @ConfigMapping(prefix = "map.defaults")
+    interface MapDefaults {
+        @WithParentName
+        @WithDefault("foo,bar")
+        Map<String, List<String>> map();
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
@@ -1,0 +1,604 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.ConfigMappings.getNames;
+import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
+import static io.smallrye.config.KeyValuesConfigSource.config;
+import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+public class ObjectCreatorTest {
+    @Test
+    void objectCreator() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "unnamed.value", "unnamed",
+                        "unnamed.key.value", "value"))
+                .withSources(config(
+                        "list-map[0].key", "value",
+                        "list-map[0].another", "another"))
+                .withSources(config(
+                        "list-group[0].value", "value"))
+                .withSources(config(
+                        "map-group.key.value", "value"))
+                .withSources(config(
+                        "optional-group.value", "value"))
+                .withSources(config(
+                        "group.value", "value"))
+                .withSources(config(
+                        "value", "value"))
+                .withSources(config(
+                        "optional-value", "value"))
+                .withSources(config(
+                        "optional-list", "value"))
+                .withSources(config(
+                        "optional-list-group[0].value", "value"))
+                .build();
+
+        ConfigMappingContext context = new ConfigMappingContext(config, new HashMap<>(),
+                getNames(configClassWithPrefix(ObjectCreator.class)));
+        ObjectCreator mapping = new ObjectCreatorImpl(context);
+
+        assertEquals(2, mapping.unnamed().size());
+        assertEquals("unnamed", mapping.unnamed().get("unnamed").value());
+        assertEquals("value", mapping.unnamed().get("key").value());
+
+        assertEquals("value", mapping.listMap().get(0).get("key"));
+        assertEquals("another", mapping.listMap().get(0).get("another"));
+
+        assertEquals("value", mapping.listGroup().get(0).value());
+
+        assertEquals("value", mapping.mapGroup().get("key").value());
+
+        assertTrue(mapping.optionalGroup().isPresent());
+        assertEquals("value", mapping.optionalGroup().get().value());
+        assertTrue(mapping.optionalGroupMissing().isEmpty());
+        assertEquals("value", mapping.group().value());
+
+        assertEquals("value", mapping.value());
+        assertTrue(mapping.optionalValue().isPresent());
+        assertEquals("value", mapping.optionalValue().get());
+        assertTrue(mapping.optionalList().isPresent());
+        assertEquals("value", mapping.optionalList().get().get(0));
+        assertTrue(mapping.optionalListGroup().isPresent());
+        assertEquals("value", mapping.optionalListGroup().get().get(0).value());
+        assertTrue(mapping.optionalListGroupMissing().isEmpty());
+
+        assertTrue(context.getProblems().isEmpty());
+    }
+
+    @ConfigMapping
+    interface ObjectCreator {
+        @WithUnnamedKey
+        Map<String, Nested> unnamed();
+
+        List<Map<String, String>> listMap();
+
+        List<Nested> listGroup();
+
+        Map<String, Nested> mapGroup();
+
+        Optional<Nested> optionalGroup();
+
+        Optional<Nested> optionalGroupMissing();
+
+        Nested group();
+
+        String value();
+
+        Optional<String> optionalValue();
+
+        Optional<List<String>> optionalList();
+
+        Optional<List<Nested>> optionalListGroup();
+
+        Optional<List<Nested>> optionalListGroupMissing();
+
+        interface Nested {
+            String value();
+        }
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    static class ObjectCreatorImpl implements ObjectCreator {
+        Map<String, Nested> unnamed;
+        List<Map<String, String>> listMap;
+        List<Nested> listGroup;
+        Map<String, Nested> mapGroup;
+        Optional<Nested> optionalGroup;
+        Optional<Nested> optionalGroupMissing;
+        Nested group;
+        String value;
+        Optional<String> optionalValue;
+        Optional<List<String>> optionalList;
+        Optional<List<Nested>> optionalListGroup;
+        Optional<List<Nested>> optionalListGroupMissing;
+
+        @SuppressWarnings("unchecked")
+        public ObjectCreatorImpl(ConfigMappingContext context) {
+            StringBuilder sb = context.getStringBuilder();
+            int length = sb.length();
+            ConfigMapping.NamingStrategy ns = ConfigMapping.NamingStrategy.KEBAB_CASE;
+
+            sb.append(ns.apply("unnamed"));
+            ConfigMappingContext.ObjectCreator<Map<String, Nested>> unnamed = context.new ObjectCreator<Map<String, Nested>>(
+                    sb.toString())
+                    .map(String.class, null, "unnamed")
+                    .lazyGroup(Nested.class);
+            this.unnamed = unnamed.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("list-map"));
+            ConfigMappingContext.ObjectCreator<List<Map<String, String>>> listMap = context.new ObjectCreator<List<Map<String, String>>>(
+                    sb.toString()).collection(List.class).values(String.class, null, String.class, null, null);
+            this.listMap = listMap.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("list-group"));
+            ConfigMappingContext.ObjectCreator<List<Nested>> listGroup = context.new ObjectCreator<List<Nested>>(sb.toString())
+                    .collection(List.class).group(Nested.class);
+            this.listGroup = listGroup.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("map-group"));
+            ConfigMappingContext.ObjectCreator<Map<String, Nested>> mapGroup = context.new ObjectCreator<Map<String, Nested>>(
+                    sb.toString()).map(String.class, null).lazyGroup(Nested.class);
+            this.mapGroup = mapGroup.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("optional-group"));
+            ConfigMappingContext.ObjectCreator<Optional<Nested>> optionalGroup = context.new ObjectCreator<Optional<Nested>>(
+                    sb.toString()).optionalGroup(Nested.class);
+            this.optionalGroup = optionalGroup.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("optional-group-missing"));
+            ConfigMappingContext.ObjectCreator<Optional<Nested>> optionalGroupMissing = context.new ObjectCreator<Optional<Nested>>(
+                    sb.toString()).optionalGroup(Nested.class);
+            this.optionalGroupMissing = optionalGroupMissing.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("group"));
+            ConfigMappingContext.ObjectCreator<Nested> group = context.new ObjectCreator<Nested>(sb.toString())
+                    .group(Nested.class);
+            this.group = group.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("value"));
+            ConfigMappingContext.ObjectCreator<String> value = context.new ObjectCreator<String>(sb.toString())
+                    .value(String.class, null);
+            this.value = value.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("optional-value"));
+            ConfigMappingContext.ObjectCreator<Optional<String>> optionalValue = context.new ObjectCreator<Optional<String>>(
+                    sb.toString()).optionalValue(String.class, null);
+            this.optionalValue = optionalValue.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("optional-value"));
+            ConfigMappingContext.ObjectCreator<Optional<List<String>>> optionalList = context.new ObjectCreator<Optional<List<String>>>(
+                    sb.toString()).optionalValues(String.class, null, List.class);
+            this.optionalList = optionalList.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("optional-list-group"));
+            ConfigMappingContext.ObjectCreator<Optional<List<Nested>>> optionalListGroup = context.new ObjectCreator<Optional<List<Nested>>>(
+                    sb.toString()).optionalCollection(List.class).group(Nested.class);
+            this.optionalListGroup = optionalListGroup.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("optional-list-group-missing"));
+            ConfigMappingContext.ObjectCreator<Optional<List<Nested>>> optionalListGroupMissing = context.new ObjectCreator<Optional<List<Nested>>>(
+                    sb.toString()).optionalCollection(List.class).group(Nested.class);
+            this.optionalListGroupMissing = optionalListGroupMissing.get();
+            sb.setLength(length);
+        }
+
+        @Override
+        public Map<String, Nested> unnamed() {
+            return unnamed;
+        }
+
+        @Override
+        public List<Map<String, String>> listMap() {
+            return listMap;
+        }
+
+        @Override
+        public List<Nested> listGroup() {
+            return listGroup;
+        }
+
+        @Override
+        public Map<String, Nested> mapGroup() {
+            return mapGroup;
+        }
+
+        @Override
+        public Optional<Nested> optionalGroup() {
+            return optionalGroup;
+        }
+
+        @Override
+        public Optional<Nested> optionalGroupMissing() {
+            return optionalGroupMissing;
+        }
+
+        @Override
+        public Nested group() {
+            return group;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public Optional<String> optionalValue() {
+            return optionalValue;
+        }
+
+        @Override
+        public Optional<List<String>> optionalList() {
+            return optionalList;
+        }
+
+        @Override
+        public Optional<List<Nested>> optionalListGroup() {
+            return optionalListGroup;
+        }
+
+        @Override
+        public Optional<List<Nested>> optionalListGroupMissing() {
+            return optionalListGroupMissing;
+        }
+    }
+
+    @Test
+    void optionalGroup() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "optional.value", "value"))
+                .build();
+
+        ConfigMappingContext context = new ConfigMappingContext(config, new HashMap<>(),
+                getNames(configClassWithPrefix(OptionalGroup.class)));
+        OptionalGroup mapping = new OptionalGroupImpl(context);
+
+        assertTrue(mapping.optional().isPresent());
+        assertTrue(mapping.empty().isEmpty());
+
+        assertTrue(context.getProblems().isEmpty());
+    }
+
+    @ConfigMapping
+    interface OptionalGroup {
+        Optional<Nested> optional();
+
+        Optional<Nested> empty();
+
+        interface Nested {
+            String value();
+        }
+    }
+
+    static class OptionalGroupImpl implements OptionalGroup {
+        Optional<Nested> optional;
+        Optional<Nested> empty;
+
+        public OptionalGroupImpl(ConfigMappingContext context) {
+            StringBuilder sb = context.getStringBuilder();
+            int length = sb.length();
+            ConfigMapping.NamingStrategy ns = ConfigMapping.NamingStrategy.KEBAB_CASE;
+
+            sb.append(ns.apply("optional"));
+            ConfigMappingContext.ObjectCreator<Optional<Nested>> optional = context.new ObjectCreator<Optional<Nested>>(
+                    sb.toString()).optionalGroup(Nested.class);
+            this.optional = optional.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("empty"));
+            ConfigMappingContext.ObjectCreator<Optional<Nested>> empty = context.new ObjectCreator<Optional<Nested>>(
+                    sb.toString()).optionalGroup(Nested.class);
+            this.empty = empty.get();
+            sb.setLength(length);
+        }
+
+        @Override
+        public Optional<Nested> optional() {
+            return optional;
+        }
+
+        @Override
+        public Optional<Nested> empty() {
+            return empty;
+        }
+    }
+
+    @Test
+    void unnamedKeys() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(UnnamedKeys.class)
+                .withSources(config(
+                        "unnamed.value", "unnamed",
+                        "unnamed.key.value", "value"))
+                .build();
+
+        ConfigMappingContext context = new ConfigMappingContext(config, new HashMap<>(),
+                getNames(configClassWithPrefix(UnnamedKeys.class)));
+        context.getStringBuilder().append("unnamed");
+
+        UnnamedKeys mapping = new UnnamedKeysImpl(context);
+        assertEquals("unnamed", mapping.map().get(null).value());
+        assertEquals("value", mapping.map().get("key").value());
+
+        mapping = config.getConfigMapping(UnnamedKeys.class);
+        assertEquals("unnamed", mapping.map().get(null).value());
+        assertEquals("value", mapping.map().get("key").value());
+
+        assertTrue(context.getProblems().isEmpty());
+    }
+
+    @ConfigMapping(prefix = "unnamed")
+    interface UnnamedKeys {
+        @WithUnnamedKey
+        @WithParentName
+        Map<String, Nested> map();
+
+        interface Nested {
+            String value();
+        }
+    }
+
+    static class UnnamedKeysImpl implements UnnamedKeys {
+        Map<String, Nested> map;
+
+        public UnnamedKeysImpl(ConfigMappingContext context) {
+            StringBuilder sb = context.getStringBuilder();
+            int length = sb.length();
+
+            ConfigMappingContext.ObjectCreator<Map<String, Nested>> map = context.new ObjectCreator<Map<String, Nested>>(
+                    sb.toString())
+                    .map(String.class, null, "")
+                    .lazyGroup(Nested.class);
+            this.map = map.get();
+            sb.setLength(length);
+        }
+
+        @Override
+        public Map<String, Nested> map() {
+            return map;
+        }
+    }
+
+    @Test
+    void mapDefaults() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(MapDefaults.class)
+                .withSources(config(
+                        "map.defaults.one", "value"))
+                .withSources(config(
+                        "map.defaults-nested.one.value", "value"))
+                .withSources(config(
+                        "map.defaults-list.one[0].value", "value"))
+                .build();
+
+        ConfigMappingContext context = new ConfigMappingContext(config, new HashMap<>(),
+                getNames(configClassWithPrefix(MapDefaults.class)));
+        context.getStringBuilder().append("map.");
+        MapDefaults mapping = new MapDefaultsImpl(context);
+
+        assertEquals("value", mapping.defaults().get("one"));
+        assertEquals("default", mapping.defaults().get("default"));
+        assertEquals("default", mapping.defaults().get("something"));
+
+        assertEquals("value", mapping.defaultsNested().get("one").value());
+        assertEquals("default", mapping.defaultsNested().get("default").value());
+        assertEquals("another", mapping.defaultsNested().get("default").another().another());
+
+        assertEquals("value", mapping.defaultsList().get("one").get(0).value());
+
+        assertTrue(context.getProblems().isEmpty());
+    }
+
+    @ConfigMapping(prefix = "map")
+    interface MapDefaults {
+        @WithDefault("default")
+        Map<String, String> defaults();
+
+        @WithDefaults
+        Map<String, Nested> defaultsNested();
+
+        @WithDefaults
+        Map<String, List<Nested>> defaultsList();
+
+        interface Nested {
+            @WithDefault("default")
+            String value();
+
+            AnotherNested another();
+
+            interface AnotherNested {
+                @WithDefault("another")
+                String another();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static class MapDefaultsImpl implements MapDefaults {
+        Map<String, String> defaults;
+        Map<String, Nested> defaultsNested;
+        Map<String, List<Nested>> defaultsList;
+
+        public MapDefaultsImpl(ConfigMappingContext context) {
+            StringBuilder sb = context.getStringBuilder();
+            int length = sb.length();
+            ConfigMapping.NamingStrategy ns = ConfigMapping.NamingStrategy.KEBAB_CASE;
+
+            sb.append(ns.apply("defaults"));
+            ConfigMappingContext.ObjectCreator<Map<String, String>> defaults = context.new ObjectCreator<Map<String, String>>(
+                    sb.toString())
+                    .values(String.class, null, String.class, null, "default");
+            this.defaults = defaults.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("defaults-nested"));
+            ConfigMappingContext.ObjectCreator<Map<String, Nested>> defaultsNested = context.new ObjectCreator<Map<String, Nested>>(
+                    sb.toString())
+                    .map(String.class, null, null, new Supplier<Nested>() {
+                        @Override
+                        public Nested get() {
+                            sb.append(".*");
+                            Nested nested = context.constructGroup(Nested.class);
+                            sb.setLength(length);
+                            return nested;
+                        }
+                    })
+                    .lazyGroup(Nested.class);
+            this.defaultsNested = defaultsNested.get();
+            sb.setLength(length);
+
+            sb.append(ns.apply("defaults-list"));
+            ConfigMappingContext.ObjectCreator<Map<String, List<Nested>>> defaultsList = context.new ObjectCreator<Map<String, List<Nested>>>(
+                    sb.toString())
+                    .map(String.class, null)
+                    .collection(List.class)
+                    .lazyGroup(Nested.class);
+            this.defaultsList = defaultsList.get();
+            sb.setLength(length);
+        }
+
+        @Override
+        public Map<String, String> defaults() {
+            return defaults;
+        }
+
+        @Override
+        public Map<String, Nested> defaultsNested() {
+            return defaultsNested;
+        }
+
+        @Override
+        public Map<String, List<Nested>> defaultsList() {
+            return defaultsList;
+        }
+    }
+
+    @Test
+    void namingStrategy() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "naming.nested_value.value", "value"))
+                .build();
+
+        ConfigMappingContext context = new ConfigMappingContext(config, new HashMap<>(),
+                getNames(configClassWithPrefix(Naming.class)));
+        context.getStringBuilder().append("naming.");
+        Naming naming = new NamingImpl(context);
+
+        assertEquals("value", naming.nestedValue().value());
+
+        assertTrue(context.getProblems().isEmpty());
+    }
+
+    @ConfigMapping(prefix = "naming", namingStrategy = ConfigMapping.NamingStrategy.SNAKE_CASE)
+    interface Naming {
+        Nested nestedValue();
+
+        interface Nested {
+            String value();
+        }
+    }
+
+    static class NamingImpl implements Naming {
+        Nested nestedValue;
+
+        public NamingImpl(ConfigMappingContext context) {
+            ConfigMapping.NamingStrategy ns = ConfigMapping.NamingStrategy.SNAKE_CASE;
+            StringBuilder sb = context.getStringBuilder();
+            int length = sb.length();
+
+            sb.append(ns.apply("nestedValue"));
+            ConfigMappingContext.ObjectCreator<Nested> nestedValue = context.new ObjectCreator<Nested>(sb.toString())
+                    .group(Nested.class);
+            this.nestedValue = nestedValue.get();
+            sb.setLength(length);
+        }
+
+        @Override
+        public Nested nestedValue() {
+            return nestedValue;
+        }
+    }
+
+    @Test
+    void splitRootsRequiredGroup() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN, "false"))
+                .withDefaultValue("nested.nested.something", "something")
+                .withMapping(SplitRootsRequiredGroup.class)
+                .build();
+
+        SplitRootsRequiredGroup mapping = config.getConfigMapping(SplitRootsRequiredGroup.class);
+        assertTrue(mapping.nested().isEmpty());
+    }
+
+    @ConfigMapping
+    interface SplitRootsRequiredGroup {
+
+        Optional<NestedOptional> nested();
+
+        interface NestedOptional {
+            @WithName("x")
+            Optional<Nested> nestedOpt();
+        }
+
+        interface Nested {
+            String value();
+        }
+    }
+
+    @Test
+    void hierarchy() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(config(
+                        "base.nested.base", "value",
+                        "base.nested.value", "value"))
+                .withMapping(ExtendsBase.class)
+                .build();
+
+        ExtendsBase mapping = config.getConfigMapping(ExtendsBase.class);
+
+        assertTrue(mapping.nested().isPresent());
+        assertEquals("value", mapping.nested().get().base());
+        assertEquals("value", mapping.nested().get().value());
+    }
+
+    public interface Base {
+        Optional<Nested> nested();
+
+        interface NestedBase {
+            String base();
+        }
+
+        interface Nested extends NestedBase {
+            String value();
+        }
+    }
+
+    @ConfigMapping(prefix = "base")
+    public interface ExtendsBase extends Base {
+
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/PropertyNameTest.java
+++ b/implementation/src/test/java/io/smallrye/config/PropertyNameTest.java
@@ -1,0 +1,52 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PropertyNameTest {
+    @Test
+    void mappingNameEquals() {
+        assertEquals(new PropertyName(new String("foo")), new PropertyName(new String("foo")));
+        assertEquals(new PropertyName(new String("foo.bar")), new PropertyName(new String("foo.bar")));
+        assertEquals(new PropertyName("foo.*"), new PropertyName("foo.bar"));
+        assertEquals(new PropertyName(new String("foo.*")), new PropertyName(new String("foo.*")));
+        assertEquals(new PropertyName("*"), new PropertyName("foo"));
+        assertEquals(new PropertyName("foo"), new PropertyName("*"));
+        assertEquals(new PropertyName("foo.*.bar"), new PropertyName("foo.bar.bar"));
+        assertEquals(new PropertyName("foo.bar.bar"), new PropertyName("foo.*.bar"));
+        assertEquals(new PropertyName("foo.*.bar"), new PropertyName("foo.\"bar\".bar"));
+        assertEquals(new PropertyName("foo.\"bar\".bar"), new PropertyName("foo.*.bar"));
+        assertEquals(new PropertyName("foo.*.bar"), new PropertyName("foo.\"bar-baz\".bar"));
+        assertEquals(new PropertyName("foo.\"bar-baz\".bar"), new PropertyName("foo.*.bar"));
+        assertNotEquals(new PropertyName("foo.*.bar"), new PropertyName("foo.bar.baz"));
+        assertNotEquals(new PropertyName("foo.bar.baz"), new PropertyName("foo.*.bar"));
+        assertEquals(new PropertyName(new String("foo.bar[*]")), new PropertyName(new String("foo.bar[*]")));
+        assertEquals(new PropertyName("foo.bar[*]"), new PropertyName("foo.bar[0]"));
+        assertEquals(new PropertyName("foo.bar[0]"), new PropertyName("foo.bar[*]"));
+        assertEquals(new PropertyName("foo.*[*]"), new PropertyName("foo.bar[0]"));
+        assertEquals(new PropertyName("foo.bar[0]"), new PropertyName("foo.*[*]"));
+        assertEquals(new PropertyName("foo.*[*]"), new PropertyName("foo.baz[1]"));
+        assertEquals(new PropertyName("foo.baz[1]"), new PropertyName("foo.*[*]"));
+        assertNotEquals(new PropertyName("foo.*[*]"), new PropertyName("foo.baz[x]"));
+        assertNotEquals(new PropertyName("foo.baz[x]"), new PropertyName("foo.*[*]"));
+        assertEquals(new PropertyName("foo.*[*].bar[*]"), new PropertyName("foo.baz[0].bar[0]"));
+        assertEquals(new PropertyName(new String("foo.*[*].bar[*]")), new PropertyName(new String("foo.*[*].bar[*]")));
+        assertEquals(new PropertyName("foo.baz[0].bar[0]"), new PropertyName("foo.*[*].bar[*]"));
+        assertEquals(new PropertyName(new String("foo.baz[0].bar[0]")), new PropertyName(new String("foo.baz[0].bar[0]")));
+        assertNotEquals(new PropertyName("foo.bar.baz[*]").hashCode(), new PropertyName("foo.bar.*").hashCode());
+        assertNotEquals(new PropertyName("foo.bar.baz[*]"), new PropertyName("foo.bar.*"));
+
+        assertEquals(new PropertyName("foo").hashCode(), new PropertyName("foo").hashCode());
+        assertEquals(new PropertyName("foo.bar").hashCode(), new PropertyName("foo.bar").hashCode());
+        assertEquals(new PropertyName("foo.*").hashCode(), new PropertyName("foo.bar").hashCode());
+        assertEquals(new PropertyName("foo.*.bar").hashCode(), new PropertyName("foo.bar.bar").hashCode());
+        assertEquals(new PropertyName("foo.*.bar").hashCode(), new PropertyName("foo.\"bar\".bar").hashCode());
+        assertEquals(new PropertyName(new String("foo.\"bar\".bar")).hashCode(),
+                new PropertyName(new String("foo.\"bar\".bar")).hashCode());
+        assertEquals(new PropertyName("foo.*.bar").hashCode(), new PropertyName("foo.\"bar-baz\".bar").hashCode());
+        assertEquals(new PropertyName(new String("foo.\"bar-baz\".bar")).hashCode(),
+                new PropertyName(new String("foo.\"bar-baz\".bar")).hashCode());
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/RelocateConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/RelocateConfigSourceInterceptorTest.java
@@ -1,5 +1,6 @@
 package io.smallrye.config;
 
+import static io.smallrye.config.ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix;
 import static io.smallrye.config.KeyValuesConfigSource.config;
 import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE;
 import static java.util.Collections.singletonMap;
@@ -272,8 +273,7 @@ class RelocateConfigSourceInterceptorTest {
                         hierarchyCandidates.add("child." + name.substring(7));
                     }
                 }
-                names.addAll(ConfigMappings.mappedProperties(
-                        ConfigMappings.ConfigClassWithPrefix.configClassWithPrefix(Child.class), hierarchyCandidates));
+                names.addAll(ConfigMappings.mappedProperties(configClassWithPrefix(Child.class), hierarchyCandidates));
                 return names.iterator();
             }
         };

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -62,7 +62,7 @@ class SmallRyeConfigTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder().withSources(config("my.list", "1,2,3,4")).build();
 
         Optional<List<Integer>> values = config.getOptionalValues("my.list", config.getConverter(Integer.class).get(),
-                ArrayList::new);
+                (IntFunction<List<Integer>>) value -> new ArrayList<>());
         assertTrue(values.isPresent());
         assertEquals(Arrays.asList(1, 2, 3, 4), values.get());
     }

--- a/validator/src/main/java/io/smallrye/config/validator/BeanValidationConfigValidator.java
+++ b/validator/src/main/java/io/smallrye/config/validator/BeanValidationConfigValidator.java
@@ -14,10 +14,10 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Path;
 import jakarta.validation.Validator;
 
+import io.smallrye.config.ConfigMapping.NamingStrategy;
 import io.smallrye.config.ConfigMappingInterface;
 import io.smallrye.config.ConfigMappingInterface.CollectionProperty;
 import io.smallrye.config.ConfigMappingInterface.MapProperty;
-import io.smallrye.config.ConfigMappingInterface.NamingStrategy;
 import io.smallrye.config.ConfigMappingInterface.Property;
 import io.smallrye.config.ConfigValidationException;
 import io.smallrye.config.ConfigValidationException.Problem;


### PR DESCRIPTION
Rewrote @ConfigMapping internal implementation to remove the runtime introspection and runtime functions. Required information can be extracted by build time runtimes and fed directly into the builder to reduce runtime operations. 