### PR TITLE
Return a pre-registered Converter if one exists when calling `getImplicitConverter`

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -282,8 +282,7 @@ public final class Converters {
         }
 
         for (Type type : clazz.getGenericInterfaces()) {
-            if (type instanceof ParameterizedType) {
-                ParameterizedType pt = (ParameterizedType) type;
+            if (type instanceof ParameterizedType pt) {
                 if (pt.getRawType().equals(Converter.class)) {
                     Type[] typeArguments = pt.getActualTypeArguments();
                     if (typeArguments.length != 1) {
@@ -304,8 +303,9 @@ public final class Converters {
      * @param <T> the type
      * @return the implicit converter for the given type class, or {@code null} if none exists
      */
+    @SuppressWarnings("unchecked")
     public static <T> Converter<T> getImplicitConverter(Class<? extends T> type) {
-        return Implicit.getConverter(type);
+        return (Converter<T>) ALL_CONVERTERS.getOrDefault(type, Implicit.getConverter(type));
     }
 
     /**

--- a/implementation/src/test/java/io/smallrye/config/ConvertersTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConvertersTest.java
@@ -513,6 +513,11 @@ class ConvertersTest {
         assertEquals("CharSequence", config.getValue("cs", CharSequence.class));
     }
 
+    @Test
+    void implicit() {
+        assertEquals(Converters.BOOLEAN_CONVERTER, Converters.getImplicitConverter(Boolean.class));
+    }
+
     @SafeVarargs
     private static <T> T[] array(T... items) {
         return items;
@@ -520,7 +525,6 @@ class ConvertersTest {
 
     private static SmallRyeConfig buildConfig(String... keyValues) {
         return new SmallRyeConfigBuilder()
-                .addDefaultSources()
                 .withSources(KeyValuesConfigSource.config(keyValues))
                 .build();
     }


### PR DESCRIPTION
- For https://github.com/quarkusio/quarkus/issues/50206