### PR TITLE
Quality Gate back to Green

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/PropertyName.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertyName.java
@@ -21,6 +21,7 @@ public class PropertyName {
         return equals(this.name, that.name) || equals(that.name, this.name);
     }
 
+    @SuppressWarnings("squid:S4973")
     static boolean equals(final String name, final String other) {
         //noinspection StringEquality
         if (name == other) {


### PR DESCRIPTION
I fixed the quality gate by adding the missing `@SuppressWarnings("squid:S4973")`.

Although I'm not sure why `Objects#equals` is not used here instead of `==`.

Two lines below it, I'm also not sure why `String#length == 0` is used instead of `String#isEmpty`