### PR TITLE
Make order of Config elements more deterministic

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -222,8 +222,8 @@ public class ConfigMappingGenerator {
      * class annotated with {@link org.eclipse.microprofile.config.inject.ConfigProperties}.
      * <p>
      *
-     * The generated configuration interface implements {@link ConfigMappingClassMapper} which provides the brige
-     * between the instace of the configuration class and the implementation of the configuration interface provided by
+     * The generated configuration interface implements {@link ConfigMappingClassMapper} which provides the bridge
+     * between the instance of the configuration class and the implementation of the configuration interface provided by
      * {@link ConfigMappingGenerator#generate(ConfigMappingInterface)} to retrieve the configuration values.
      *
      * @param classType the configuration class.


### PR DESCRIPTION
This is important because they might be used to generate code and we
want the order to be deterministic.

I added a second commit that is based on the first one (I can isolate it in a follow-up if you prefer) to try to reduce a bit the allocations of the discovery.

Also fixed a few typos noticed while reading the javadoc :)