### PR TITLE
check duplicate keys

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigValueConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigValueConfigSource.java
@@ -416,7 +416,8 @@ public interface ConfigValueConfigSource extends ConfigSource {
                         .withLineNumber(lr.lineNumber)
                         .build());
                 if (oldConfigValue != null) {
-                    ConfigLogging.log.duplicateValue( oldConfigValue.getName(), oldConfigValue.getConfigSourceName(), oldConfigValue.getValue() );
+                    ConfigLogging.log.duplicateValue(oldConfigValue.getName(), oldConfigValue.getConfigSourceName(),
+                            oldConfigValue.getValue());
                 }
             }
         }

--- a/implementation/src/main/java/io/smallrye/config/ConfigValueConfigSource.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigValueConfigSource.java
@@ -416,8 +416,7 @@ public interface ConfigValueConfigSource extends ConfigSource {
                         .withLineNumber(lr.lineNumber)
                         .build());
                 if (oldConfigValue != null) {
-                    log.warnv("duplicate keys found for : {0}, source name : {1}", oldConfigValue.getName(),
-                            oldConfigValue.getConfigSourceName());
+                    ConfigLogging.log.duplicateValue( oldConfigValue.getName(), oldConfigValue.getConfigSourceName(), oldConfigValue.getValue() );
                 }
             }
         }

--- a/implementation/src/main/java/io/smallrye/config/_private/ConfigLogging.java
+++ b/implementation/src/main/java/io/smallrye/config/_private/ConfigLogging.java
@@ -40,4 +40,9 @@ public interface ConfigLogging extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 1006, value = "Loaded ConfigSource %s with ordinal %d")
     void loadedConfigSource(String name, int ordinal);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 1007, value = "Duplicate value found for name : %s, config source name : %s, (old value : %s)")
+    void duplicateValue(String key, String sourceName, String oldValue);
+
 }

--- a/implementation/src/test/java/io/smallrye/config/ConfigValuePropertiesTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigValuePropertiesTest.java
@@ -81,7 +81,7 @@ class ConfigValuePropertiesTest {
     }
 
     @Test
-    void logDuplicateKeys() throws Exception {
+    void logDuplicateValue() throws Exception {
         ConfigValueProperties map = new ConfigValueProperties("config", 1);
         String config = "key=value\n" +
                 "key2=value\n" +

--- a/implementation/src/test/java/io/smallrye/config/ConfigValuePropertiesTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigValuePropertiesTest.java
@@ -79,4 +79,17 @@ class ConfigValuePropertiesTest {
         assertEquals(2, map.get("key2").getLineNumber());
         assertEquals(6, map.get("key3").getLineNumber());
     }
+
+    @Test
+    void logDuplicateKeys() throws Exception {
+        ConfigValueProperties map = new ConfigValueProperties("config", 1);
+        String config = "key=value\n" +
+                "key2=value\n" +
+                "key2=value2\n";
+        map.load(new StringReader(config));
+
+        // property expected with the last value found
+        assertEquals("value2", map.get("key2").getValue());
+    }
+
 }


### PR DESCRIPTION
- Fixes #1269

Edit : 

Only for properties config source : duplicate keys found in te same config source will be logged as warning.

NOTE: this is just a proposal of implementation.