### PR TITLE
Dramatically increase recursion cap

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigSourceInterceptorContext.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigSourceInterceptorContext.java
@@ -46,7 +46,7 @@ class SmallRyeConfigSourceInterceptorContext implements ConfigSourceInterceptorC
 
         void increment() {
             int old = count;
-            if (old == 20) {
+            if (old == 2000) {
                 throw new IllegalStateException("Too many recursive interceptor actions");
             }
             count = old + 1;


### PR DESCRIPTION
When using compatibility interceptors (`restart`) it is very easy to hit the very low cap of 20 interceptor actions. Raise it substantially.