### PR TITLE
fix: avoid out of range error with long profile names

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ProfileConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ProfileConfigSourceInterceptor.java
@@ -107,7 +107,11 @@ public class ProfileConfigSourceInterceptor implements ConfigSourceInterceptor {
                 int toOffset = 1;
                 while (nextSplit != -1) {
                     for (String profile : profiles) {
-                        char expectedEnd = name.charAt(toOffset + profile.length());
+                        int end = toOffset + profile.length();
+                        if (end >= name.length()) {
+                            continue;
+                        }
+                        char expectedEnd = name.charAt(end);
                         if ((expectedEnd == '.' || expectedEnd == ',') &&
                                 name.regionMatches(toOffset, profile, 0, profile.length())) {
                             return name.substring(profilesEnd + 1);

--- a/implementation/src/test/java/io/smallrye/config/ProfileConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ProfileConfigSourceInterceptorTest.java
@@ -542,6 +542,12 @@ class ProfileConfigSourceInterceptorTest {
         assertIterableEquals(List.of("kubernetes", "prod", "cluster"), config.getProfiles());
     }
 
+    @Test
+    void profilesLongerThanPropDoNotOverflowString() {
+        String name = ProfileConfigSourceInterceptor.activeName("%a,b.c.d", List.of("test-with-native-agent"));
+        assertEquals("%a,b.c.d", name);
+    }
+
     private static SmallRyeConfig buildConfig(String... keyValues) {
         return new SmallRyeConfigBuilder()
                 .addDefaultInterceptors()


### PR DESCRIPTION
Long profile names, such as `test-with-native-agent` may cause string length overruns on short properties.

This introduces a check to avoid that.