### PR TITLE
Use `invokeExact` when creating a ConfigMapping object

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -88,9 +88,10 @@ public final class ConfigMappingLoader {
 
     static <T> T configMappingObject(final Class<T> interfaceType, final ConfigMappingContext configMappingContext) {
         try {
-            MethodHandle constructor = LOOKUP.findConstructor(CACHE.get(interfaceType).getImplementationClass(),
+            Class<? extends ConfigMappingObject> implClass = CACHE.get(interfaceType).getImplementationClass();
+            MethodHandle constructor = LOOKUP.findConstructor(implClass,
                     methodType(void.class, ConfigMappingContext.class));
-            return interfaceType.cast(constructor.invoke(configMappingContext));
+            return (T) constructor.asType(constructor.type().changeReturnType(Object.class)).invokeExact(configMappingContext);
         } catch (NoSuchMethodException e) {
             throw new NoSuchMethodError(e.getMessage());
         } catch (IllegalAccessException e) {


### PR DESCRIPTION
This invocation should be slightly more efficient
that the generic `invoke` method.

This is a very tiny optimization that is unlikely
to yield any real world improvements, but given that
ConfigMapping objects are being used more and more,
it doesn't hurt to improve their construction.