### PR TITLE
Revert "Remove the generation of a comma separated value name for Collections in the YamlConfigSource (#1203)"

### DIFF
--- a/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSource.java
+++ b/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSource.java
@@ -1,16 +1,21 @@
 package io.smallrye.config.source.yaml;
 
+import static java.util.Collections.singletonMap;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -31,6 +36,14 @@ public class YamlConfigSource extends MapBackedConfigSource {
 
     private static final String NAME_PREFIX = "YamlConfigSource[source=";
     private static final int ORDINAL = ConfigSource.DEFAULT_ORDINAL + 10;
+    private static final Yaml DUMPER;
+
+    static {
+        final DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.FLOW);
+        dumperOptions.setDefaultScalarStyle(DumperOptions.ScalarStyle.FOLDED);
+        DUMPER = new Yaml(dumperOptions);
+    }
 
     public YamlConfigSource(String name, Map<String, String> source, int ordinal) {
         super(name, source, ordinal, false);
@@ -127,7 +140,8 @@ public class YamlConfigSource extends MapBackedConfigSource {
             } else if (value instanceof Map) {
                 flattenYaml(key, (Map<Object, Object>) value, target, false);
             } else if (value instanceof List) {
-                List<Object> list = (List<Object>) value;
+                final List<Object> list = (List<Object>) value;
+                flattenList(key, list, target);
                 for (int i = 0; i < list.size(); i++) {
                     flattenYaml(key, Collections.singletonMap("[" + i + "]", list.get(i)), target, true);
                 }
@@ -137,6 +151,40 @@ public class YamlConfigSource extends MapBackedConfigSource {
                 }
             }
         });
+    }
+
+    private static void flattenList(String key, List<Object> source, Map<String, String> target) {
+        boolean mixed = false;
+        List<String> flatten = new ArrayList<>();
+        for (Object value : source) {
+            if (value instanceof String || value instanceof Boolean) {
+                flatten.add(value.toString());
+            } else if (value != null) {
+                mixed = true;
+                break;
+            }
+        }
+
+        if (!mixed) {
+            target.put(key, flatten.stream().map(value -> {
+                StringBuilder sb = new StringBuilder();
+                escapeCommas(sb, value, 1);
+                return sb.toString();
+            }).collect(Collectors.joining(",")));
+        }
+    }
+
+    private static void escapeCommas(StringBuilder b, String src, int escapeLevel) {
+        int cp;
+        for (int i = 0; i < src.length(); i += Character.charCount(cp)) {
+            cp = src.codePointAt(i);
+            if (cp == '\\' || cp == ',') {
+                for (int j = 0; j < escapeLevel; j++) {
+                    b.append('\\');
+                }
+            }
+            b.appendCodePoint(cp);
+        }
     }
 
     /**

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ArrayTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/ArrayTest.java
@@ -43,6 +43,7 @@ class ArrayTest {
                         + "    - ~\n"))
                 .build();
 
+        assertEquals("something,1,true", config.getRawValue("foo"));
         assertEquals("something", config.getRawValue("foo[0]"));
         assertEquals("1", config.getRawValue("foo[1]"));
         assertEquals("true", config.getRawValue("foo[2]"));

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/BasicTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/BasicTest.java
@@ -41,9 +41,7 @@ class BasicTest {
 
         ConfigSource src = new YamlConfigSource("Yaml", yaml);
 
-        assertEquals("cat", src.getValue("foo.bar[0]"));
-        assertEquals("dog", src.getValue("foo.bar[1]"));
-        assertEquals("chicken", src.getValue("foo.bar[2]"));
+        assertEquals("cat,dog,chicken", src.getValue("foo.bar"));
     }
 
     @Test

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlConfigSourceTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlConfigSourceTest.java
@@ -160,6 +160,7 @@ class YamlConfigSourceTest {
 
         assertTrue(propertyNames.contains("quarkus.http.port"));
         assertTrue(propertyNames.contains("quarkus.http.ssl-port"));
+        assertTrue(propertyNames.contains("quarkus.http.ssl.protocols"));
         assertTrue(propertyNames.contains("quarkus.http.ssl.protocols[0]"));
         assertNotNull(config.getRawValue("quarkus.http.ssl.protocols[0]"));
     }


### PR DESCRIPTION
This reverts commit 529c72c108f11cd025a6b3eb31b822bd45c75550.

For https://github.com/quarkusio/quarkus/issues/44811.