### PR TITLE
Make ImplicitConverterTest.simpleDateFormat timezone independent

### DIFF
--- a/implementation/src/test/java/io/smallrye/config/ImplicitConverterTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ImplicitConverterTest.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import org.eclipse.microprofile.config.spi.Converter;
 import org.junit.jupiter.api.Test;
@@ -208,7 +209,10 @@ class ImplicitConverterTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withSources(config("sdf", "yyyy-MM-dd"))
                 .build();
+
         SimpleDateFormat sdf = config.getValue("sdf", SimpleDateFormat.class);
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+
         assertEquals("1970-01-01", sdf.format(Date.from(Instant.EPOCH)));
     }
 


### PR DESCRIPTION
This PR fixes a test failure in non-UTC environments.

ImplicitConverterTest.simpleDateFormat relied on the JVM default time zone,
which caused the epoch date to resolve to 1969-12-31 in some regions
(e.g. America/Chicago).

The test is made deterministic by explicitly setting the timezone
to UTC on the SimpleDateFormat instance.

Fixes #1445
