### PR TITLE
Converters - Add some shortcuts for JDK classes

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.smallrye.config;
 
 import static io.smallrye.config.common.utils.StringUtil.unquoted;
 
+import java.io.File;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.Array;
@@ -29,6 +29,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -187,6 +188,11 @@ public final class Converters {
     static final Converter<Path> PATH_CONVERTER = BuiltInConverter.of(18,
             newEmptyValueConverter(Path::of));
 
+    static final Converter<File> FILE_CONVERTER = BuiltInConverter.of(19, newEmptyValueConverter(File::new));
+
+    static final Converter<URI> URI_CONVERTER = BuiltInConverter.of(20,
+            newTrimmingConverter(newEmptyValueConverter(URI::create)));
+
     static final Map<Class<?>, Class<?>> PRIMITIVE_TYPES;
 
     static final Map<Type, Converter<?>> ALL_CONVERTERS = new HashMap<>();
@@ -226,6 +232,9 @@ public final class Converters {
         ALL_CONVERTERS.put(Pattern.class, PATTERN_CONVERTER);
 
         ALL_CONVERTERS.put(Path.class, PATH_CONVERTER);
+        ALL_CONVERTERS.put(File.class, FILE_CONVERTER);
+
+        ALL_CONVERTERS.put(URI.class, URI_CONVERTER);
 
         Map<Class<?>, Class<?>> primitiveTypes = new HashMap<>(9);
         primitiveTypes.put(byte.class, Byte.class);

--- a/implementation/src/test/java/io/smallrye/config/ConvertersTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConvertersTest.java
@@ -17,6 +17,8 @@ package io.smallrye.config;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.chrono.ChronoLocalDate;
@@ -387,6 +389,26 @@ class ConvertersTest {
         assertThrows(NullPointerException.class, () -> convertNull(config, OptionalInt.class));
         assertThrows(NullPointerException.class, () -> convertNull(config, OptionalLong.class));
         assertThrows(NullPointerException.class, () -> convertNull(config, OptionalDouble.class));
+    }
+
+    @Test
+    void file() {
+        SmallRyeConfig config = buildConfig("file", "/test", "file.leading.space", " test");
+        assertEquals(new File("/test"), config.getValue("file", File.class));
+        assertEquals(new File(" test"), config.getValue("file.leading.space", File.class));
+        Converter<File> fileConverter = config.getConverterOrNull(File.class);
+        assertNotNull(fileConverter);
+        assertTrue(fileConverter.getClass().getName().contains("BuiltInConverter"));
+    }
+
+    @Test
+    void uri() {
+        SmallRyeConfig config = buildConfig("uri", "http://localhost", "uri.leading.space", " http://localhost");
+        assertEquals(URI.create("http://localhost"), config.getValue("uri", URI.class));
+        assertEquals(URI.create("http://localhost"), config.getValue("uri.leading.space", URI.class));
+        Converter<URI> uriConverter = config.getConverterOrNull(URI.class);
+        assertNotNull(uriConverter);
+        assertTrue(uriConverter.getClass().getName().contains("BuiltInConverter"));
     }
 
     @SafeVarargs


### PR DESCRIPTION
It seems counter productive to throw so many NoSuchMethodExceptions for these common uses cases.

These are the ones I could identify in the flame graph, let me know if you see more.