### PR TITLE
Avoid using string concatenation to forge impl name

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -47,7 +47,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
     ConfigMappingInterface(final Class<?> interfaceType, final ConfigMappingInterface[] superTypes,
             final Property[] properties) {
         this.interfaceType = interfaceType;
-        this.className = interfaceType.getName() + interfaceType.getName().hashCode() + "Impl";
+        this.className = getImplementationClassName(interfaceType);
         this.superTypes = superTypes;
 
         List<Property> filteredProperties = new ArrayList<>();
@@ -65,6 +65,15 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
 
         this.properties = filteredProperties.toArray(new Property[0]);
         this.toStringMethod = toStringMethod;
+    }
+
+    static String getImplementationClassName(Class<?> type) {
+        // do not use string concatenation here
+        // make sure the impl name doesn't clash with potential user classes
+        String className = type.getName();
+        StringBuilder implementationClassName = new StringBuilder(className.length() + 8);
+        implementationClassName.append(className).append("$$CMImpl");
+        return implementationClassName.toString();
     }
 
     /**

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -127,7 +127,8 @@ public final class ConfigMappingLoader {
     @SuppressWarnings("unchecked")
     public static <T> Class<? extends ConfigMappingObject> getImplementationClass(final Class<T> type) {
         try {
-            Class<?> implementationClass = type.getClassLoader().loadClass(type.getName() + type.getName().hashCode() + "Impl");
+            Class<?> implementationClass = type.getClassLoader()
+                    .loadClass(ConfigMappingInterface.getImplementationClassName(type));
             if (type.isAssignableFrom(implementationClass)) {
                 return (Class<? extends ConfigMappingObject>) implementationClass;
             }


### PR DESCRIPTION
Also avoid using hashCode(). My understanding is that it was used to make sure the name wouldn't clash but I think it's better to use an approach to what we did for other technical classes.

This is related to the discussion in https://github.com/quarkusio/quarkus/issues/42506 .

And in particular to this:

![Screenshot from 2024-08-24 16-46-44](https://github.com/user-attachments/assets/70f5cb62-9503-48b0-a75b-be1780cefa3a)
