### PR TITLE
Do not skip a character if the env var character after a number is

### DIFF
--- a/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
+++ b/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
@@ -209,7 +209,6 @@ public class StringUtil {
                                 break;
                             } else { // not an index
                                 result[i] = '.';
-                                i = j;
                                 break;
                             }
                         }

--- a/common/src/test/java/io/smallrye/config/common/utils/StringUtilTest.java
+++ b/common/src/test/java/io/smallrye/config/common/utils/StringUtilTest.java
@@ -171,6 +171,10 @@ class StringUtilTest {
         assertEquals("foo", StringUtil.toLowerCaseAndDotted("FOO"));
         assertEquals("foo.bar", StringUtil.toLowerCaseAndDotted("FOO_BAR"));
         assertEquals("foo.bar.baz", StringUtil.toLowerCaseAndDotted("FOO_BAR_BAZ"));
+        assertEquals("foo.bar.baz2", StringUtil.toLowerCaseAndDotted("FOO_BAR_BAZ2"));
+        assertEquals("foo.bar.2baz", StringUtil.toLowerCaseAndDotted("FOO_BAR_2BAZ"));
+        assertEquals("foo.bar.baz20", StringUtil.toLowerCaseAndDotted("FOO_BAR_BAZ20"));
+        assertEquals("foo.bar.20baz", StringUtil.toLowerCaseAndDotted("FOO_BAR_20BAZ"));
         assertEquals("foo.bar.baz[20]", StringUtil.toLowerCaseAndDotted("FOO_BAR_BAZ_20_"));
         assertEquals("foo.bar.\"baz\".i[20].e", StringUtil.toLowerCaseAndDotted("FOO_BAR__BAZ__I_20__E"));
         assertEquals("test.language.\"de.etr\"", StringUtil.toLowerCaseAndDotted("TEST_LANGUAGE__DE_ETR__"));


### PR DESCRIPTION
alphabetic

If the env var had the format FOO_BAR_1BAZ the second B was missed.

There was an error that occurred when we had an env var that combined both digits and alphabetical characters.
It turns out that if a digit is found, but its not an index in a map the character after the digit was missed.
This leads to 

`SRCFG00050: foo.bar.1 az in null does not map to any root`

when trying to start an application that relies on Smallrye (example is Quarkus 3.5.0 and later)