### PR TITLE
Add SPI ConfigMappingHandler to split handling of @ConfigMapping and @ConfigProperties

### DIFF
--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>smallrye-config-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-microprofile</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigExtension.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigExtension.java
@@ -15,8 +15,7 @@
  */
 package io.smallrye.config.inject;
 
-import static io.smallrye.config.ConfigMappings.registerConfigMappings;
-import static io.smallrye.config.ConfigMappings.registerConfigProperties;
+import static io.smallrye.config.ConfigMappings.registerConfigClasses;
 import static io.smallrye.config.inject.ConfigProducer.isClassHandledByConfigProducer;
 import static io.smallrye.config.inject.InjectionMessages.formatInjectionPoint;
 import static io.smallrye.config.inject.SecuritySupport.getContextClassLoader;
@@ -238,8 +237,8 @@ public class ConfigExtension implements Extension {
         }
 
         try {
-            registerConfigMappings(config, configMappings);
-            registerConfigProperties(config, configProperties);
+            registerConfigClasses(config, configMappings, true);
+            registerConfigClasses(config, configProperties, false);
         } catch (ConfigValidationException e) {
             adv.addDeploymentProblem(e);
         }

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -28,6 +28,11 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-microprofile</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-validator</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -65,8 +65,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.eclipse.microprofile.config.inject.ConfigProperties;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -206,6 +204,7 @@ public class ConfigMappingGenerator {
     static byte[] generate(final Class<?> classType, final String interfaceName) {
         String classInternalName = getInternalName(classType);
         String interfaceInternalName = interfaceName.replace('.', '/');
+        ConfigMappingHandler configClassHandler = ConfigMappingHandler.Handlers.find(classType);
 
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
         writer.visit(V1_8, ACC_PUBLIC | ACC_INTERFACE | ACC_ABSTRACT, interfaceInternalName, null, I_OBJECT,
@@ -214,10 +213,11 @@ public class ConfigMappingGenerator {
         {
             AnnotationVisitor av = writer.visitAnnotation("L" + getInternalName(ConfigMapping.class) + ";", true);
             av.visitEnum("namingStrategy", "L" + getInternalName(NamingStrategy.class) + ";",
-                    NamingStrategy.VERBATIM.toString());
+                    configClassHandler.getNamingStrategy().toString());
 
-            if (classType.isAnnotationPresent(ConfigProperties.class)) {
-                av.visit("prefix", classType.getAnnotation(ConfigProperties.class).prefix());
+            String prefix = configClassHandler.getPrefix(classType);
+            if (!prefix.isEmpty()) {
+                av.visit("prefix", prefix);
             }
 
             av.visitEnd();
@@ -236,53 +236,46 @@ public class ConfigMappingGenerator {
                     getMethodDescriptor(getType(declaredField.getType())), getSignature(declaredField),
                     null);
 
-            boolean hasDefault = false;
+            ConfigMappingHandler.FieldMember fieldMember = configClassHandler.processField(declaredField);
 
-            if (declaredField.isAnnotationPresent(WithName.class)) {
+            String name = declaredField.isAnnotationPresent(WithName.class)
+                    ? declaredField.getAnnotation(WithName.class).value()
+                    : fieldMember.name();
+
+            String defaultValue = declaredField.isAnnotationPresent(WithDefault.class)
+                    ? declaredField.getAnnotation(WithDefault.class).value()
+                    : fieldMember.defaultValue();
+
+            Class<? extends org.eclipse.microprofile.config.spi.Converter<?>> converter = declaredField
+                    .isAnnotationPresent(WithConverter.class)
+                            ? declaredField.getAnnotation(WithConverter.class).value()
+                            : fieldMember.converter();
+
+            if (name != null) {
                 AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithName.class) + ";", true);
-                av.visit("value", declaredField.getAnnotation(WithName.class).value());
+                av.visit("value", name);
                 av.visitEnd();
             }
 
-            if (declaredField.isAnnotationPresent(WithDefault.class)) {
+            if (defaultValue != null) {
                 AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithDefault.class) + ";", true);
-                av.visit("value", declaredField.getAnnotation(WithDefault.class).value());
+                av.visit("value", defaultValue);
                 av.visitEnd();
-                hasDefault = true;
             }
 
-            if (declaredField.isAnnotationPresent(WithConverter.class)) {
+            if (converter != null) {
                 AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithConverter.class) + ";", true);
-                av.visit("value", declaredField.getAnnotation(WithConverter.class).value());
+                av.visit("value", converter);
                 av.visitEnd();
             }
 
-            if (declaredField.isAnnotationPresent(ConfigProperty.class)) {
-                ConfigProperty configProperty = declaredField.getAnnotation(ConfigProperty.class);
-                {
-                    if (!configProperty.name().isEmpty()) {
-                        AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithName.class) + ";", true);
-                        av.visit("value", configProperty.name());
-                        av.visitEnd();
-                    }
-                }
-                {
-                    if (!configProperty.defaultValue().equals(ConfigProperty.UNCONFIGURED_VALUE)) {
-                        AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithDefault.class) + ";", true);
-                        av.visit("value", configProperty.defaultValue());
-                        av.visitEnd();
-                        hasDefault = true;
-                    }
-                }
-            }
-
-            if (!hasDefault) {
+            if (defaultValue == null) {
                 try {
                     declaredField.setAccessible(true);
-                    Object defaultValue = declaredField.get(classInstance);
-                    if (hasDefaultValue(declaredField.getType(), defaultValue)) {
+                    Object fieldDefault = declaredField.get(classInstance);
+                    if (hasDefaultValue(declaredField.getType(), fieldDefault)) {
                         AnnotationVisitor av = mv.visitAnnotation("L" + getInternalName(WithDefault.class) + ";", true);
-                        av.visit("value", defaultValue.toString());
+                        av.visit("value", fieldDefault.toString());
                         av.visitEnd();
                     }
                 } catch (IllegalAccessException e) {

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingHandler.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingHandler.java
@@ -1,0 +1,142 @@
+package io.smallrye.config;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.WeakHashMap;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+import io.smallrye.config.ConfigMapping.NamingStrategy;
+import io.smallrye.config._private.ConfigMessages;
+
+/**
+ * SPI to support configuration classes.
+ * <p>
+ * Implementations describe how to extract configuration metadata from annotated classes, enabling the core
+ * {@link ConfigMappingGenerator} to produce a backing interface and implementation without being coupled to any
+ * specific annotation model.
+ * <p>
+ * Implementations are discovered via {@link java.util.ServiceLoader}.
+ */
+public interface ConfigMappingHandler {
+    /**
+     * Whether this handler recognizes the given class as a configuration class.
+     *
+     * @param classType the candidate class.
+     * @return {@code true} if this handler can extract configuration metadata from the class.
+     */
+    boolean handles(Class<?> classType);
+
+    /**
+     * Extract the configuration prefix from the class.
+     *
+     * @param classType the configuration class.
+     * @return the prefix, or an empty string if none.
+     */
+    String getPrefix(Class<?> classType);
+
+    /**
+     * Extract configuration metadata from a field of a configuration class.
+     * <p>
+     * The returned {@link FieldMember} provides name, default value, and converter metadata derived from
+     * handler-specific annotations. SmallRye Config's own annotations ({@link WithName}, {@link WithDefault},
+     * {@link WithConverter}) take precedence over the values returned here.
+     *
+     * @param field the field to process.
+     * @return a {@link FieldMember} with the extracted metadata, or {@link FieldMember#EMPTY} if this handler has
+     *         nothing to contribute for the given field.
+     */
+    default FieldMember processField(Field field) {
+        return FieldMember.EMPTY;
+    }
+
+    /**
+     * The naming strategy to use when generating the backing interface for the configuration class.
+     * <p>
+     * Defaults to {@link NamingStrategy#VERBATIM}, which uses field names as-is.
+     *
+     * @return the naming strategy.
+     */
+    default NamingStrategy getNamingStrategy() {
+        return NamingStrategy.VERBATIM;
+    }
+
+    /**
+     * Whether unmapped properties under the configuration prefix should be ignored during validation.
+     * <p>
+     * When {@code true}, properties present in config sources that do not map to any field in the configuration
+     * class are silently ignored. When {@code false}, they are reported as validation errors.
+     * <p>
+     * Defaults to {@code false}.
+     *
+     * @return {@code true} to ignore unmapped properties, {@code false} to validate them.
+     */
+    default boolean ignoreUnmappedProperties() {
+        return false;
+    }
+
+    record FieldMember(String name, String defaultValue, Class<? extends Converter<?>> converter) {
+        public static final FieldMember EMPTY = new FieldMember(null, null, null);
+    }
+
+    final class Handlers {
+        private static final ConfigMappingHandler FALLBACK = new FallbackClassHandler();
+        private static final Map<ClassLoader, List<ConfigMappingHandler>> cache = Collections
+                .synchronizedMap(new WeakHashMap<>());
+
+        static ConfigMappingHandler find(final Class<?> classType) {
+            List<ConfigMappingHandler> handlers = cache.computeIfAbsent(classType.getClassLoader(), Handlers::load);
+            for (ConfigMappingHandler handler : handlers) {
+                if (handler.handles(classType)) {
+                    return handler;
+                }
+            }
+            Class<?> declaring = classType.getDeclaringClass();
+            if (declaring != null) {
+                return find(declaring);
+            }
+            return FALLBACK;
+        }
+
+        private static List<ConfigMappingHandler> load(final ClassLoader classLoader) {
+            List<ConfigMappingHandler> handlers = new ArrayList<>();
+            for (ConfigMappingHandler handler : ServiceLoader.load(ConfigMappingHandler.class, classLoader)) {
+                handlers.add(handler);
+            }
+            handlers.add(new ConfigMappingInterfaceHandler());
+            return List.copyOf(handlers);
+        }
+
+        private final static class ConfigMappingInterfaceHandler implements ConfigMappingHandler {
+            @Override
+            public boolean handles(Class<?> classType) {
+                if (!classType.isInterface() && classType.isAnnotationPresent(ConfigMapping.class)) {
+                    throw ConfigMessages.msg.mappingAnnotationNotSupportedInClass(classType);
+                }
+                return classType.isInterface();
+            }
+
+            @Override
+            public String getPrefix(Class<?> classType) {
+                ConfigMapping configMapping = classType.getAnnotation(ConfigMapping.class);
+                return configMapping != null ? configMapping.prefix() : "";
+            }
+        }
+
+        private final static class FallbackClassHandler implements ConfigMappingHandler {
+            @Override
+            public boolean handles(Class<?> classType) {
+                return true;
+            }
+
+            @Override
+            public String getPrefix(Class<?> classType) {
+                return "";
+            }
+        }
+    }
+}

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -13,8 +13,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.microprofile.config.inject.ConfigProperties;
-
 import io.smallrye.common.classloader.ClassDefiner;
 import io.smallrye.common.constraint.Assert;
 import io.smallrye.config._private.ConfigMessages;
@@ -174,7 +172,7 @@ public final class ConfigMappingLoader {
                 if (parent.isAssignableFrom(klass)) {
                     return klass;
                 }
-                // ConfigProperties should not have issues with classloader and interfaces.
+                // Config classes should not have issues with classloader and interfaces.
                 if (configMappingMetadata instanceof ConfigMappingClass) {
                     return klass;
                 }
@@ -200,7 +198,7 @@ public final class ConfigMappingLoader {
         return classLoaderLocks.computeIfAbsent(className, c -> new Object());
     }
 
-    public static final class ConfigMappingImplementation {
+    static final class ConfigMappingImplementation {
         private final Class<?> implementation;
         private MethodHandle constructor;
         private MethodHandle getProperties;
@@ -212,11 +210,11 @@ public final class ConfigMappingLoader {
             ConfigMappingImplementation.class.getModule().addReads(implementation.getModule());
         }
 
-        public Class<?> implementation() {
+        Class<?> implementation() {
             return implementation;
         }
 
-        public MethodHandle constructor() {
+        MethodHandle constructor() {
             MethodHandle constructor = this.constructor;
             if (constructor == null) {
                 try {
@@ -232,7 +230,7 @@ public final class ConfigMappingLoader {
             return this.constructor;
         }
 
-        public MethodHandle getProperties() {
+        MethodHandle getProperties() {
             MethodHandle getProperties = this.getProperties;
             if (getProperties == null) {
                 try {
@@ -247,7 +245,7 @@ public final class ConfigMappingLoader {
             return getProperties;
         }
 
-        public MethodHandle getSecrets() {
+        MethodHandle getSecrets() {
             MethodHandle getSecrets = this.getSecrets;
             if (getSecrets == null) {
                 try {
@@ -264,7 +262,7 @@ public final class ConfigMappingLoader {
     }
 
     /**
-     * Implementation of {@link ConfigMappingMetadata} for MicroProfile {@link ConfigProperties}.
+     * Implementation of {@link ConfigMappingMetadata} for configuration classes.
      */
     static final class ConfigMappingClass implements ConfigMappingMetadata {
         private static final ClassValue<ConfigMappingClass> cv = new ClassValue<>() {

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappings.java
@@ -9,11 +9,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.eclipse.microprofile.config.inject.ConfigProperties;
-
 import io.smallrye.common.constraint.Assert;
+import io.smallrye.config.ConfigMappingHandler.Handlers;
 import io.smallrye.config.ConfigMappingInterface.Property;
-import io.smallrye.config._private.ConfigMessages;
 
 /**
  * Utility class for {@link ConfigMapping} annotated classes.
@@ -21,40 +19,25 @@ import io.smallrye.config._private.ConfigMessages;
 public final class ConfigMappings {
 
     /**
-     * Registers additional {@link ConfigMapping} annotated classes with a {@link SmallRyeConfig} instance.
+     * Registers additional {@link ConfigClass} classes with a {@link SmallRyeConfig} instance.
      * <p>
-     * The recommended method of registering {@link ConfigMapping} is with a
+     * The recommended method of registering {@link ConfigClass} is with a
      * {@link SmallRyeConfigBuilder#withMapping(Class)}. In certain cases, this is not possible (ex. a CDI
-     * runtime), where mapping classes can only be discovered after the <code>Config</code> instance creation.
+     * runtime), where config classes can only be discovered after the <code>Config</code> instance creation.
      *
      * @param config the {@link SmallRyeConfig} instance
-     * @param configClasses a <code>Set</code> of {@link ConfigMapping} annotated classes with prefixes
-     * @throws ConfigValidationException if a {@link ConfigMapping} cannot be registed with the
-     *         {@link SmallRyeConfig} instance
+     * @param configClasses a <code>Set</code> of {@link ConfigClass} classes with prefixes
+     * @param validateUnknown if <code>true</code> it will validate that all configurations in {@link SmallRyeConfig}
+     *        under the specified config classes prefixes have a matching property
+     * @throws ConfigValidationException if a {@link ConfigClass} cannot be registered with the {@link SmallRyeConfig} instance
      */
-    public static void registerConfigMappings(final SmallRyeConfig config, final Set<ConfigClass> configClasses)
+    public static void registerConfigClasses(
+            final SmallRyeConfig config,
+            final Set<ConfigClass> configClasses,
+            final boolean validateUnknown)
             throws ConfigValidationException {
         if (!configClasses.isEmpty()) {
-            mapConfiguration(config, new SmallRyeConfigBuilder(), configClasses);
-        }
-    }
-
-    /**
-     * Registers additional <code>ConfigProperties</code> annotated classes with a {@link SmallRyeConfig} instance.
-     * <p>
-     * The recommended method of registering <code>ConfigProperties</code> is with a
-     * {@link SmallRyeConfigBuilder#withMapping(Class)}. In certain cases, this is not possible (ex. a CDI
-     * runtime), where mapping classes can only be discovered after the <code>Config</code> instance creation.
-     *
-     * @param config the {@link SmallRyeConfig} instance
-     * @param configClasses a <code>Set</code> of <code>ConfigProperties</code> annotated classes with prefixes
-     * @throws ConfigValidationException if a <code>ConfigProperties</code> cannot be registed with the
-     *         {@link SmallRyeConfig} instance
-     */
-    public static void registerConfigProperties(final SmallRyeConfig config, final Set<ConfigClass> configClasses)
-            throws ConfigValidationException {
-        if (!configClasses.isEmpty()) {
-            mapConfiguration(config, new SmallRyeConfigBuilder().withValidateUnknown(false), configClasses);
+            mapConfiguration(config, new SmallRyeConfigBuilder().withValidateUnknown(validateUnknown), configClasses);
         }
     }
 
@@ -122,7 +105,7 @@ public final class ConfigMappings {
     }
 
     /**
-     * A representation of a {@link ConfigMapping} or <code>@ConfigProperties</code>.
+     * A representation of a configuration class.
      */
     public static final class ConfigClass {
         private final Class<?> type;
@@ -200,26 +183,8 @@ public final class ConfigMappings {
         }
 
         public static ConfigClass configClass(final Class<?> klass) {
-            if (!klass.isInterface() && klass.isAnnotationPresent(ConfigMapping.class)) {
-                throw ConfigMessages.msg.mappingAnnotationNotSupportedInClass(klass);
-            }
-
-            if (klass.isInterface() && klass.isAnnotationPresent(ConfigProperties.class)) {
-                throw ConfigMessages.msg.propertiesAnnotationNotSupportedInInterface(klass);
-            }
-
-            if (klass.isInterface()) {
-                ConfigMapping configMapping = klass.getAnnotation(ConfigMapping.class);
-                String prefix = configMapping != null ? configMapping.prefix() : "";
-                return configClass(klass, prefix);
-            } else {
-                ConfigProperties configProperties = klass.getAnnotation(ConfigProperties.class);
-                String prefix = configProperties != null ? configProperties.prefix() : "";
-                if (prefix.equals(ConfigProperties.UNCONFIGURED_PREFIX)) {
-                    prefix = "";
-                }
-                return configClass(klass, prefix);
-            }
+            ConfigMappingHandler configClassHandler = Handlers.find(klass);
+            return configClass(klass, configClassHandler.getPrefix(klass));
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -51,7 +51,6 @@ import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
-import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
 import org.eclipse.microprofile.config.spi.Converter;
@@ -641,14 +640,7 @@ public class SmallRyeConfig implements Config, Serializable {
 
     @Override
     public <T> T getConfigMapping(final Class<T> type) {
-        String prefix;
-        if (type.isInterface()) {
-            ConfigMapping configMapping = type.getAnnotation(ConfigMapping.class);
-            prefix = configMapping != null ? configMapping.prefix() : "";
-        } else {
-            ConfigProperties configProperties = type.getAnnotation(ConfigProperties.class);
-            prefix = configProperties != null ? configProperties.prefix() : "";
-        }
+        String prefix = ConfigMappingHandler.Handlers.find(type).getPrefix(type);
         return getConfigMapping(type, prefix);
     }
 

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -840,8 +840,8 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
             defaults.add(configClass.getProperties());
             secretKeys.add(configClass.getSecrets());
 
-            // It is an MP ConfigProperties, so ignore unmapped properties
-            if (ConfigMappingLoader.ConfigMappingClass.getConfigurationClass(configClass.getType()) != null) {
+            ConfigMappingHandler handler = ConfigMappingHandler.Handlers.find(configClass.getType());
+            if (handler.ignoreUnmappedProperties()) {
                 ignores.add(configClass.getPrefix().isEmpty() ? "*" : configClass.getPrefix() + ".**");
             }
         }

--- a/implementation/src/main/java/io/smallrye/config/_private/ConfigMessages.java
+++ b/implementation/src/main/java/io/smallrye/config/_private/ConfigMessages.java
@@ -211,4 +211,7 @@ public interface ConfigMessages {
 
     @Message(id = 56, value = "Incompatible ConfigProviderResolver type: Expected %s, but found %s")
     IllegalStateException incompatibleConfigProvider(String expected, String actual);
+
+    @Message(id = 57, value = "Class %s is not recognized as a config class")
+    IllegalStateException classNotRecognizedAsConfigClass(Class<?> type);
 }

--- a/implementation/src/main/java/module-info.java
+++ b/implementation/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module io.smallrye.config {
     exports io.smallrye.config;
     exports io.smallrye.config._private to
         io.smallrye.config.inject,
+        io.smallrye.config.microprofile,
         io.smallrye.config.source.file,
         io.smallrye.config.source.keystore,
         io.smallrye.config.crypto;
@@ -30,6 +31,7 @@ module io.smallrye.config {
     uses io.smallrye.config.SecretKeysHandler;
     uses io.smallrye.config.SecretKeysHandlerFactory;
     uses io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+    uses io.smallrye.config.ConfigMappingHandler;
 
     uses org.eclipse.microprofile.config.spi.ConfigSource;
     uses org.eclipse.microprofile.config.spi.ConfigSourceProvider;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.Converter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -92,16 +91,6 @@ class ConfigMappingClassTest {
     @Test
     void initializedDefault() {
         assertThrows(Exception.class, () -> new SmallRyeConfigBuilder().withMapping(ServerInitializedDefault.class).build());
-    }
-
-    @Test
-    void mpConfig20() {
-        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerMPConfig20.class)
-                .withDefaultValue("name", "localhost")
-                .build();
-        ServerMPConfig20 server = config.getConfigMapping(ServerMPConfig20.class);
-        assertEquals("localhost", server.getHost());
-        assertEquals(8080, server.getPort());
     }
 
     @Test
@@ -244,21 +233,6 @@ class ConfigMappingClassTest {
 
     static class ServerInitializedDefault {
         private int port;
-
-        public int getPort() {
-            return port;
-        }
-    }
-
-    static class ServerMPConfig20 {
-        @ConfigProperty(name = "name")
-        private String host;
-        @ConfigProperty(defaultValue = "8080")
-        private int port;
-
-        public String getHost() {
-            return host;
-        }
 
         public int getPort() {
             return port;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingWithKeysTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingWithKeysTest.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.Test;
 
-import io.smallrye.config.ConfigMappingWithKeysTest.AdditionalKeys.KeysProvider;
 import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.common.MapBackedConfigSource;
 
@@ -312,7 +311,7 @@ class ConfigMappingWithKeysTest {
                 .withMappingIgnore("env.**")
                 .build();
 
-        ConfigMappings.registerConfigMappings(originalConfig, Set.of(ConfigClass.configClass(EnvKeys.class)));
+        ConfigMappings.registerConfigClasses(originalConfig, Set.of(ConfigClass.configClass(EnvKeys.class)), true);
         Map<String, String> map = originalConfig.getConfigMapping(EnvKeys.class).map();
         assertEquals("value", map.get("dashed-key"));
 

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingsTest.java
@@ -1,6 +1,6 @@
 package io.smallrye.config;
 
-import static io.smallrye.config.ConfigMappings.registerConfigMappings;
+import static io.smallrye.config.ConfigMappings.registerConfigClasses;
 import static io.smallrye.config.ConfigMappings.ConfigClass.configClass;
 import static io.smallrye.config.KeyValuesConfigSource.config;
 import static java.util.Collections.singleton;
@@ -30,7 +30,7 @@ public class ConfigMappingsTest {
                 .withConverter(Version.class, 100, new VersionConverter())
                 .build();
 
-        registerConfigMappings(config, singleton(configClass(Server.class, "server")));
+        registerConfigClasses(config, singleton(configClass(Server.class, "server")), true);
         Server server = config.getConfigMapping(Server.class);
 
         assertEquals("localhost", server.host());
@@ -55,7 +55,7 @@ public class ConfigMappingsTest {
                 .build();
 
         assertThrows(ConfigValidationException.class,
-                () -> registerConfigMappings(config, singleton(configClass(Server.class, "server"))),
+                () -> registerConfigClasses(config, singleton(configClass(Server.class, "server")), true),
                 "server.unmapped does not map to any root");
     }
 
@@ -63,7 +63,7 @@ public class ConfigMappingsTest {
     void validateAnnotations() {
         SmallRyeConfig config = new SmallRyeConfigBuilder().build();
         IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> registerConfigMappings(config, singleton(configClass(ServerMappingClass.class))));
+                () -> registerConfigClasses(config, singleton(configClass(ServerMappingClass.class)), true));
         assertTrue(exception.getMessage()
                 .startsWith("SRCFG00043: The @ConfigMapping annotation can only be placed in interfaces"));
 

--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~  Copyright 2025 Red Hat, Inc.
+ ~
+ ~  Licensed under the Apache License, Version 2.0 (the "License");
+ ~  you may not use this file except in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing, software
+ ~  distributed under the License is distributed on an "AS IS" BASIS,
+ ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~  See the License for the specific language governing permissions and
+ ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye.config</groupId>
+        <artifactId>smallrye-config-parent</artifactId>
+        <version>3.17.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>smallrye-config-microprofile</artifactId>
+
+    <name>SmallRye Config: MicroProfile</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-core</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens=io.smallrye.config.microprofile/io.smallrye.config.microprofile=io.smallrye.config</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/microprofile/src/main/java/io/smallrye/config/microprofile/ConfigPropertiesConfigMappingHandler.java
+++ b/microprofile/src/main/java/io/smallrye/config/microprofile/ConfigPropertiesConfigMappingHandler.java
@@ -1,0 +1,56 @@
+package io.smallrye.config.microprofile;
+
+import java.lang.reflect.Field;
+
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.smallrye.config.ConfigMappingHandler;
+import io.smallrye.config._private.ConfigMessages;
+
+/**
+ * A {@link ConfigMappingHandler} for MicroProfile Config {@link ConfigProperties @ConfigProperties} annotated classes.
+ * <p>
+ * Extracts the configuration prefix from {@link ConfigProperties#prefix()} and field-level metadata from
+ * {@link ConfigProperty @ConfigProperty} annotations (name and default value).
+ */
+public final class ConfigPropertiesConfigMappingHandler implements ConfigMappingHandler {
+    @Override
+    public boolean handles(Class<?> classType) {
+        if (!classType.isEnum() && !classType.isInterface() && !classType.isArray() && !classType.isPrimitive()) {
+            return classType.isAnnotationPresent(ConfigProperties.class);
+        }
+        if (classType.isAnnotationPresent(ConfigProperties.class)) {
+            throw ConfigMessages.msg.propertiesAnnotationNotSupportedInInterface(classType);
+        }
+        return false;
+    }
+
+    @Override
+    public FieldMember processField(final Field field) {
+        ConfigProperty configProperty = field.getAnnotation(ConfigProperty.class);
+        if (configProperty != null) {
+            String name = !configProperty.name().isEmpty() ? configProperty.name() : null;
+            String defaultValue = !configProperty.defaultValue().equals(ConfigProperty.UNCONFIGURED_VALUE)
+                    ? configProperty.defaultValue()
+                    : null;
+            return new FieldMember(name, defaultValue, null);
+        }
+        return FieldMember.EMPTY;
+    }
+
+    @Override
+    public boolean ignoreUnmappedProperties() {
+        return true;
+    }
+
+    @Override
+    public String getPrefix(Class<?> classType) {
+        ConfigProperties configProperties = classType.getAnnotation(ConfigProperties.class);
+        String prefix = configProperties != null ? configProperties.prefix() : "";
+        if (prefix.equals(ConfigProperties.UNCONFIGURED_PREFIX)) {
+            prefix = "";
+        }
+        return prefix;
+    }
+}

--- a/microprofile/src/main/java/module-info.java
+++ b/microprofile/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.smallrye.config.microprofile {
+    requires transitive io.smallrye.config;
+
+    exports io.smallrye.config.microprofile;
+
+    provides io.smallrye.config.ConfigMappingHandler with
+        io.smallrye.config.microprofile.ConfigPropertiesConfigMappingHandler;
+}

--- a/microprofile/src/test/java/io/smallrye/config/microprofile/ConfigPropertiesMappingsTest.java
+++ b/microprofile/src/test/java/io/smallrye/config/microprofile/ConfigPropertiesMappingsTest.java
@@ -1,9 +1,7 @@
-package io.smallrye.config.inject;
+package io.smallrye.config.microprofile;
 
-import static io.smallrye.config.ConfigMappings.registerConfigMappings;
-import static io.smallrye.config.ConfigMappings.registerConfigProperties;
+import static io.smallrye.config.ConfigMappings.registerConfigClasses;
 import static io.smallrye.config.ConfigMappings.ConfigClass.configClass;
-import static io.smallrye.config.inject.KeyValuesConfigSource.config;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,11 +13,13 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.Converter;
 import org.junit.jupiter.api.Test;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.ConfigMappingLoader;
+import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.WithParentName;
@@ -28,15 +28,16 @@ class ConfigPropertiesMappingsTest {
     @Test
     void registerProperties() {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
-                .withSources(config("server.host", "localhost", "server.port", "8080",
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.host", "localhost", "server.port", "8080",
                         "server.reasons.200", "OK", "server.reasons.201", "Created",
                         "server.versions.v1", "1.The version 1.2.3",
                         "server.versions.v2", "2.The version 2.0.0",
-                        "server.numbers.one", "1", "server.numbers.two", "2", "server.numbers.three", "3"))
+                        "server.numbers.one", "1", "server.numbers.two", "2", "server.numbers.three", "3"), "test"))
                 .withConverter(Version.class, 100, new VersionConverter())
                 .build();
 
-        registerConfigProperties(config, singleton(configClass(ServerClass.class, "server")));
+        registerConfigClasses(config, singleton(configClass(ServerClass.class, "server")), false);
         ServerClass server = config.getConfigMapping(ServerClass.class);
 
         assertEquals("localhost", server.host);
@@ -66,10 +67,11 @@ class ConfigPropertiesMappingsTest {
     void validateProperties() {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withConverter(Version.class, 100, new VersionConverter())
-                .withSources(config("server.host", "localhost", "server.port", "8080", "server.unmapped", "unmapped"))
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.host", "localhost", "server.port", "8080", "server.unmapped", "unmapped"), "test"))
                 .build();
 
-        registerConfigProperties(config, singleton(configClass(ServerClass.class, "server")));
+        registerConfigClasses(config, singleton(configClass(ServerClass.class, "server")), false);
         ServerClass server = config.getConfigMapping(ServerClass.class);
 
         assertEquals("localhost", server.host);
@@ -79,7 +81,8 @@ class ConfigPropertiesMappingsTest {
     @Test
     void validateWithBuilderOrConfig() {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
-                .withSources(config("server.host", "localhost", "server.port", "8080", "server.unmapped", "unmapped"))
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.host", "localhost", "server.port", "8080", "server.unmapped", "unmapped"), "test"))
                 .withMapping(ServerClass.class)
                 .withConverter(Version.class, 100, new VersionConverter())
                 .withValidateUnknown(true)
@@ -95,7 +98,8 @@ class ConfigPropertiesMappingsTest {
     @Test
     void validateDisableOnConfigProperties() {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
-                .withSources(config("server.host", "localhost", "server.port", "8080", "server.unmapped", "unmapped"))
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.host", "localhost", "server.port", "8080", "server.unmapped", "unmapped"), "test"))
                 .withMapping(ServerClass.class)
                 .withConverter(Version.class, 100, new VersionConverter())
                 .build();
@@ -111,7 +115,7 @@ class ConfigPropertiesMappingsTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder().build();
 
         IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> registerConfigMappings(config, singleton(configClass(ServerPropertiesInterface.class))));
+                () -> registerConfigClasses(config, singleton(configClass(ServerPropertiesInterface.class)), true));
         assertTrue(exception.getMessage()
                 .startsWith("SRCFG00044: The @ConfigProperties annotation can only be placed in classes"));
 
@@ -126,8 +130,9 @@ class ConfigPropertiesMappingsTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withMapping(ConfigMappingNamingKebab.class)
                 .withMapping(ConfigPropertiesNamingVerbatim.class)
-                .withSources(config("server.theHost", "localhost"))
-                .withSources(config("server.the-host", "localhost", "server.form.login-page", "login"))
+                .withSources(new PropertiesConfigSource(Map.of("server.theHost", "localhost"), "test"))
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.the-host", "localhost", "server.form.login-page", "login"), "test"))
                 .build();
 
         ConfigPropertiesNamingVerbatim configProperties = config.getConfigMapping(ConfigPropertiesNamingVerbatim.class);
@@ -136,6 +141,16 @@ class ConfigPropertiesMappingsTest {
         ConfigMappingNamingKebab configMapping = config.getConfigMapping(ConfigMappingNamingKebab.class);
         assertEquals("localhost", configMapping.theHost());
         assertEquals("login", configMapping.form().get("form").loginPage());
+    }
+
+    @Test
+    void configPropertyAnnotation() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder().withMapping(ServerMPConfig20.class)
+                .withDefaultValue("name", "localhost")
+                .build();
+        ServerMPConfig20 server = config.getConfigMapping(ServerMPConfig20.class);
+        assertEquals("localhost", server.host);
+        assertEquals(8080, server.port);
     }
 
     @Test
@@ -178,6 +193,14 @@ class ConfigPropertiesMappingsTest {
     @ConfigProperties(prefix = "server")
     public static class ServerProperties {
         public String host;
+        public int port;
+    }
+
+    @ConfigProperties
+    public static class ServerMPConfig20 {
+        @ConfigProperty(name = "name")
+        public String host;
+        @ConfigProperty(defaultValue = "8080")
         public int port;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
   <modules>
     <module>common</module>
     <module>implementation</module>
+    <module>microprofile</module>
     <module>cdi</module>
     <module>validator</module>
     <module>sources/hocon</module>


### PR DESCRIPTION
Introduces the `ConfigMappingHandler` SPI to decouple annotation-specific handling from the core implementation. 

This allows different annotation models (`@ConfigMapping`, `@ConfigProperties`, and potentially Spring's `@ConfigurationProperties`) to be supported through pluggable handlers discovered via ServiceLoader.