### PR TITLE
Re-introduce a no-args constructor for LoggingConfigSourceInterceptor...

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/LoggingConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/LoggingConfigSourceInterceptor.java
@@ -12,6 +12,10 @@ public class LoggingConfigSourceInterceptor implements ConfigSourceInterceptor {
 
     private final boolean enabled;
 
+    public LoggingConfigSourceInterceptor() {
+        this(true);
+    }
+
     public LoggingConfigSourceInterceptor(final boolean enabled) {
         this.enabled = enabled;
     }


### PR DESCRIPTION
… so that loading the service as described on https://smallrye.io/smallrye-config/Main/extensions/logging/ is still/again possible