### PR TITLE
Support a fixed list of Map keys statically @WithKeys

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/NameIterator.java
+++ b/implementation/src/main/java/io/smallrye/config/NameIterator.java
@@ -329,12 +329,6 @@ public final class NameIterator {
         pos = getNextEnd();
     }
 
-    public void next(int segments) {
-        for (int i = 0; i < segments; i++) {
-            next();
-        }
-    }
-
     public void previous() {
         pos = getPreviousStart() - 1;
     }

--- a/implementation/src/main/java/io/smallrye/config/WithKeys.java
+++ b/implementation/src/main/java/io/smallrye/config/WithKeys.java
@@ -1,0 +1,39 @@
+package io.smallrye.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.Supplier;
+
+/**
+ * Provide a list of map keys when populating {@link java.util.Map} types.
+ * <p>
+ * When populating a {@link java.util.Map}, {@link SmallRyeConfig} requires the configuration names listed in
+ * {@link SmallRyeConfig#getPropertyNames()} to be able to find the {@link java.util.Map} keys. The provided list will
+ * effectively substitute the lookup in {@link SmallRyeConfig#getPropertyNames()}, thus enabling a
+ * {@link org.eclipse.microprofile.config.spi.ConfigSource} that does not list its properties, to contribute
+ * configuration to the {@link java.util.Map}.
+ * <p>
+ * Each key must exist in the final configuration (relative to the {@link java.util.Map} path segment), or the mapping
+ * will fail with a {@link ConfigValidationException}.
+ * <p>
+ * In the case of {@link java.util.Map} value references a {@link java.util.Collection}, {@link SmallRyeConfig} would
+ * still require the lookup in {@link SmallRyeConfig#getPropertyNames()}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE_USE })
+public @interface WithKeys {
+    /**
+     * A {@link Class} implementing a {@link Supplier} of {@link Iterable} with the {@link java.util.Map} keys to look
+     * in the configuration. Keys containing a <code>dot</code> are quoted.
+     * <p>
+     * The {@link Supplier} is instantiated when mapping the {@link java.util.Map}. It may be instanciated multiple
+     * times if the {@link Class} is used across multiple {@link WithKeys}.
+     *
+     * @return A {@link Class} implementing a {@link Supplier} of {@link Iterable} of {@link String} keys
+     */
+    Class<? extends Supplier<Iterable<String>>> value();
+}

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingCollectionsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingCollectionsTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.ConfigMappingCollectionsTest.ServerCollectionsSet.Environment;
@@ -1030,5 +1031,25 @@ public class ConfigMappingCollectionsTest {
             @WithDefault("one,two")
             List<String> list();
         }
+    }
+
+    @Test
+    @Disabled(value = "@WithUnnamedKey not implemented for leaf Maps")
+    void withUnnamedLeaf() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withDefaultValue("unnamed.leaf", "unnamed")
+                .withDefaultValue("unnamed.leaf.one", "one")
+                .withMapping(WithUnnamedLeaf.class)
+                .build();
+
+        WithUnnamedLeaf mapping = config.getConfigMapping(WithUnnamedLeaf.class);
+        assertEquals("unnamed", mapping.leaf().get(null));
+        assertEquals("one", mapping.leaf().get("one"));
+    }
+
+    @ConfigMapping(prefix = "unnamed")
+    interface WithUnnamedLeaf {
+        //@WithUnnamedKey
+        Map<String, String> leaf();
     }
 }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingInterfaceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingInterfaceTest.java
@@ -597,13 +597,13 @@ class ConfigMappingInterfaceTest {
         Map<String, Server> groupParentName();
     }
 
-    public interface ComplexSample {
+    interface ComplexSample {
         ServerSub server();
 
         Optional<ServerSub> client();
     }
 
-    public interface Converters {
+    interface Converters {
         @WithConverter(FooBarConverter.class)
         String foo();
 

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingWithKeysTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingWithKeysTest.java
@@ -1,0 +1,303 @@
+package io.smallrye.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.common.MapBackedConfigSource;
+
+class ConfigMappingWithKeysTest {
+    @Test
+    void withKeys() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("", Map.of(
+                        "map.leaf.one", "one",
+                        "map.leaf.two", "two",
+                        "map.leaf.dashed-key", "dashed-value",
+                        "map.leaf.\"dotted.key\"", "dotted.value")) {
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        return Collections.emptySet();
+                    }
+                })
+                .withSources(new MapBackedConfigSource("", Map.of(
+                        "map.nested.one.value", "one",
+                        "map.nested.two.value", "two",
+                        "map.nested.dashed-key.value", "dashed-value",
+                        "map.nested.\"dotted.key\".value", "dotted.value")) {
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        return Collections.emptySet();
+                    }
+                })
+                .withSources(new MapBackedConfigSource("", Map.of(
+                        "map.leaf-list.one[0]", "one",
+                        "map.leaf-list.two[0]", "two",
+                        "map.leaf-list.dashed-key[0]", "dashed-value",
+                        "map.leaf-list.\"dotted.key\"[0]", "dotted.value")) {
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        // indexed properties still need to query property names, because indexes are also dynamic
+                        return super.getPropertyNames();
+                    }
+                })
+                .withSources(new MapBackedConfigSource("", Map.of(
+                        "map.nested-list.one[0].value", "one",
+                        "map.nested-list.two[0].value", "two",
+                        "map.nested-list.dashed-key[0].value", "dashed-value",
+                        "map.nested-list.\"dotted.key\"[0].value", "dotted.value")) {
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        // indexed properties still need to query property names, because indexes are also dynamic
+                        return super.getPropertyNames();
+                    }
+                })
+                .withMapping(WithMapKeys.class)
+                .build();
+
+        WithMapKeys mapping = config.getConfigMapping(WithMapKeys.class);
+
+        assertEquals("one", mapping.leaf().get("one"));
+        assertEquals("two", mapping.leaf().get("two"));
+        assertEquals("dashed-value", mapping.leaf().get("dashed-key"));
+        assertEquals("dotted.value", mapping.leaf().get("dotted.key"));
+
+        assertEquals("one", mapping.nested().get("one").value());
+        assertEquals("two", mapping.nested().get("two").value());
+        assertEquals("dashed-value", mapping.nested().get("dashed-key").value());
+        assertEquals("dotted.value", mapping.nested().get("dotted.key").value());
+
+        assertEquals("one", mapping.leafList().get("one").get(0));
+        assertEquals("two", mapping.leafList().get("two").get(0));
+        assertEquals("dashed-value", mapping.leafList().get("dashed-key").get(0));
+        assertEquals("dotted.value", mapping.leafList().get("dotted.key").get(0));
+
+        assertEquals("one", mapping.nestedList().get("one").get(0).value());
+        assertEquals("two", mapping.nestedList().get("two").get(0).value());
+        assertEquals("dashed-value", mapping.nestedList().get("dashed-key").get(0).value());
+        assertEquals("dotted.value", mapping.nestedList().get("dotted.key").get(0).value());
+
+        // TODO - Implement remaining pieces
+        // - docs
+    }
+
+    @ConfigMapping(prefix = "map")
+    interface WithMapKeys {
+        @WithKeys(KeysProvider.class)
+        Map<String, String> leaf();
+
+        @WithKeys(KeysProvider.class)
+        Map<String, Nested> nested();
+
+        @WithKeys(KeysProvider.class)
+        Map<String, List<String>> leafList();
+
+        @WithKeys(KeysProvider.class)
+        Map<String, List<Nested>> nestedList();
+
+        interface Nested {
+            String value();
+        }
+
+        class KeysProvider implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("one", "two", "dashed-key", "dotted.key");
+            }
+        }
+    }
+
+    @Test
+    void requiredKeys() {
+        assertThrows(ConfigValidationException.class, () -> new SmallRyeConfigBuilder()
+                .withDefaultValue("required.nested.required.value", "required")
+                .withMapping(EmptyKey.class).build());
+
+        assertThrows(ConfigValidationException.class, () -> new SmallRyeConfigBuilder()
+                .withDefaultValue("required.leaf.required", "required")
+                .withMapping(EmptyKey.class).build());
+
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withDefaultValue("required.nested.required.value", "required")
+                .withDefaultValue("required.leaf.required", "required")
+                .withMapping(RequiredKeys.class)
+                .build();
+
+        RequiredKeys mapping = config.getConfigMapping(RequiredKeys.class);
+        assertEquals("required", mapping.leaf().get("required"));
+        assertEquals("required", mapping.nested().get("required").value());
+    }
+
+    @ConfigMapping(prefix = "required")
+    interface RequiredKeys {
+        @WithKeys(RequiredKeysProvider.class)
+        Map<String, String> leaf();
+
+        @WithKeys(RequiredKeysProvider.class)
+        Map<String, Nested> nested();
+
+        interface Nested {
+            String value();
+        }
+
+        class RequiredKeysProvider implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("required");
+            }
+        }
+    }
+
+    @Test
+    void emptyKey() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withDefaultValue("empty.nested.value", "value")
+                .withMapping(EmptyKey.class)
+                .build();
+
+        EmptyKey mapping = config.getConfigMapping(EmptyKey.class);
+        assertEquals("value", mapping.nested().get(null).value());
+    }
+
+    @ConfigMapping(prefix = "empty")
+    interface EmptyKey {
+        @WithKeys(EmptyKeyProdiver.class)
+        Map<String, Nested> nested();
+
+        interface Nested {
+            String value();
+        }
+
+        class EmptyKeyProdiver implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("");
+            }
+        }
+    }
+
+    @Test
+    void emptyKeyWithUnnamedEmpty() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withDefaultValue("empty.nested.value", "value")
+                .withMapping(EmptyKeyWithUnnamedEmpty.class)
+                .build();
+
+        EmptyKeyWithUnnamedEmpty mapping = config.getConfigMapping(EmptyKeyWithUnnamedEmpty.class);
+        assertEquals("value", mapping.nested().get(null).value());
+    }
+
+    @ConfigMapping(prefix = "empty")
+    interface EmptyKeyWithUnnamedEmpty {
+        @WithUnnamedKey
+        @WithKeys(EmptyKeyProdiver.class)
+        Map<String, Nested> nested();
+
+        interface Nested {
+            String value();
+        }
+
+        class EmptyKeyProdiver implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("");
+            }
+        }
+    }
+
+    @Test
+    void emptyKeyWithUnnamedDefault() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withDefaultValue("empty.nested.value", "value")
+                .withMapping(EmptyKeyWithUnnamedDefault.class)
+                .build();
+
+        EmptyKeyWithUnnamedDefault mapping = config.getConfigMapping(EmptyKeyWithUnnamedDefault.class);
+        assertEquals("value", mapping.nested().get(null).value());
+        assertEquals("value", mapping.nested().get("default").value());
+    }
+
+    @ConfigMapping(prefix = "empty")
+    interface EmptyKeyWithUnnamedDefault {
+        @WithUnnamedKey("default")
+        @WithKeys(EmptyKeyProdiver.class)
+        Map<String, Nested> nested();
+
+        interface Nested {
+            String value();
+        }
+
+        class EmptyKeyProdiver implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("");
+            }
+        }
+    }
+
+    @Test
+    void keysWithParentName() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("", Map.of("parent.one.value", "one")) {
+                    @Override
+                    public Set<String> getPropertyNames() {
+                        return Collections.emptySet();
+                    }
+                })
+                .withMapping(KeysWithParentName.class)
+                .build();
+
+        KeysWithParentName mapping = config.getConfigMapping(KeysWithParentName.class);
+        assertEquals("one", mapping.nested().get("one").value());
+    }
+
+    @ConfigMapping(prefix = "parent")
+    interface KeysWithParentName {
+        @WithParentName
+        @WithKeys(KeysProvider.class)
+        Map<String, Nested> nested();
+
+        interface Nested {
+            String value();
+        }
+
+        class KeysProvider implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("one");
+            }
+        }
+    }
+
+    @Test
+    void additionalKeys() {
+        SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("", Map.of(
+                        "additional.leaf.one", "one", "additional.leaf.two", "two")) {
+                })
+                .withMapping(AdditionalKeys.class);
+
+        // additional.leaf.two in  does not map to any root
+        assertThrows(ConfigValidationException.class, builder::build);
+    }
+
+    @ConfigMapping(prefix = "additional")
+    interface AdditionalKeys {
+        @WithKeys(KeysProvider.class)
+        Map<String, String> leaf();
+
+        class KeysProvider implements Supplier<Iterable<String>> {
+            @Override
+            public Iterable<String> get() {
+                return List.of("one");
+            }
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
@@ -2,6 +2,7 @@ package io.smallrye.config;
 
 import static io.smallrye.config.KeyValuesConfigSource.config;
 import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_MAPPING_VALIDATE_UNKNOWN;
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -129,14 +130,14 @@ public class ObjectCreatorTest {
             sb.append(ns.apply("unnamed"));
             ConfigMappingContext.ObjectCreator<Map<String, Nested>> unnamed = context.new ObjectCreator<Map<String, Nested>>(
                     sb.toString())
-                    .map(String.class, null, "unnamed")
+                    .map(String.class, null, "unnamed", null)
                     .lazyGroup(Nested.class);
             this.unnamed = unnamed.get();
             sb.setLength(length);
 
             sb.append(ns.apply("list-map"));
             ConfigMappingContext.ObjectCreator<List<Map<String, String>>> listMap = context.new ObjectCreator<List<Map<String, String>>>(
-                    sb.toString()).collection(List.class).values(String.class, null, String.class, null, null);
+                    sb.toString()).collection(List.class).values(String.class, null, String.class, null, emptyList(), null);
             this.listMap = listMap.get();
             sb.setLength(length);
 
@@ -368,7 +369,7 @@ public class ObjectCreatorTest {
 
             ConfigMappingContext.ObjectCreator<Map<String, Nested>> map = context.new ObjectCreator<Map<String, Nested>>(
                     sb.toString())
-                    .map(String.class, null, "")
+                    .map(String.class, null, "", null)
                     .lazyGroup(Nested.class);
             this.map = map.get();
             sb.setLength(length);
@@ -449,14 +450,14 @@ public class ObjectCreatorTest {
             sb.append(ns.apply("defaults"));
             ConfigMappingContext.ObjectCreator<Map<String, String>> defaults = context.new ObjectCreator<Map<String, String>>(
                     sb.toString())
-                    .values(String.class, null, String.class, null, "default");
+                    .values(String.class, null, String.class, null, emptyList(), "default");
             this.defaults = defaults.get();
             sb.setLength(length);
 
             sb.append(ns.apply("defaults-nested"));
             ConfigMappingContext.ObjectCreator<Map<String, Nested>> defaultsNested = context.new ObjectCreator<Map<String, Nested>>(
                     sb.toString())
-                    .map(String.class, null, null, new Supplier<Nested>() {
+                    .map(String.class, null, null, null, new Supplier<Nested>() {
                         @Override
                         public Nested get() {
                             sb.append(".*");


### PR DESCRIPTION
Add a new annotation `@WithKeys` to be used with `Map` in ` @ConfigMapping`.

The purpose is to provide a list of keys to populate the `Map` instead of relying on the list of property names (which may not include all the defined keys in the configuration).

Inspired by 
- https://github.com/quarkusio/quarkus/pull/42932
- https://github.com/quarkusio/quarkus/pull/42106
- https://github.com/quarkusio/quarkus/pull/42814