### PR TITLE
Use StringBuilder instead of String concat for startup code

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/AbstractLocationConfigSourceLoader.java
@@ -264,7 +264,13 @@ public abstract class AbstractLocationConfigSourceLoader {
 
     private static URI addProfileName(final URI uri, final String profile, final String fileExtension) {
         if ("jar".equals(uri.getScheme())) {
-            return URI.create("jar:" + addProfileName(URI.create(uri.getRawSchemeSpecificPart()), profile, fileExtension));
+            URI rec = addProfileName(URI.create(uri.getRawSchemeSpecificPart()), profile, fileExtension);
+            String recString = rec.toString();
+            String finalString = new StringBuilder("jar:".length() + recString.length())
+                    .append("jar:")
+                    .append(recString)
+                    .toString();
+            return URI.create(finalString);
         }
 
         final String fileName = uri.getPath();
@@ -273,9 +279,20 @@ public abstract class AbstractLocationConfigSourceLoader {
         final int dot = fileName.lastIndexOf(".");
         final String fileNameProfile;
         if (dot != -1 && dot != 0 && fileName.charAt(dot - 1) != '/') {
-            fileNameProfile = fileName.substring(0, dot) + "-" + profile + "." + fileExtension;
+            String substring = fileName.substring(0, dot);
+            fileNameProfile = new StringBuilder(substring.length() + 1 + profile.length() + 1 + fileExtension.length())
+                    .append(substring)
+                    .append("-")
+                    .append(profile)
+                    .append(".")
+                    .append(fileExtension)
+                    .toString();
         } else {
-            fileNameProfile = fileName + "-" + profile;
+            fileNameProfile = new StringBuilder(fileName.length() + 1 + profile.length())
+                    .append(fileName)
+                    .append("-")
+                    .append(profile)
+                    .toString();
         }
 
         try {

--- a/implementation/src/main/java/io/smallrye/config/ProfileConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ProfileConfigSourceInterceptor.java
@@ -35,7 +35,10 @@ public class ProfileConfigSourceInterceptor implements ConfigSourceInterceptor {
         this.profiles = reverseProfiles;
         this.prefixProfiles = new ArrayList<>();
         for (String profile : this.profiles) {
-            this.prefixProfiles.add("%" + profile + ".");
+            this.prefixProfiles.add(new StringBuilder(1 + profile.length() + 1)
+                    .append("%")
+                    .append(profile)
+                    .append(".").toString());
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -255,7 +255,14 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
                 if (profileValue != null) {
                     final List<String> convertProfiles = convertProfile(profileValue.getValue());
                     for (String profile : convertProfiles) {
-                        profiles.addAll(getProfiles(context, "%" + profile + "." + SMALLRYE_CONFIG_PROFILE_PARENT));
+                        String effectivePropertyName = new StringBuilder(
+                                1 + profile.length() + 1 + SMALLRYE_CONFIG_PROFILE_PARENT.length())
+                                .append("%")
+                                .append(profile)
+                                .append(".")
+                                .append(SMALLRYE_CONFIG_PROFILE_PARENT)
+                                .toString();
+                        profiles.addAll(getProfiles(context, effectivePropertyName));
                         profiles.add(profile);
                     }
                 }


### PR DESCRIPTION
Unfortunately the JDK's indyfied String concatenation has a slight performance penalty at startup, so for code we know will always be run at startup, let's not pay that unnecessary price