### PR TITLE
check duplicate keys for yaml (snakeyaml.version update to 2.4)

### DIFF
--- a/sources/yaml/pom.xml
+++ b/sources/yaml/pom.xml
@@ -13,7 +13,7 @@
     <name>SmallRye Config: ConfigSource - YAML</name>
 
     <properties>
-        <snakeyaml.version>2.3</snakeyaml.version>
+        <snakeyaml.version>2.4</snakeyaml.version>
     </properties>
 
     <dependencies>

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlConfigDuplicateTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/YamlConfigDuplicateTest.java
@@ -1,0 +1,82 @@
+package io.smallrye.config.source.yaml;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+class YamlConfigDuplicateTest {
+
+    @Test
+    void yamlConfigDuplicate() {
+
+        // setup logger to capture messages
+        LogMessageInterceptorHandler logCaptureHandler = new LogMessageInterceptorHandler();
+        java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
+        rootLogger.addHandler(logCaptureHandler);
+
+        // sample yaml with duplicate keys
+        String yaml = "---\n" +
+                "quarkus:\n" +
+                "  banner:\n" +
+                "    enabled: false\n" +
+                "  banner:\n" +
+                "    enabled: true";
+
+        // read yaml configuration
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new YamlConfigSource("yaml", yaml))
+                .build();
+
+        // check current value of duplicate key (the last value is read, true)
+        Assertions.assertTrue(config.getValue("quarkus.banner.enabled", Boolean.class));
+
+        // check if the duplication warning has been logged
+        Assertions.assertTrue(logCaptureHandler.containsLogMessage("duplicate keys found : banner"));
+
+        // remove log capture handler
+        rootLogger.removeHandler(logCaptureHandler);
+    }
+
+    /*
+     * Logging handler used to test if a message has been really logged.
+     */
+    public static class LogMessageInterceptorHandler extends Handler {
+
+        private Set<String> messages = new HashSet<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            // add log messages to a set
+            this.messages.add(record.getMessage());
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() throws SecurityException {
+
+        }
+
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            return super.isLoggable(record);
+        }
+
+        public boolean containsLogMessage(String message) {
+            // check if a message has been logged
+            return this.messages.contains(message);
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Fixes #1269

Hello, first of all thanks for your great work on SmallRye project 😊

With pull request [check duplicate keys #1270](https://github.com/smallrye/smallrye-config/pull/1270) I was only able to detect duplicate key in property configuration.

So I worked on [SnakeYAML Project](https://bitbucket.org/snakeyaml/snakeyaml/issues/1101/option-to-log-duplicate-keys) and opened a pull request to [check duplicate keys in yaml](https://github.com/snakeyaml/snakeyaml/pull/17).

This contribution was added in [SnakeYAML 2.4](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes).

Basically I propose to : 
- update SnakeYAML version to 2.4
- add testing for yaml duplication check (just capture and check logging)

What do you think @radcortez ? is it acceptable?

Thanks in advance.
