### PR TITLE
Stabilize hashCode of ConfigClass

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -192,7 +192,10 @@ public final class ConfigMappings {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, prefix);
+            // we are specifically hashing the class name here as Class doesn't implement hashCode and doesn't provide a stable hashCode implementation
+            // we want this hashCode to be stable so that order in HashMap/HashSet is preserved - if added in same order
+            // the equals implementation is still using Class so that it's ClassLoader aware
+            return Objects.hash(type.getName(), prefix);
         }
 
         public static ConfigClass configClass(final Class<?> klass, final String prefix) {


### PR DESCRIPTION
Class doesn't implement its own hashCode so its hashCode is not stable at all.
During the reproducibility work made by @reaver585, we figured out it would be better to have a stable hashCode.

We don't change the equals() as we want the class loader to be taken into account in the equals().

Related to a discussion in:
https://github.com/quarkusio/quarkus/pull/54371#discussion_r3312830183