### PR TITLE
Use config ordinal to determine which config style to use when populating list, between comma-separated and indexed

### DIFF
--- a/documentation/src/main/docs/config/indexed-properties.md
+++ b/documentation/src/main/docs/config/indexed-properties.md
@@ -20,8 +20,9 @@ The indexed property syntax uses the property name and square brackets with an i
 
 A call to `Config#getValues("my.collection", String.class)`, will automatically create and convert a `List<String>` 
 that contains the values `dog`, `cat` and `turtle`. A call to `Config#getValues("my.indexed.collection", String.class)` 
-returns the exact same result. If SmallRye Config finds the same property name in their indexed and unindexed format, 
-the indexed value has priority.
+returns the exact same result. The indexed property format is prioritized when both styles are found in the same 
+configuration source. When available in multiple sources, the higher ordinal source wins, like any other configuration 
+lookup.
 
 The indexed property is sorted by its index before being added to the target `Collection`. Any gaps in the indexes do 
 not resolve to the target `Collection`, which means that the `Collection` result will store all values without empty 


### PR DESCRIPTION
For https://github.com/quarkusio/quarkus/issues/44891