### PR TITLE
Fix PropertyNamesMatcher fallback to wildcards even if exact match exists as null

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/PropertyNamesMatcher.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertyNamesMatcher.java
@@ -103,10 +103,6 @@ public class PropertyNamesMatcher<T> {
             return result;
         }
 
-        if (properties.containsKey(name)) {
-            return null;
-        }
-
         NameIterator ni = new NameIterator(name);
         result = get(wildcards, ni);
         return result == noMatch() ? null : result;

--- a/implementation/src/test/java/io/smallrye/config/PropertyNamesMatcherTest.java
+++ b/implementation/src/test/java/io/smallrye/config/PropertyNamesMatcherTest.java
@@ -113,6 +113,14 @@ class PropertyNamesMatcherTest {
     }
 
     @Test
+    void fallbackWildcard() {
+        PropertyNamesMatcher<String> matcher = new PropertyNamesMatcher<>();
+        matcher.add("map.specific.key", null);
+        matcher.add("map.*.key", "wildcard");
+        assertEquals("wildcard", matcher.get("map.specific.key"));
+    }
+
+    @Test
     void allPaths() {
         PropertyNamesMatcher<?> matcher = new PropertyNamesMatcher<>();
         matcher.add("name.*");


### PR DESCRIPTION
For https://github.com/quarkiverse/quarkiverse/issues/195#issuecomment-4278471857