### PR TITLE
Fix #1390: preserve line breaks and whitespace in FileSystemConfigSource

### DIFF
--- a/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
+++ b/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
@@ -97,8 +97,8 @@ public class FileSystemConfigSource extends MapBackedConfigSource {
     }
 
     private static String readContent(Path file) {
-        try (Stream<String> stream = Files.lines(file)) {
-            return stream.collect(Collectors.joining());
+        try {
+            return Files.readString(file);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
+++ b/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
@@ -97,11 +97,7 @@ public class FileSystemConfigSource extends MapBackedConfigSource {
     }
 
     private static String readContent(Path file) {
-        try {
-            return Files.readString(file);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return Files.readString(file);
     }
 
     @Override

--- a/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceTest.java
+++ b/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceTest.java
@@ -57,4 +57,13 @@ class FileSystemConfigSourceTest {
         // you can't rewrite the key, only the file name
         assertNull(configSource.getValue("MYSERVICE_MP_REST_URL"));
     }
+
+    @Test
+    void testMultilineValue() throws URISyntaxException {
+        URL configDirURL = this.getClass().getResource("configDir");
+        File dir = new File(configDirURL.toURI());
+
+        ConfigSource configSource = new FileSystemConfigSource(dir);
+        assertEquals("line 1\n\n   \nline with trailing spaces   \n\n", configSource.getValue("foo"));
+    }
 }

--- a/sources/file-system/src/test/resources/io/smallrye/config/source/file/configDir/foo
+++ b/sources/file-system/src/test/resources/io/smallrye/config/source/file/configDir/foo
@@ -1,0 +1,5 @@
+line 1
+
+   
+line with trailing spaces   
+


### PR DESCRIPTION
Currently, FileSystemConfigSource uses `Files.lines().collect(joining())` which strips all line endings from the source file.

This PR switches to `Files.readString()` to ensure the content is returned exactly as-is, preserving multiline values and trailing spaces.