### PR TITLE
Add new method isEnabled to ConfigSourceInterceptor

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/AbstractMappingConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/AbstractMappingConfigSourceInterceptor.java
@@ -8,9 +8,10 @@ public abstract class AbstractMappingConfigSourceInterceptor implements ConfigSo
     private static final long serialVersionUID = -3181156290079915301L;
 
     private final Function<String, String> mapping;
+    private final boolean enabled;
 
     public AbstractMappingConfigSourceInterceptor(final Function<String, String> mapping) {
-        this.mapping = mapping != null ? mapping : Function.identity();
+        this(mapping, true);
     }
 
     public AbstractMappingConfigSourceInterceptor(final Map<String, String> mappings) {
@@ -19,7 +20,12 @@ public abstract class AbstractMappingConfigSourceInterceptor implements ConfigSo
             public String apply(final String name) {
                 return mappings.getOrDefault(name, name);
             }
-        });
+        }, !mappings.isEmpty());
+    }
+
+    AbstractMappingConfigSourceInterceptor(final Function<String, String> mapping, boolean enabled) {
+        this.mapping = mapping != null ? mapping : Function.identity();
+        this.enabled = enabled;
     }
 
     @Override
@@ -48,6 +54,11 @@ public abstract class AbstractMappingConfigSourceInterceptor implements ConfigSo
                 return name;
             }
         };
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
     }
 
     protected Function<String, String> getMapping() {

--- a/implementation/src/main/java/io/smallrye/config/ConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigSourceInterceptor.java
@@ -55,6 +55,18 @@ public interface ConfigSourceInterceptor extends Serializable {
         return context.iterateNames();
     }
 
+    /**
+     * If the interceptor is enabled or disabled. If the interceptor is disabled, it will be removed from the final
+     * interceptor chain. The interceptor is still used and evaluated during the intermediate steps when assembling
+     * the configuration. For instance, an interceptor marked as disabled is still evaluated when calling the chain in
+     * {@link ConfigSourceFactory}, since late configuration may reenable or disable the current interceptor.
+     *
+     * @return <code>true</code> if the interceptor is enabld or <code>false</code> otherwise
+     */
+    default boolean isEnabled() {
+        return true;
+    }
+
     ConfigSourceInterceptor EMPTY = new ConfigSourceInterceptor() {
         private static final long serialVersionUID = 5749001327530543433L;
 

--- a/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java
@@ -143,4 +143,9 @@ public class ExpressionConfigSourceInterceptor implements ConfigSourceIntercepto
         }
         return handler;
     }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
 }

--- a/implementation/src/main/java/io/smallrye/config/LoggingConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/LoggingConfigSourceInterceptor.java
@@ -48,4 +48,9 @@ public class LoggingConfigSourceInterceptor implements ConfigSourceInterceptor {
         }
         return secret;
     }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
 }

--- a/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
@@ -41,4 +41,9 @@ public class SecretKeysConfigSourceInterceptor implements ConfigSourceIntercepto
         }
         return context.iterateNames();
     }
+
+    @Override
+    public boolean isEnabled() {
+        return !secrets.isEmpty();
+    }
 }

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -919,12 +919,16 @@ public class SmallRyeConfig implements Config, Serializable {
             current = new SmallRyeConfigSourceInterceptorContext(new SmallRyeConfigSources(sourcesWithPriorities, true),
                     current, chain);
             for (ConfigSourceInterceptor interceptor : negativeInterceptors) {
-                current = new SmallRyeConfigSourceInterceptorContext(interceptor, current, chain);
+                if (interceptor.isEnabled()) {
+                    current = new SmallRyeConfigSourceInterceptorContext(interceptor, current, chain);
+                }
             }
             current = new SmallRyeConfigSourceInterceptorContext(new SmallRyeConfigSources(sourcesWithPriorities, false),
                     current, chain);
             for (ConfigSourceInterceptor interceptor : positiveInterceptors) {
-                current = new SmallRyeConfigSourceInterceptorContext(interceptor, current, chain);
+                if (interceptor.isEnabled()) {
+                    current = new SmallRyeConfigSourceInterceptorContext(interceptor, current, chain);
+                }
             }
 
             this.profiles = profiles;

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -300,7 +300,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
                 return OptionalInt.of(Priorities.LIBRARY + 200 - 1);
             }
 
-            class MultipleProfileProperty implements Comparable<MultipleProfileProperty> {
+            private static class MultipleProfileProperty implements Comparable<MultipleProfileProperty> {
                 private final String name;
                 private final String relocateName;
                 private final List<String> profiles;


### PR DESCRIPTION
The goal is to remove the interceptor from the chain if `isEnabled=false` to reduce the stack call, instead of keeping a passthrough interceptor.