### PR TITLE
Correctly match Env names when mapping contains empty names

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -290,7 +290,7 @@ public final class ConfigMappingContext {
      *         properties do not match.
      */
     private static List<Integer> indexOfDashes(final String mappedProperty, final String envProperty) {
-        if (mappedProperty.length() > envProperty.length()) {
+        if (mappedProperty.isEmpty() || mappedProperty.length() > envProperty.length()) {
             return null;
         }
 

--- a/implementation/src/test/java/io/smallrye/config/EnvConfigSourceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/EnvConfigSourceTest.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toSet;
 import static java.util.stream.StreamSupport.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -361,6 +362,27 @@ class EnvConfigSourceTest {
         interface Nested {
             String another();
         }
+    }
+
+    @Test
+    void dashedEnvNamesWithEmpty() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new EnvConfigSource(Map.of("DASHED_IGNORED_ERRORS_0_", "error0"), 300))
+                .withMapping(DashedEnvNamesWithEmpty.class)
+                .build();
+
+        DashedEnvNamesWithEmpty mapping = config.getConfigMapping(DashedEnvNamesWithEmpty.class);
+
+        assertTrue(mapping.ignoredErrors().isPresent());
+        mapping.ignoredErrors().ifPresent(ignoredErrors -> assertIterableEquals(List.of("error0"), ignoredErrors));
+    }
+
+    @ConfigMapping(prefix = "dashed")
+    interface DashedEnvNamesWithEmpty {
+        @WithParentName
+        Optional<Boolean> enable();
+
+        Optional<List<String>> ignoredErrors();
     }
 
     @Test


### PR DESCRIPTION
For https://github.com/quarkiverse/quarkus-logging-sentry/pull/286