### PR TITLE
Ensure modular access when reflecting

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -776,6 +776,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
     }
 
     private static ConfigMappingInterface createConfigurationInterface(Class<?> interfaceType) {
+        ConfigMappingInterface.class.getModule().addReads(interfaceType.getModule());
         if (!interfaceType.isInterface() || interfaceType.getTypeParameters().length != 0) {
             return null;
         }

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -158,6 +158,7 @@ public final class ConfigMappingLoader {
     }
 
     static Class<?> loadClass(final Class<?> parent, final ConfigMappingMetadata configMappingMetadata) {
+        ConfigMappingLoader.class.getModule().addReads(parent.getModule());
         // acquire a lock on the class name to prevent race conditions in multithreaded use cases
         synchronized (getClassLoaderLock(configMappingMetadata.getClassName())) {
             // Check if the interface implementation was already loaded. If not we will load it.
@@ -202,6 +203,8 @@ public final class ConfigMappingLoader {
         ConfigMappingImplementation(final Class<?> implementation) {
             try {
                 this.implementation = implementation;
+                // ensure modular access
+                ConfigMappingImplementation.class.getModule().addReads(implementation.getModule());
                 MethodHandle constructor = LOOKUP.findConstructor(implementation,
                         methodType(void.class, ConfigMappingContext.class));
                 this.constructor = constructor.asType(constructor.type().changeReturnType(Object.class));


### PR DESCRIPTION
The exception trace looks like this:

```
15:30:02,846 ERROR [io.qua.run.Quarkus] Error running Quarkus: java.lang.ExceptionInInitializerError
	at org.acme.getting.started@1.0.0-SNAPSHOT/io.quarkus.runtime.generated.StaticInitConfigCustomizer.configBuilder(Unknown Source)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.SmallRyeConfigBuilder.build(SmallRyeConfigBuilder.java:772)
	at org.acme.getting.started@1.0.0-SNAPSHOT/io.quarkus.runtime.generated.Config.<clinit>(Unknown Source)
	at org.acme.getting.started@1.0.0-SNAPSHOT/io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
	at java.base/jdk.internal.misc.Unsafe.allocateInstance(Native Method)
	at java.base/java.lang.invoke.DirectMethodHandle.allocateInstance(DirectMethodHandle.java:501)
	at io.quarkus.core@999-SNAPSHOT/io.quarkus.runtime.Quarkus.run(Quarkus.java:78)
	at io.quarkus.core@999-SNAPSHOT/io.quarkus.runtime.Quarkus.run(Quarkus.java:50)
	at io.quarkus.core@999-SNAPSHOT/io.quarkus.runtime.Quarkus.run(Quarkus.java:143)
	at org.acme.getting.started@1.0.0-SNAPSHOT/io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at io.github.dmlloyd.modules@1.0-SNAPSHOT/io.github.dmlloyd.modules.Launcher.run(Launcher.java:146)
	at io.github.dmlloyd.modules@1.0-SNAPSHOT/io.github.dmlloyd.modules.Launcher.main(Launcher.java:380)
	at io.github.dmlloyd.modules@1.0-SNAPSHOT/io.github.dmlloyd.modules.Launcher.main(Launcher.java:256)
Caused by: java.lang.reflect.UndeclaredThrowableException
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappingLoader.configMappingSecrets(ConfigMappingLoader.java:107)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappings$ConfigClass.<init>(ConfigMappings.java:127)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappings$ConfigClass.configClass(ConfigMappings.java:188)
	at io.quarkus.core@999-SNAPSHOT/io.quarkus.runtime.configuration.AbstractConfigBuilder.configClass(AbstractConfigBuilder.java:141)
	at org.acme.getting.started@1.0.0-SNAPSHOT/io.quarkus.runtime.generated.SharedConfig.<clinit>(Unknown Source)
	... 13 more
Caused by: java.lang.IllegalAccessError: symbolic reference class is not accessible: class io.quarkus.resteasy.reactive.common.runtime.ResteasyReactiveConfig$$CMImpl, from class io.smallrye.config.ConfigMappingLoader (module io.smallrye.config.core)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappingLoader$ConfigMappingImplementation.<init>(ConfigMappingLoader.java:213)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappingLoader$1.computeValue(ConfigMappingLoader.java:29)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappingLoader$1.computeValue(ConfigMappingLoader.java:26)
	at java.base/java.lang.ClassValue.getFromHashMap(ClassValue.java:229)
	at java.base/java.lang.ClassValue.getFromBackup(ClassValue.java:211)
	at java.base/java.lang.ClassValue.get(ClassValue.java:117)
	at io.smallrye.config.core@3.14.1/io.smallrye.config.ConfigMappingLoader.configMappingSecrets(ConfigMappingLoader.java:91)
	... 17 more
```