### PR TITLE
Correctly set the config source position in ConfigValue

### DIFF
--- a/implementation/src/test/java/io/smallrye/config/ConfigValueConfigSourceWrapperTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigValueConfigSourceWrapperTest.java
@@ -7,6 +7,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import io.smallrye.config.SmallRyeConfigSources.ConfigValueConfigSourceWrapper;
+
 class ConfigValueConfigSourceWrapperTest {
     @Test
     void getConfigValue() {
@@ -54,6 +56,6 @@ class ConfigValueConfigSourceWrapperTest {
     }
 
     private static ConfigValueConfigSource config() {
-        return SmallRyeConfigSources.ConfigValueConfigSourceWrapper.wrap(KeyValuesConfigSource.config("my.prop", "1234"));
+        return new ConfigValueConfigSourceWrapper(KeyValuesConfigSource.config("my.prop", "1234"));
     }
 }


### PR DESCRIPTION
Since https://github.com/smallrye/smallrye-config/pull/1128, the `ConfigValue#configSourcePosition` was reset between positive / negative sources. This correctly sets the source position in the lookup, regardless of whether the source is positive or negative.