### PR TITLE
Provide a way to enable / disable cache of property names when building the config

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -86,6 +86,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
     private boolean addDiscoveredInterceptors = false;
     private boolean addDiscoveredSecretKeysHandlers = false;
     private boolean addDiscoveredValidator = false;
+    private boolean cachePropertyNames = true;
 
     public SmallRyeConfigBuilder addDiscoveredCustomizers() {
         addDiscoveredCustomizers = true;
@@ -708,6 +709,10 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         return addDiscoveredValidator;
     }
 
+    public boolean isCachePropertyNames() {
+        return cachePropertyNames;
+    }
+
     public SmallRyeConfigBuilder setAddDefaultSources(final boolean addDefaultSources) {
         this.addDefaultSources = addDefaultSources;
         return this;
@@ -750,6 +755,11 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
 
     public SmallRyeConfigBuilder setAddDiscoveredValidator(final boolean addDiscoveredValidator) {
         this.addDiscoveredValidator = addDiscoveredValidator;
+        return this;
+    }
+
+    public SmallRyeConfigBuilder setCachePropertyNames(boolean cachePropertyNames) {
+        this.cachePropertyNames = cachePropertyNames;
         return this;
     }
 

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -805,4 +805,55 @@ class SmallRyeConfigTest {
         assertEquals("1234", wrappedConfig.getConfigValue("my.prop").getValue());
         assertEquals("1234", wrappedConfig.getConfigValue("%prod.my.prop").getValue());
     }
+
+    @Test
+    void propertyNames() {
+        Map<String, String> configSource = new HashMap<>();
+        configSource.put("one", "1");
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withSources(new MapBackedConfigSource("map", configSource) {
+                })
+                .build();
+
+        Set<String> propertyNames = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertEquals(1, propertyNames.size());
+        assertTrue(propertyNames.contains("one"));
+
+        configSource.put("two", "2");
+        propertyNames = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertEquals(1, propertyNames.size());
+        assertTrue(propertyNames.contains("one"));
+        assertEquals("2", config.getConfigValue("two").getValue());
+
+        propertyNames = stream(config.getLatestPropertyNames().spliterator(), false).collect(toSet());
+        assertEquals(2, propertyNames.size());
+        assertTrue(propertyNames.contains("one"));
+        assertTrue(propertyNames.contains("two"));
+
+        propertyNames = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertEquals(2, propertyNames.size());
+        assertTrue(propertyNames.contains("one"));
+        assertTrue(propertyNames.contains("two"));
+    }
+
+    @Test
+    void propertyNamesNoCache() {
+        Map<String, String> configSource = new HashMap<>();
+        configSource.put("one", "1");
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .setCachePropertyNames(false)
+                .withSources(new MapBackedConfigSource("map", configSource) {
+                })
+                .build();
+
+        Set<String> propertyNames = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertEquals(1, propertyNames.size());
+        assertTrue(propertyNames.contains("one"));
+
+        configSource.put("two", "2");
+        propertyNames = stream(config.getPropertyNames().spliterator(), false).collect(toSet());
+        assertEquals(2, propertyNames.size());
+        assertTrue(propertyNames.contains("one"));
+        assertTrue(propertyNames.contains("two"));
+    }
 }


### PR DESCRIPTION
We cache the list of property names because they are expensive to calculate on every call to `org.eclipse.microprofile.config.Config#getPropertyNames` (the spec, leaves that open to the implementation).

Now, because in Quarkus, we mutate configuration during tests, we cannot cache the list of names, so we need to call `io.smallrye.config.SmallRyeConfig#getLatestPropertyNames`. 

With this PR, we can disable the caching for the test config and rely solely on `getPropertyNames`.