### PR TITLE
Allow interceptors to interpose between "regular" sources and default sources

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -756,6 +756,18 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
             this.priority = factory.getPriority().orElse(DEFAULT_PRIORITY);
         }
 
+        InterceptorWithPriority(ConfigSourceInterceptor interceptor, int priority) {
+            this(new ConfigSourceInterceptorFactory() {
+                public ConfigSourceInterceptor getInterceptor(final ConfigSourceInterceptorContext context) {
+                    return interceptor;
+                }
+
+                public OptionalInt getPriority() {
+                    return OptionalInt.of(priority);
+                }
+            });
+        }
+
         ConfigSourceInterceptor getInterceptor(ConfigSourceInterceptorContext context) {
             return factory.getInterceptor(context);
         }

--- a/implementation/src/test/java/io/smallrye/config/ConfigConfigSourceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigConfigSourceTest.java
@@ -200,7 +200,7 @@ class ConfigConfigSourceTest {
 
                     @Override
                     public OptionalInt getPriority() {
-                        return OptionalInt.of(Integer.MIN_VALUE);
+                        return OptionalInt.of(0);
                     }
                 })
                 .withSources(new MapBackedConfigSource("test", new HashMap<String, String>() {


### PR DESCRIPTION
We split the interceptors and sources into two groups: those with negative priority and those with positive priority. The positive interceptors come before positive sources, which come before negative interceptors, which come before negative sources.