### PR TITLE
Support application configuration file by default

### DIFF
--- a/documentation/src/main/docs/config-sources/yaml.md
+++ b/documentation/src/main/docs/config-sources/yaml.md
@@ -1,8 +1,10 @@
 # YAML Config Source
 
-This Config Source allows to use a `yaml` file to load configuration values. The YAML Config Source loads the 
-configuration from the file `META-INF/microprofile-config.yaml`. It has a higher ordinal (`110`) than the 
-`microprofile-config.properties`.
+This Config Source allows to use a `yaml` file to load configuration values. The YAML Config Source loads the configuration from the following files:
+
+1. (`265`) `application.yaml|yml` in `config` folder, located in the current working directory
+2. (`255`) `application.yaml|yml` in the classpath
+3. (`110`) MicroProfile Config configuration file `META-INF/microprofile-config.yaml|yml` in the classpath
 
 The following dependency is required in the classpath to use the YAML Config Source:
 

--- a/documentation/src/main/docs/config/getting-started.md
+++ b/documentation/src/main/docs/config/getting-started.md
@@ -6,7 +6,9 @@ By default, SmallRye Config reads configuration properties from multiple configu
 
 1. (`400`) System properties
 2. (`300`) Environment variables
-3. (`100`) MicroProfile Config configuration file `META-INF/microprofile-config.properties` in the classpath
+3. (`260`) `application.properties` in `config` folder, located in the current working directory
+3. (`250`) `application.properties` in the classpath 
+4. (`100`) MicroProfile Config configuration file `META-INF/microprofile-config.properties` in the classpath
 
 A configuration source is handled by a `ConfigSource`. A `ConfigSource` provides configuration values from a specific
 place.  

--- a/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceLoader.java
@@ -1,0 +1,71 @@
+package io.smallrye.config;
+
+import static java.util.Collections.emptyList;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+public class PropertiesConfigSourceLoader extends AbstractLocationConfigSourceLoader {
+    protected final String path;
+    protected final int ordinal;
+
+    PropertiesConfigSourceLoader(final String path, final int ordinal) {
+        this.path = path;
+        this.ordinal = ordinal;
+    }
+
+    @Override
+    protected String[] getFileExtensions() {
+        return new String[] { "properties" };
+    }
+
+    @Override
+    protected ConfigSource loadConfigSource(final URL url, final int ordinal) throws IOException {
+        return new PropertiesConfigSource(url, ordinal);
+    }
+
+    public static List<ConfigSource> inClassPath(final String path, final int ordinal, final ClassLoader loader) {
+        return new InClassPath(path, ordinal).getConfigSources(loader);
+    }
+
+    public static List<ConfigSource> inFileSystem(final String path, final int ordinal, final ClassLoader loader) {
+        return new InFileSystem(path, ordinal).getConfigSources(loader);
+    }
+
+    private static class InClassPath extends PropertiesConfigSourceLoader implements ConfigSourceProvider {
+        public InClassPath(final String path, final int ordinal) {
+            super(path, ordinal);
+        }
+
+        @Override
+        public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
+            return loadConfigSources(path, ordinal, classLoader);
+        }
+
+        @Override
+        protected List<ConfigSource> tryFileSystem(final URI uri, final int ordinal) {
+            return emptyList();
+        }
+    }
+
+    private static class InFileSystem extends PropertiesConfigSourceLoader implements ConfigSourceProvider {
+        public InFileSystem(final String path, final int ordinal) {
+            super(path, ordinal);
+        }
+
+        @Override
+        public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
+            return loadConfigSources(path, ordinal, classLoader);
+        }
+
+        @Override
+        protected List<ConfigSource> tryClassPath(final URI uri, final int ordinal, final ClassLoader classLoader) {
+            return emptyList();
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceProvider.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertiesConfigSourceProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
+@Deprecated(forRemoval = true)
 public class PropertiesConfigSourceProvider extends AbstractLocationConfigSourceLoader implements ConfigSourceProvider {
     private final List<ConfigSource> configSources = new ArrayList<>();
     private final boolean includeFileSystem;

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -839,6 +839,13 @@ public class SmallRyeConfig implements Config, Serializable {
             }
             if (builder.isAddDefaultSources()) {
                 sourcesToBuild.addAll(builder.getDefaultSources());
+            } else {
+                if (builder.isAddSystemSources()) {
+                    sourcesToBuild.addAll(builder.getSystemSources());
+                }
+                if (builder.isAddPropertiesSources()) {
+                    sourcesToBuild.addAll(builder.getPropertiesSources());
+                }
             }
 
             return sourcesToBuild;

--- a/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSourceLoader.java
+++ b/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSourceLoader.java
@@ -1,0 +1,66 @@
+package io.smallrye.config.source.yaml;
+
+import static java.util.Collections.emptyList;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+
+import io.smallrye.config.AbstractLocationConfigSourceLoader;
+
+public class YamlConfigSourceLoader extends AbstractLocationConfigSourceLoader {
+    @Override
+    protected String[] getFileExtensions() {
+        return new String[] {
+                "yaml",
+                "yml"
+        };
+    }
+
+    @Override
+    protected ConfigSource loadConfigSource(final URL url, final int ordinal) throws IOException {
+        return new YamlConfigSource(url, ordinal);
+    }
+
+    public static class InClassPath extends YamlConfigSourceLoader implements ConfigSourceProvider {
+        @Override
+        public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
+            List<ConfigSource> configSources = new ArrayList<>();
+            configSources.addAll(loadConfigSources("application.yaml", 255, classLoader));
+            configSources.addAll(loadConfigSources("application.yml", 255, classLoader));
+            configSources.addAll(loadConfigSources("META-INF/microprofile-config.yaml", 110, classLoader));
+            configSources.addAll(loadConfigSources("META-INF/microprofile-config.yml", 110, classLoader));
+            return configSources;
+        }
+
+        @Override
+        protected List<ConfigSource> tryFileSystem(final URI uri, final int ordinal) {
+            return emptyList();
+        }
+    }
+
+    public static class InFileSystem extends YamlConfigSourceLoader implements ConfigSourceProvider {
+        @Override
+        public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
+            List<ConfigSource> configSources = new ArrayList<>();
+            configSources.addAll(loadConfigSources(
+                    Paths.get(System.getProperty("user.dir"), "config", "application.yaml").toUri().toString(), 265,
+                    classLoader));
+            configSources.addAll(
+                    loadConfigSources(Paths.get(System.getProperty("user.dir"), "config", "application.yml").toUri().toString(),
+                            265, classLoader));
+            return configSources;
+        }
+
+        @Override
+        protected List<ConfigSource> tryClassPath(final URI uri, final int ordinal, final ClassLoader classLoader) {
+            return emptyList();
+        }
+    }
+}

--- a/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSourceProvider.java
+++ b/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSourceProvider.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 
 import io.smallrye.config.AbstractLocationConfigSourceLoader;
 
+@Deprecated(forRemoval = true)
 public class YamlConfigSourceProvider extends AbstractLocationConfigSourceLoader implements ConfigSourceProvider {
     @Override
     public String[] getFileExtensions() {

--- a/sources/yaml/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
+++ b/sources/yaml/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
@@ -1,1 +1,2 @@
-io.smallrye.config.source.yaml.YamlConfigSourceProvider
+io.smallrye.config.source.yaml.YamlConfigSourceLoader$InClassPath
+io.smallrye.config.source.yaml.YamlConfigSourceLoader$InFileSystem

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlConfigSourceLoaderTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlConfigSourceLoaderTest.java
@@ -1,0 +1,36 @@
+package io.smallrye.config.source.yaml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+public class YamlConfigSourceLoaderTest {
+    @Test
+    void applicationYaml(@TempDir Path tempDir) throws Exception {
+        String yaml = "my:\n" +
+                "  prop: 1234\n";
+        File file = tempDir.resolve("application.yaml").toFile();
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            out.write(yaml.getBytes());
+        }
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .forClassLoader(new URLClassLoader(new URL[] { tempDir.toUri().toURL() }))
+                .addDiscoveredSources()
+                .build();
+
+        assertTrue(config.getConfigSources(YamlConfigSource.class).iterator().hasNext());
+        assertEquals("1234", config.getRawValue("my.prop"));
+    }
+}


### PR DESCRIPTION
Load `application.properties|yaml` from the classpath or in a `config` folder relative to the working directory.