### PR TITLE
Adding the protected modifier back to getDefaultSources() in SmallRyeConfigBuilder

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -186,7 +186,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         return this;
     }
 
-    List<ConfigSource> getDefaultSources() {
+    protected List<ConfigSource> getDefaultSources() {
         List<ConfigSource> defaultSources = new ArrayList<>();
 
         defaultSources.add(new EnvConfigSource());


### PR DESCRIPTION
Fixes #1085 

Adding back the `protected` modified to `SmallRyeConfigBuilder.getDefaultSources()` to be able to override and extend the list