### PR TITLE
fix: passing the whole property name to the error message

### DIFF
--- a/sources/keystore/src/main/java/io/smallrye/config/source/keystore/KeyStoreConfigSourceFactory.java
+++ b/sources/keystore/src/main/java/io/smallrye/config/source/keystore/KeyStoreConfigSourceFactory.java
@@ -127,7 +127,7 @@ public class KeyStoreConfigSourceFactory implements ConfigSourceFactory {
             passwordName = "smallrye.config.source.keystore.\"" + name + "\".password";
             password = context.getValue(passwordName);
             if (password == null || password.getValue() == null) {
-                throw new NoSuchElementException(ConfigMessages.msg.propertyNotFound(name));
+                throw new NoSuchElementException(ConfigMessages.msg.propertyNotFound(passwordName));
             }
         }
         return password;


### PR DESCRIPTION
closes: #1068