### PR TITLE
Replace streams with for loop in customizers handling

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -760,9 +760,15 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
             }
         }
 
-        customizers.stream()
-                .sorted(Comparator.comparingInt(SmallRyeConfigBuilderCustomizer::priority))
-                .forEach(customizer -> customizer.configBuilder(SmallRyeConfigBuilder.this));
+        customizers.sort(new Comparator<>() {
+            @Override
+            public int compare(SmallRyeConfigBuilderCustomizer o1, SmallRyeConfigBuilderCustomizer o2) {
+                return o1.priority() - o2.priority();
+            }
+        });
+        for (SmallRyeConfigBuilderCustomizer customizer : customizers) {
+            customizer.configBuilder(this);
+        }
 
         return new SmallRyeConfig(this);
     }


### PR DESCRIPTION
This isn't going to make any difference in real life, but it does at least make stacktraces look
a little better to look at
(when an exception is thrown or in a flamegraph)

Theoretically this change does change the semantics slightly as the customizers array is now sorted, but these customizers are private, so it shouldn't matter