### PR TITLE
Update sample ordinal in custom.md

### DIFF
--- a/documentation/src/main/docs/config-sources/custom.md
+++ b/documentation/src/main/docs/config-sources/custom.md
@@ -33,7 +33,7 @@ public class InMemoryConfigSource implements ConfigSource {
 
     @Override
     public int getOrdinal() {
-        return 275;
+        return 350;
     }
 
     @Override


### PR DESCRIPTION
This pull request includes a change in the `InMemoryConfigSource` class in the `custom.md` file. The `getOrdinal` method's return value has been updated from `275` to `350`, to be the same as text describes:

"The InMemoryConfigSource will be ordered between the System properties config source, and the Environment variables config source due to the 350 ordinal."