### PR TITLE
Use module-friendly logger methods

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/_private/ConfigLogging.java
+++ b/implementation/src/main/java/io/smallrye/config/_private/ConfigLogging.java
@@ -1,5 +1,7 @@
 package io.smallrye.config._private;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -9,7 +11,7 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "SRCFG", length = 5)
 public interface ConfigLogging extends BasicLogger {
-    ConfigLogging log = Logger.getMessageLogger(ConfigLogging.class, "io.smallrye.config");
+    ConfigLogging log = Logger.getMessageLogger(MethodHandles.lookup(), ConfigLogging.class, "io.smallrye.config");
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 1000, value = "Unable to get context classloader instance")

--- a/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemLogging.java
+++ b/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemLogging.java
@@ -1,5 +1,7 @@
 package io.smallrye.config.source.file;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
@@ -8,7 +10,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "SRCFG", length = 5)
 interface FileSystemLogging extends BasicLogger {
-    FileSystemLogging log = Logger.getMessageLogger(FileSystemLogging.class, FileSystemLogging.class.getPackage().getName());
+    FileSystemLogging log = Logger.getMessageLogger(MethodHandles.lookup(), FileSystemLogging.class,
+            FileSystemLogging.class.getPackage().getName());
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 3000, value = "Unable to read content from file %s. Exception: %s")

--- a/sources/zookeeper/src/main/java/io/smallrye/config/source/zookeeper/ZooKeepperLogging.java
+++ b/sources/zookeeper/src/main/java/io/smallrye/config/source/zookeeper/ZooKeepperLogging.java
@@ -1,5 +1,7 @@
 package io.smallrye.config.source.zookeeper;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -9,7 +11,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "SRCFG", length = 5)
 interface ZooKeepperLogging extends BasicLogger {
-    ZooKeepperLogging log = Logger.getMessageLogger(ZooKeepperLogging.class, ZooKeepperLogging.class.getPackage().getName());
+    ZooKeepperLogging log = Logger.getMessageLogger(MethodHandles.lookup(), ZooKeepperLogging.class,
+            ZooKeepperLogging.class.getPackage().getName());
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 4500, value = "Failed to retrieve property names from ZooKeeperConfigSource")

--- a/utils/events/src/main/java/io/smallrye/config/events/regex/RegexLogging.java
+++ b/utils/events/src/main/java/io/smallrye/config/events/regex/RegexLogging.java
@@ -1,5 +1,7 @@
 package io.smallrye.config.events.regex;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
@@ -8,7 +10,8 @@ import org.jboss.logging.annotations.MessageLogger;
 
 @MessageLogger(projectCode = "SRCFG", length = 5)
 interface RegexLogging extends BasicLogger {
-    RegexLogging log = Logger.getMessageLogger(RegexLogging.class, RegexLogging.class.getPackage().getName());
+    RegexLogging log = Logger.getMessageLogger(MethodHandles.lookup(), RegexLogging.class,
+            RegexLogging.class.getPackage().getName());
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 5000, value = "Can not find ChangeEvent parameter for method %s. @RegexFilter is being ignored")


### PR DESCRIPTION
Prevents errors such as this one when running in modular environments:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at app//io.smallrye.config.SmallRyeConfig$ConfigSources.getSources(SmallRyeConfig.java:1007)
	at app//io.smallrye.config.SmallRyeConfig$ConfigSources.<init>(SmallRyeConfig.java:843)
	at app//io.smallrye.config.SmallRyeConfig.<init>(SmallRyeConfig.java:86)
	at app//io.smallrye.config.SmallRyeConfigBuilder.build(SmallRyeConfigBuilder.java:767)
	at app//io.quarkus.runtime.generated.Config.<clinit>(Unknown Source)
	at app//io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1160)
	at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:300)
	at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newConstructorAccessor(MethodHandleAccessorFactory.java:103)
	at java.base/jdk.internal.reflect.ReflectionFactory.newConstructorAccessor(ReflectionFactory.java:200)
	at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:549)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at app//io.quarkus.runtime.Quarkus.run(Quarkus.java:70)
	at app//io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at app//io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at app//io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at io.github.dmlloyd.modules@1.0-SNAPSHOT/io.github.dmlloyd.modules.Launcher.run(Launcher.java:118)
	at io.github.dmlloyd.modules@1.0-SNAPSHOT/io.github.dmlloyd.modules.Launcher.main(Launcher.java:225)
	at io.github.dmlloyd.modules@1.0-SNAPSHOT/io.github.dmlloyd.modules.Launcher.main(Launcher.java:136)
Caused by: java.lang.IllegalArgumentException: This library does not have private access to interface io.smallrye.config._private.ConfigLogging
	at org.jboss.logging@3.6.1.Final/org.jboss.logging.Logger.getMessageLogger(Logger.java:2572)
	at org.jboss.logging@3.6.1.Final/org.jboss.logging.Logger.getMessageLogger(Logger.java:2552)
	at app//io.smallrye.config._private.ConfigLogging.<clinit>(ConfigLogging.java:12)
	... 21 more
```