### PR TITLE
Update current sources while reading late sources

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -2007,6 +2007,12 @@ public class SmallRyeConfig implements Config, Serializable {
                         countSourcesFromLocations = countSourcesFromLocations + configSources.size();
                     }
 
+                    List<ConfigSourceWithPriority> updatedCurrentSources = mapSources(profileContext.getConfigSources(),
+                            configSources);
+                    profileContext.getConfigSources().clear();
+                    profileContext.getConfigSources()
+                            .addAll(updatedCurrentSources.stream().map(ConfigSourceWithPriority::getSource).toList());
+
                     lateSources.addAll(configSources);
                 }
             }


### PR DESCRIPTION
Without this, a custom `ConfigSourceFactory` is not able to access properties defined in files referenced in `smallrye.config.locations`.