### PR TITLE
Use StringBuilder instead of String concat for startup code

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -87,6 +87,16 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <!-- As string concatenation has a non-zero impact on startup, let's disable it for this module -->
+            <compilerArgument>-XDstringConcat=inline</compilerArgument>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <environmentVariables>


### PR DESCRIPTION
Unfortunately the JDK's indyfied String concatenation has a slight performance penalty at startup, so for code we know will always be run at startup, let's not pay that unnecessary price
With this change we force `javac` to use the StringBuilder strategy

Replaces: #1292