### PR TITLE
Move mapping Env matching to ConfigSource initialization

### DIFF
--- a/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
+++ b/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
@@ -286,6 +286,10 @@ public class StringUtil {
      * @return <code>true</code> if the dotted property name ir part of a dotted path, or <code>false</code> otherwise.
      */
     public static boolean isInPath(final String path, final String name) {
+        if (path.isEmpty()) {
+            return true;
+        }
+
         if (name.equals(path)) {
             return false;
         }

--- a/implementation/src/test/java/io/smallrye/config/EnvConfigSourceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/EnvConfigSourceTest.java
@@ -707,6 +707,31 @@ class EnvConfigSourceTest {
         Optional<String> value();
     }
 
+    @Test
+    void clashMapKeysWithNames() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new EnvConfigSource(Map.of("MAP_CLIENT_ID", "VALUE"), 300))
+                .withMapping(ClashMapKeysWithNames.class)
+                .build();
+
+        ClashMapKeysWithNames mapping = config.getConfigMapping(ClashMapKeysWithNames.class);
+        assertTrue(mapping.clashes().get(null).clientId().isPresent());
+    }
+
+    @ConfigMapping(prefix = "map")
+    interface ClashMapKeysWithNames {
+        @WithParentName
+        @WithUnnamedKey
+        @WithDefaults
+        Map<String, Clash> clashes();
+
+        interface Clash {
+            Optional<String> id();
+
+            Optional<String> clientId();
+        }
+    }
+
     private static boolean envSourceEquals(String name, String lookup) {
         return BOOLEAN_CONVERTER.convert(new EnvConfigSource(Map.of(name, "true"), 100).getValue(lookup));
     }


### PR DESCRIPTION
Env matching is now done when we initialize ConfigSources, which allows to remove some workarounds and unrelated code in other areas. Relevant code is now part of the `EnvSource` and the source env matching and mapping matching are not handled by a single method (before, each had their own specific method).