### PR TITLE
Reduce allocations and batch appends on StringUtil::replaceNonAlphanumericByUnderscores

### DIFF
--- a/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
+++ b/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
@@ -94,21 +94,37 @@ public class StringUtil {
     }
 
     public static String replaceNonAlphanumericByUnderscores(final String name) {
-        return replaceNonAlphanumericByUnderscores(name, new StringBuilder(name.length()));
+        return replaceNonAlphanumericByUnderscores(name, null);
     }
 
-    public static String replaceNonAlphanumericByUnderscores(final String name, final StringBuilder sb) {
+    public static String replaceNonAlphanumericByUnderscores(final String name, StringBuilder sb) {
         int length = name.length();
+        int copyIndex = -1;
         for (int i = 0; i < length; i++) {
             char c = name.charAt(i);
-            if (isAsciiLetterOrDigit(c)) {
-                sb.append(c);
-            } else {
+            if (!isAsciiLetterOrDigit(c)) {
+                if (sb == null) {
+                    sb = new StringBuilder(name.length());
+                }
+                if (copyIndex != -1) {
+                    sb.append(name, copyIndex, i);
+                    copyIndex = -1;
+                }
                 sb.append('_');
                 if (c == '"' && i + 1 == length) {
                     sb.append('_');
                 }
+            } else {
+                if (copyIndex == -1) {
+                    copyIndex = i;
+                }
             }
+        }
+        if (copyIndex != -1) {
+            if (sb == null) {
+                return name;
+            }
+            sb.append(name, copyIndex, length);
         }
         return sb.toString();
     }


### PR DESCRIPTION
@radcortez  this is still a draft, but it:
- avoid allocating at all any `StringBuilder` if not necessary (usually it happens)
- it avoid advancing the `StringBuilder` 's length for each appended ascii/numeric char (including performing bound checks over and over), but try hard performing an optimized batch append

I have to write a JMH bench to verify if it is *much* better (as I expect, given that while still C1 compiled, usually, having less work overall deliver better performance) or instead is better to split the state machine into different loops (not on this PR yet).

I'll provide a JMH benchmark to show if it brings the benefits I expect