### PR TITLE
Secret type to represent secrets and integrate with the secrets handling

### DIFF
--- a/documentation/src/main/docs/config/mappings.md
+++ b/documentation/src/main/docs/config/mappings.md
@@ -597,6 +597,28 @@ Map<String, Alias> any = server.aliases.get("prod");
 - A mapping can wrap any complex type with an `Optional`
 - `Optional` mappings do not require the configuration path and value to be present
 
+## Secrets
+
+- A mapping can mark a member type as a secret with `Secret<T>`:
+
+```java
+@ConfigMapping(prefix = "credentials")
+public interface Credentials {
+    String username();
+
+    Secret<String> password();
+}
+```
+
+A `Secret` value modifies the behaviour of the config system by:
+
+- Omitting the name of the secret in `SmallRyeConfig#getPropertyNames()`
+- Omitting the name and value of the secret in the mapping `toString` method
+- Throwing a `SecurityException` when trying to retrieve the value via `SmallRyeConfig` programmatic API
+
+A Secret can be of any type that can be converted by a registered `org.eclipse.microprofile.config.spi.Converter` of 
+the same type.
+
 ## toString, equals, hashcode
 
 If the config mapping contains a `toString` method declaration, the config mapping instance will include a proper

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -3,6 +3,7 @@ package io.smallrye.config;
 import static io.smallrye.config.ConfigMappingLoader.getConfigMappingClass;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -111,6 +112,7 @@ public final class ConfigMappings {
         private final Class<?> type;
         private final String prefix;
         private final Map<String, String> properties;
+        private final Set<String> secrets;
 
         public ConfigClass(final Class<?> type, final String prefix) {
             Assert.checkNotNullParam("klass", type);
@@ -119,8 +121,10 @@ public final class ConfigMappings {
             this.type = type;
             this.prefix = prefix;
             this.properties = new HashMap<>();
+            this.secrets = new HashSet<>();
 
             Class<?> mappingClass = getConfigMappingClass(type);
+            Set<String> secrets = ConfigMappingLoader.configMappingSecrets(mappingClass);
             StringBuilder sb = new StringBuilder(prefix);
             for (Map.Entry<String, String> property : ConfigMappingLoader.configMappingProperties(mappingClass).entrySet()) {
                 String path = property.getKey();
@@ -135,6 +139,9 @@ public final class ConfigMappings {
                     name = sb.append(".").append(path).toString();
                 }
                 properties.put(name, property.getValue());
+                if (secrets.contains(property.getKey())) {
+                    this.secrets.add(name);
+                }
                 sb.setLength(prefix.length());
             }
         }
@@ -154,6 +161,10 @@ public final class ConfigMappings {
 
         public Map<String, String> getProperties() {
             return properties;
+        }
+
+        public Set<String> getSecrets() {
+            return secrets;
         }
 
         @Override

--- a/implementation/src/main/java/io/smallrye/config/ProfileConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ProfileConfigSourceInterceptor.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.IntFunction;
 
 import jakarta.annotation.Priority;
 
@@ -22,7 +21,7 @@ public class ProfileConfigSourceInterceptor implements ConfigSourceInterceptor {
     private static final long serialVersionUID = -6305289277993917313L;
 
     private static final Converter<ArrayList<String>> PROFILES_CONVERTER = newCollectionConverter(
-            newTrimmingConverter(STRING_CONVERTER), new ArrayListFactory());
+            newTrimmingConverter(STRING_CONVERTER), ArrayList::new);
 
     private final List<String> profiles;
     private final List<String> prefixProfiles;
@@ -148,13 +147,5 @@ public class ProfileConfigSourceInterceptor implements ConfigSourceInterceptor {
     public static List<String> convertProfile(final String profile) {
         List<String> profiles = PROFILES_CONVERTER.convert(profile);
         return profiles != null ? profiles : Collections.emptyList();
-    }
-
-    private static class ArrayListFactory implements IntFunction<ArrayList<String>> {
-
-        @Override
-        public ArrayList<String> apply(int value) {
-            return new ArrayList<String>(value);
-        }
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/PropertyName.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertyName.java
@@ -181,4 +181,13 @@ public class PropertyName {
     public static PropertyName name(final String name) {
         return new PropertyName(name);
     }
+
+    public static PropertyName unprofiled(final String name) {
+        if (!name.isEmpty() && name.charAt(0) == '%') {
+            int profilesEnd = name.indexOf('.', 1);
+            return new PropertyName(profilesEnd == -1 ? name : name.substring(profilesEnd + 1));
+        } else {
+            return new PropertyName(name);
+        }
+    }
 }

--- a/implementation/src/main/java/io/smallrye/config/Secret.java
+++ b/implementation/src/main/java/io/smallrye/config/Secret.java
@@ -1,0 +1,41 @@
+package io.smallrye.config;
+
+/**
+ * A container type to mark a {@link io.smallrye.config.ConfigMapping} member as a {@link Secret} value.
+ * <p>
+ *
+ * A {@link Secret} value modifies the behaviour of the config system by:
+ * <ol>
+ * <li>Omitting the name of the secret in {@link SmallRyeConfig#getPropertyNames()}</li>
+ * <li>Omitting the name and value of the secret in the mapping {@code toString} method</li>
+ * <li>Throwing a {@link SecurityException} when trying to retrieve the value via {@link SmallRyeConfig} programmatic API</li>
+ * </ol>
+ *
+ * A {@link ConfigMapping} is still capable of performing the mapping without these restrictions, and the secret value
+ * is available for retrieval in its declared member:
+ *
+ * <pre>
+ * &#064;ConfigMapping(prefix = "credentials")
+ * public interface Credentials {
+ *     String username();
+ *
+ *     Secret&lt;String&gt; password();
+ * }
+ * </pre>
+ *
+ * A Secret can be of any type that can be converted by a registered
+ * {@link org.eclipse.microprofile.config.spi.Converter} of the same type.
+ *
+ * @param <T> the secret type
+ *
+ * @see SecretKeys
+ * @see SmallRyeConfigBuilder#withSecretKeys(String...)
+ */
+public interface Secret<T> {
+    /**
+     * Get the actual value of the {@link Secret}.
+     *
+     * @return the actual value of the {@link Secret}.
+     */
+    T get();
+}

--- a/implementation/src/main/java/io/smallrye/config/SecretKeys.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeys.java
@@ -4,6 +4,24 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.function.Supplier;
 
+/**
+ * Provide a way to control the access to Secret Keys.
+ * <p>
+ * A Secret Key is a plain configuration name that modifies the behaviour of the config system by:
+ * <ol>
+ * <li>Omitting the name of the secret in {@link SmallRyeConfig#getPropertyNames()}</li>
+ * <li>Omitting the name and value of the secret in the mapping {@code toString} method</li>
+ * <li>Throwing a {@link SecurityException} when trying to retrieve the value via {@link SmallRyeConfig} programmatic API</li>
+ * </ol>
+ * A Secret Key is defined by either adding the configuration name with
+ * {@link SmallRyeConfigBuilder#withSecretKeys(String...)} or by wrapping a member type of a
+ * {@link ConfigMapping} with {@link Secret}.
+ * <p>
+ * Secret Keys are locked by default. Locking and unlocking keys is a local operation to the current executing thread.
+ *
+ * @see Secret
+ * @see SmallRyeConfigBuilder#withSecretKeys(String...)
+ */
 @SuppressWarnings("squid:S5164")
 public final class SecretKeys implements Serializable {
     @Serial
@@ -11,11 +29,21 @@ public final class SecretKeys implements Serializable {
 
     private static final ThreadLocal<Boolean> LOCKED = new ThreadLocal<>();
 
+    /**
+     * Check if the Secret Keys are locked.
+     *
+     * @return {@code true} if the Secret Keys are locked or {@code false} otherwise.
+     */
     public static boolean isLocked() {
         Boolean result = LOCKED.get();
         return result == null || result;
     }
 
+    /**
+     * Executes a {@code Runnable} with full access to the Secret Keys.
+     *
+     * @param runnable the code to execute
+     */
     public static void doUnlocked(Runnable runnable) {
         doUnlocked(() -> {
             runnable.run();
@@ -23,6 +51,13 @@ public final class SecretKeys implements Serializable {
         });
     }
 
+    /**
+     * Get the result of a {@code Supplier} with full access to the Secret Keys.
+     *
+     * @param supplier a {@code Supplier} to retrieve the results
+     * @return the result
+     * @param <T> the type of results
+     */
     public static <T> T doUnlocked(Supplier<T> supplier) {
         if (isLocked()) {
             LOCKED.set(false);
@@ -36,6 +71,11 @@ public final class SecretKeys implements Serializable {
         }
     }
 
+    /**
+     * Executes a {@code Runnable} with no access to the Secret Keys.
+     *
+     * @param runnable the code to execute
+     */
     public static void doLocked(Runnable runnable) {
         doLocked(() -> {
             runnable.run();
@@ -43,6 +83,13 @@ public final class SecretKeys implements Serializable {
         });
     }
 
+    /**
+     * Get the result of a {@code Supplier} with no access to the Secret Keys.
+     *
+     * @param supplier a {@code Supplier} to retrieve the results
+     * @return the result
+     * @param <T> the type of results
+     */
     public static <T> T doLocked(Supplier<T> supplier) {
         if (!isLocked()) {
             LOCKED.set(true);

--- a/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
@@ -1,46 +1,38 @@
 package io.smallrye.config;
 
 import java.io.Serial;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import jakarta.annotation.Priority;
 
 import io.smallrye.config._private.ConfigMessages;
 
+/**
+ * Intercept the resolution of a configuration name and throw {@link java.lang.SecurityException} if the name is a
+ * Secret Key and the keys are locked.
+ * <p>
+ * To avoid having to recalculate the list of property names, the filter of secret keys is applied in
+ * {@code SmallRyeConfig.ConfigSources.PropertyNames}, so this interceptor does not implement
+ * {@link io.smallrye.config.ConfigSourceInterceptor#iterateNames(ConfigSourceInterceptorContext)}.
+ *
+ * @see SecretKeys
+ */
 @Priority(Priorities.LIBRARY + 100)
 public class SecretKeysConfigSourceInterceptor implements ConfigSourceInterceptor {
     @Serial
     private static final long serialVersionUID = 7291982039729980590L;
 
-    private final Set<String> secrets;
+    private final Set<PropertyName> secrets;
 
-    public SecretKeysConfigSourceInterceptor(final Set<String> secrets) {
+    public SecretKeysConfigSourceInterceptor(final Set<PropertyName> secrets) {
         this.secrets = secrets;
     }
 
     @Override
     public ConfigValue getValue(final ConfigSourceInterceptorContext context, final String name) {
-        if (SecretKeys.isLocked() && secrets.contains(name)) {
+        if (SecretKeys.isLocked() && secrets.contains(PropertyName.unprofiled(name))) {
             throw ConfigMessages.msg.notAllowed(name);
         }
         return context.proceed(name);
-    }
-
-    @Override
-    public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
-        if (!secrets.isEmpty() && SecretKeys.isLocked()) {
-            Set<String> names = new HashSet<>();
-            Iterator<String> namesIterator = context.iterateNames();
-            while (namesIterator.hasNext()) {
-                String name = namesIterator.next();
-                if (!secrets.contains(name)) {
-                    names.add(name);
-                }
-            }
-            return names.iterator();
-        }
-        return context.iterateNames();
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/SecretKeysHandler.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeysHandler.java
@@ -10,6 +10,8 @@ package io.smallrye.config;
  * Instances of this interface will be discovered via the {@link java.util.ServiceLoader} mechanism and can be
  * registered by providing a {@code META-INF/services/io.smallrye.config.SecretKeysHandler} which contains the fully
  * qualified class name of the custom {@code SecretKeysHandler} implementation.
+ *
+ * @see io.smallrye.config.SecretKeysHandlerFactory
  */
 public interface SecretKeysHandler {
     /**

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.smallrye.config;
 
 import static io.smallrye.config.ConfigSourceInterceptorFactory.DEFAULT_PRIORITY;
@@ -70,7 +69,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
     private final List<ConfigSourceProvider> sourceProviders = new ArrayList<>();
     private final Map<Type, ConverterWithPriority> converters = new HashMap<>();
     private final List<String> profiles = new ArrayList<>();
-    private final Set<String> secretKeys = new HashSet<>();
+    private final Set<PropertyName> secretKeys = new HashSet<>();
     private final List<InterceptorWithPriority> interceptors = new ArrayList<>();
     private final List<SecretKeysHandlerWithName> secretKeysHandlers = new ArrayList<>();
     private ConfigValidator validator = ConfigValidator.EMPTY;
@@ -519,7 +518,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
     }
 
     public SmallRyeConfigBuilder withSecretKeys(String... keys) {
-        secretKeys.addAll(Stream.of(keys).collect(Collectors.toSet()));
+        secretKeys.addAll(Stream.of(keys).map(PropertyName::name).collect(Collectors.toSet()));
         return this;
     }
 
@@ -655,6 +654,10 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
 
     public Map<String, String> getDefaultValues() {
         return defaultValues;
+    }
+
+    public Set<PropertyName> getSecretKeys() {
+        return secretKeys;
     }
 
     public MappingBuilder getMappingsBuilder() {
@@ -825,6 +828,8 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
                     }
                 }
             });
+
+            configClass.getSecrets().forEach(secret -> secretKeys.add(PropertyName.name(secret)));
 
             // It is an MP ConfigProperties, so ignore unmapped properties
             if (ConfigMappingLoader.ConfigMappingClass.getConfigurationClass(configClass.getType()) != null) {

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingSecretsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingSecretsTest.java
@@ -1,0 +1,170 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.KeyValuesConfigSource.config;
+import static io.smallrye.config.SecretKeys.doUnlocked;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.Test;
+
+class ConfigMappingSecretsTest {
+    @Test
+    void secrets() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultInterceptors()
+                .withMapping(MappingSecrets.class)
+                .withSources(config(
+                        "secrets.secret", "secret",
+                        "secrets.optional", "secret",
+                        "secrets.list[0]", "secret",
+                        "secrets.optional-list[0]", "secret",
+                        "secrets.map.key", "secret",
+                        "secrets.map-list.key[0]", "secret"))
+                .withSecretKeys()
+                .build();
+
+        MappingSecrets mapping = config.getConfigMapping(MappingSecrets.class);
+        assertEquals("secret", mapping.secret().get());
+        assertTrue(mapping.optional().isPresent());
+        assertEquals("secret", mapping.optional().get().get());
+        assertEquals("secret", mapping.list().get(0).get());
+        assertTrue(mapping.optionalList().isPresent());
+        assertEquals("secret", mapping.optionalList().get().get(0).get());
+        assertEquals("secret", mapping.map().get("key").get());
+        assertEquals("secret", mapping.mapList().get("key").get(0).get());
+
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.secret"));
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.optional"));
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.list[0]"));
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.optional-list[0]"));
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.map.key"));
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.map-list.key[0]"));
+
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("secrets.secret").getValue()));
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("secrets.optional").getValue()));
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("secrets.list[0]").getValue()));
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("secrets.optional-list[0]").getValue()));
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("secrets.map.key").getValue()));
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("secrets.map-list.key[0]").getValue()));
+
+        Set<String> names = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertFalse(names.contains("secrets.secret"));
+        assertFalse(names.contains("secrets.optional"));
+        assertFalse(names.contains("secrets.list[0]"));
+        assertFalse(names.contains("secrets.optional-list[0]"));
+        assertFalse(names.contains("secrets.map.key"));
+        assertFalse(names.contains("secrets.map-list.key[0]"));
+
+        names = doUnlocked(() -> stream(config.getPropertyNames().spliterator(), false).collect(toSet()));
+        assertTrue(names.contains("secrets.secret"));
+        assertTrue(names.contains("secrets.optional"));
+        assertTrue(names.contains("secrets.list[0]"));
+        assertTrue(names.contains("secrets.optional-list[0]"));
+        assertTrue(names.contains("secrets.map.key"));
+        assertTrue(names.contains("secrets.map-list.key[0]"));
+
+        assertEquals("MappingSecrets{}", mapping.toString());
+    }
+
+    @Test
+    void profiles() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultInterceptors()
+                .withMapping(MappingSecrets.class)
+                .withSources(config(
+                        "%dev.secrets.secret", "secret",
+                        "secrets.secret", "secret",
+                        "secrets.optional", "secret",
+                        "secrets.list[0]", "secret",
+                        "secrets.optional-list[0]", "secret",
+                        "secrets.map.key", "secret",
+                        "secrets.map-list.key[0]", "secret"))
+                .withSecretKeys()
+                .build();
+
+        Set<String> names = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertTrue(names.isEmpty());
+
+        assertThrows(SecurityException.class, () -> config.getConfigValue("%dev.secrets.secret"));
+        assertThrows(SecurityException.class, () -> config.getConfigValue("secrets.secret"));
+
+        assertEquals("secret", doUnlocked(() -> config.getConfigValue("%dev.secrets.secret").getValue()));
+    }
+
+    @ConfigMapping(prefix = "secrets")
+    interface MappingSecrets {
+        Secret<String> secret();
+
+        Optional<Secret<String>> optional();
+
+        List<Secret<String>> list();
+
+        Optional<List<Secret<String>>> optionalList();
+
+        Map<String, Secret<String>> map();
+
+        Map<String, List<Secret<String>>> mapList();
+
+        @Override
+        String toString();
+    }
+
+    @Test
+    void convertWith() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .addDefaultInterceptors()
+                .withMapping(ConvertWithSecrets.class)
+                .withSources(config(
+                        "secrets.secret", "secret",
+                        "secrets.optional", "secret",
+                        "secrets.list[0]", "secret",
+                        "secrets.optional-list[0]", "secret",
+                        "secrets.map.key", "secret",
+                        "secrets.map-list.key[0]", "secret"))
+                .withSecretKeys()
+                .build();
+
+        ConvertWithSecrets mapping = config.getConfigMapping(ConvertWithSecrets.class);
+        assertEquals("redacted", mapping.secret().get());
+        assertTrue(mapping.optional().isPresent());
+        assertEquals("redacted", mapping.optional().get().get());
+        assertEquals("redacted", mapping.list().get(0).get());
+        assertTrue(mapping.optionalList().isPresent());
+        assertEquals("redacted", mapping.optionalList().get().get(0).get());
+        assertEquals("redacted", mapping.map().get("key").get());
+        assertEquals("redacted", mapping.mapList().get("key").get(0).get());
+    }
+
+    @ConfigMapping(prefix = "secrets")
+    interface ConvertWithSecrets {
+        @WithConverter(RedactedConverter.class)
+        Secret<String> secret();
+
+        Optional<@WithConverter(RedactedConverter.class) Secret<String>> optional();
+
+        List<@WithConverter(RedactedConverter.class) Secret<String>> list();
+
+        Optional<List<@WithConverter(RedactedConverter.class) Secret<String>>> optionalList();
+
+        Map<String, @WithConverter(RedactedConverter.class) Secret<String>> map();
+
+        Map<String, List<@WithConverter(RedactedConverter.class) Secret<String>>> mapList();
+
+        class RedactedConverter implements Converter<String> {
+            @Override
+            public String convert(String value) throws IllegalArgumentException, NullPointerException {
+                return "redacted";
+            }
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -410,15 +410,17 @@ class SmallRyeConfigTest {
         assertEquals("1234", config.getConfigValue("SMALLRYE_MP_CONFIG_PROP").getValue());
         assertEquals("1234", config.getConfigValue("smallrye.mp.config.prop").getValue());
         assertEquals("1234", config.getConfigValue("smallrye.mp-config.prop").getValue());
-        assertTrue(((Set<String>) config.getPropertyNames()).contains("SMALLRYE_MP_CONFIG_PROP"));
-        assertTrue(((Set<String>) config.getPropertyNames()).contains("smallrye.mp.config.prop"));
+        Set<String> names = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertTrue(names.contains("SMALLRYE_MP_CONFIG_PROP"));
+        assertTrue(names.contains("smallrye.mp.config.prop"));
 
         config = new SmallRyeConfigBuilder().addDefaultInterceptors().addDefaultSources()
                 .withSources(KeyValuesConfigSource.config("smallrye.mp-config.prop", "5678")).build();
         assertEquals("1234", config.getConfigValue("SMALLRYE_MP_CONFIG_PROP").getValue());
         assertEquals("1234", config.getConfigValue("smallrye.mp-config.prop").getValue());
-        assertTrue(((Set<String>) config.getPropertyNames()).contains("SMALLRYE_MP_CONFIG_PROP"));
-        assertTrue(((Set<String>) config.getPropertyNames()).contains("smallrye.mp-config.prop"));
+        names = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertTrue(names.contains("SMALLRYE_MP_CONFIG_PROP"));
+        assertTrue(names.contains("smallrye.mp-config.prop"));
     }
 
     @Test

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ArrayTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ArrayTest.java
@@ -1,5 +1,7 @@
 package io.smallrye.config.source.yaml;
 
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -48,6 +50,7 @@ class ArrayTest {
         assertEquals("1", config.getConfigValue("foo[1]").getValue());
         assertEquals("true", config.getConfigValue("foo[2]").getValue());
         assertNull(config.getConfigValue("foo[3]").getValue());
-        assertFalse(((Set<String>) config.getPropertyNames()).contains("foo[3]"));
+        Set<String> names = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertFalse(names.contains("foo[3]"));
     }
 }


### PR DESCRIPTION
- Fixes #1199

Adds a new wrapper type, `Secret<T>`, to represent a secret. When a `Secret` is part of a mapping, the path is added to the Secrets interceptor, to not include the secret in property names or access the secret without calling `SecretKeys.doUnlocked`.

This is initial work to support more advanced scenarios around secrets, that we should discuss.