### PR TITLE
Reproduce issue with `@WithUnnamedKey` config group considered present even if unconfigured

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -45,6 +45,8 @@ public final class ConfigMappingContext {
 
     private NamingStrategy namingStrategy = NamingStrategy.KEBAB_CASE;
     private BeanStyleGetters beanStyleGetters = BeanStyleGetters.DISABLED;
+    private boolean resolvedNonDefault;
+
     private final StringBuilder nameBuilder = new StringBuilder();
     private final Set<String> usedProperties = new HashSet<>();
     private final List<Problem> problems = new ArrayList<>();
@@ -289,7 +291,7 @@ public final class ConfigMappingContext {
                 final Class<? extends Converter<K>> keyConvertWith,
                 final String unnamedKey,
                 final Iterable<String> keys) {
-            return map(keyRawType, keyConvertWith, unnamedKey, keys, null);
+            return map(keyRawType, keyConvertWith, unnamedKey, keys, null, null);
         }
 
         public <K, V> ObjectCreator<T> map(
@@ -297,7 +299,8 @@ public final class ConfigMappingContext {
                 final Class<? extends Converter<K>> keyConvertWith,
                 final String unnamedKey,
                 final Iterable<String> keys,
-                final Supplier<V> defaultValue) {
+                final Supplier<V> defaultValue,
+                final Supplier<V> unnamedDefaultSupplier) {
             Converter<K> keyConverter = keyConvertWith == null ? config.requireConverter(keyRawType)
                     : getConverterInstance(keyConvertWith);
             List<Consumer<Function<String, Object>>> nestedCreators = new ArrayList<>();
@@ -315,11 +318,26 @@ public final class ConfigMappingContext {
                         Map<K, V> map = defaultInstance != null ? new MapWithDefault<>(defaultInstance) : new HashMap<>();
 
                         if (unnamedKey != null) {
+                            V unnamedDefault = defaultInstance;
+                            if (unnamedDefault == null && unnamedDefaultSupplier != null) {
+                                int problemsBefore = problems.size();
+                                int length = nameBuilder.length();
+                                nameBuilder.append(".*");
+                                unnamedDefault = constructGroup(unnamedDefaultSupplier);
+                                nameBuilder.setLength(length);
+                                if (problems.size() > problemsBefore) {
+                                    problems.subList(problemsBefore, problems.size()).clear();
+                                    unnamedDefault = null;
+                                }
+                            }
+                            final V unnamedDefaultInstance = unnamedDefault;
                             nestedCreators.add(new Consumer<>() {
                                 @Override
                                 public void accept(Function<String, Object> get) {
+                                    resolvedNonDefault = false;
                                     V value = (V) get.apply(path);
-                                    if (value != null) {
+                                    if (value != null
+                                            && (resolvedNonDefault || !value.equals(unnamedDefaultInstance))) {
                                         map.put(unnamedKey.isEmpty() ? null : keyConverter.convert(unnamedKey), value);
                                     }
                                 }
@@ -590,7 +608,14 @@ public final class ConfigMappingContext {
                 final String propertyName,
                 final Converter<V> valueConverter) {
             context.usedProperties.add(propertyName);
-            return context.config.getValue(propertyName, valueConverter);
+            ConfigValue configValue = context.config.getConfigValue(propertyName);
+            if (configValue.getValue() != null && !configValue.isDefault()) {
+                context.resolvedNonDefault = true;
+            }
+            if (Converters.CONFIG_VALUE_CONVERTER.equals(valueConverter)) {
+                return (V) configValue.noProblems();
+            }
+            return context.config.convertValue(configValue, valueConverter);
         }
 
         public ObjectCreator<T> value(
@@ -644,7 +669,11 @@ public final class ConfigMappingContext {
                 final String propertyName,
                 final Converter<V> valueConverter) {
             context.usedProperties.add(propertyName);
-            return context.config.getOptionalValue(propertyName, valueConverter);
+            ConfigValue configValue = context.config.getConfigValue(propertyName);
+            if (configValue.getValue() != null && !configValue.isDefault()) {
+                context.resolvedNonDefault = true;
+            }
+            return context.config.convertValue(configValue, newOptionalConverter(valueConverter));
         }
 
         public <V> ObjectCreator<T> optionalValue(

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -594,6 +594,11 @@ public class ConfigMappingGenerator {
                 } else {
                     ctor.visitInsn(ACONST_NULL);
                 }
+                if (mapProperty.hasKeyUnnamed()) {
+                    ctor.visitGroupSupplier(valueProperty.asGroup().getGroupType().getInterfaceType());
+                } else {
+                    ctor.visitInsn(ACONST_NULL);
+                }
                 ctor.visitMethod(ObjectCreatorMapGroupInvocation.map);
                 if (mapProperty.hasKeyProvider()) {
                     ctor.visitGroupSupplier(valueProperty.asGroup().getGroupType().getInterfaceType());
@@ -1353,7 +1358,8 @@ public class ConfigMappingGenerator {
     }
 
     private enum ObjectCreatorMapGroupInvocation implements MethodInvocation {
-        map(INVOKEVIRTUAL, "(" + D_CLASS + D_CLASS + D_STRING + D_ITERABLE + D_SUPPLIER + ")" + D_OBJECT_CREATOR);
+        map(INVOKEVIRTUAL,
+                "(" + D_CLASS + D_CLASS + D_STRING + D_ITERABLE + D_SUPPLIER + D_SUPPLIER + ")" + D_OBJECT_CREATOR);
 
         private final int opcode;
         private final String desc;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingFullTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingFullTest.java
@@ -267,11 +267,50 @@ public class ConfigMappingFullTest {
                 .build();
 
         OrmConfig ormConfig = config.getConfigMapping(OrmConfig.class);
-        assertEquals(1, ormConfig.persistenceUnits().size());
+        assertEquals(0, ormConfig.persistenceUnits().size());
+        assertFalse(ormConfig.persistenceUnits().get("<default>").database().globallyQuotedIdentifiers());
         OrmRuntimeConfig ormRuntimeConfig = config.getConfigMapping(OrmRuntimeConfig.class);
         assertEquals(1, ormRuntimeConfig.persistenceUnits().size());
         assertEquals("drop-and-create",
                 ormRuntimeConfig.persistenceUnits().get("<default>").database().generation().generation());
+    }
+
+    @Test
+    void noUnnamedKeyUnlessSetByUser() {
+        SmallRyeConfig config;
+        OrmRuntimeConfig mapping;
+
+        // Nothing set by the user, so no key, but I can query a default
+        config = new SmallRyeConfigBuilder()
+                .withMapping(OrmRuntimeConfig.class)
+                .build();
+        mapping = config.getConfigMapping(OrmRuntimeConfig.class);
+        assertEquals(0, mapping.persistenceUnits().size());
+        assertEquals("none", mapping.persistenceUnits().get("<default>").database().generation().generation());
+        assertTrue(mapping.persistenceUnits().get("<default>").schemas().isEmpty());
+        assertEquals("none", mapping.persistenceUnits().get("named").database().generation().generation());
+        assertTrue(mapping.persistenceUnits().get("named").schemas().isEmpty());
+
+        // A property set by the user, so the default key must be present in the Map
+        config = new SmallRyeConfigBuilder()
+                .withSources(config("smallrye.config-orm.database.generation", "create"))
+                .withMapping(OrmRuntimeConfig.class)
+                .build();
+        mapping = config.getConfigMapping(OrmRuntimeConfig.class);
+        assertEquals(1, mapping.persistenceUnits().size());
+        assertTrue(mapping.persistenceUnits().containsKey("<default>"));
+        assertEquals("create", mapping.persistenceUnits().get("<default>").database().generation().generation());
+        assertTrue(mapping.persistenceUnits().get("<default>").schemas().isEmpty());
+
+        config = new SmallRyeConfigBuilder()
+                .withSources(config("smallrye.config-orm.schemas.version", "1"))
+                .withMapping(OrmRuntimeConfig.class)
+                .build();
+        mapping = config.getConfigMapping(OrmRuntimeConfig.class);
+        assertEquals(1, mapping.persistenceUnits().size());
+        assertTrue(mapping.persistenceUnits().containsKey("<default>"));
+        assertTrue(mapping.persistenceUnits().get("<default>").schemas().get(null).version().isPresent());
+        assertEquals("1", mapping.persistenceUnits().get("<default>").schemas().get(null).version().get());
     }
 
     @ConfigMapping(prefix = "smallrye.config-orm")
@@ -307,14 +346,26 @@ public class ConfigMappingFullTest {
         interface OrmRuntimeConfigPersistenceUnit {
             OrmConfigPersistenceUnitDatabase database();
 
+            @WithUnnamedKey
+            Map<String, OrmConfigPersistenceUnitSchema> schemas();
+
             interface OrmConfigPersistenceUnitDatabase {
                 OrmConfigPersistenceUnitDatabaseGeneration generation();
+
+                @WithDefault("true")
+                boolean log();
+
+                OptionalInt version();
+
+                interface OrmConfigPersistenceUnitDatabaseGeneration {
+                    @WithParentName
+                    @WithDefault("none")
+                    String generation();
+                }
             }
 
-            interface OrmConfigPersistenceUnitDatabaseGeneration {
-                @WithParentName
-                @WithDefault("none")
-                String generation();
+            interface OrmConfigPersistenceUnitSchema {
+                Optional<String> version();
             }
         }
     }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingInterfaceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingInterfaceTest.java
@@ -2727,6 +2727,7 @@ class ConfigMappingInterfaceTest {
         GroupDefaults mapping = config.getConfigMapping(GroupDefaults.class);
         assertEquals("value", mapping.group().value());
         assertEquals("default", mapping.defaults().group().get("default").value());
+        assertEquals("default", config.getConfigValue("group-defaults.group.x.value").getValue());
     }
 
     @ConfigMapping(prefix = "group-defaults")

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingMapDefaultsUnnamedKeyTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingMapDefaultsUnnamedKeyTest.java
@@ -1,0 +1,556 @@
+package io.smallrye.config;
+
+import static io.smallrye.config.KeyValuesConfigSource.config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Systematic tests for the behavior of {@link WithDefaults} and {@link WithUnnamedKey} on Maps in
+ * {@link ConfigMapping} interfaces.
+ * <p>
+ * These tests document <b>expected</b> behavior. Some assertions currently fail because of a bug:
+ * when {@code @WithUnnamedKey} is used and the config group has a config property with
+ * {@code @WithDefault}, the unnamed config group key always appears in the map, even when nothing
+ * is configured for it.
+ *
+ * @see <a href="https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/.40WithUnnamedKey.20and.20keySet">
+ *      Zulip discussion</a>
+ */
+public class ConfigMappingMapDefaultsUnnamedKeyTest {
+
+    // -- Config group interfaces (shared across multiple mappings) --
+
+    interface ConfigGroup {
+        @WithDefault("default-val")
+        String configProperty1();
+
+        Optional<String> configProperty2();
+    }
+
+    interface ConfigGroupNoPropertyDefaults {
+        Optional<String> configProperty1();
+
+        Optional<String> configProperty2();
+    }
+
+    // -- Non-map baseline config --
+
+    @ConfigMapping(prefix = "non-map")
+    interface NonMapConfig {
+        ConfigGroup nested();
+    }
+
+    // -- Non-map baseline tests --
+
+    @Test
+    void nonMap_configProperty2Configured() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(NonMapConfig.class)
+                .withSources(config("non-map.nested.config-property2", "user-val"))
+                .build();
+
+        NonMapConfig nonMap = config.getConfigMapping(NonMapConfig.class);
+        assertEquals("default-val", nonMap.nested().configProperty1());
+        assertEquals(Optional.of("user-val"), nonMap.nested().configProperty2());
+    }
+
+    @Test
+    void nonMap_noPropertiesConfigured() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(NonMapConfig.class)
+                .build();
+
+        NonMapConfig nonMap = config.getConfigMapping(NonMapConfig.class);
+        assertEquals("default-val", nonMap.nested().configProperty1());
+        assertEquals(Optional.empty(), nonMap.nested().configProperty2());
+    }
+
+    // -- Map tests --
+
+    @ParameterizedTest
+    @MethodSource("mapMappingsAndConfigGroupKeys")
+    <E> void keyConfigured(ConfigGroupMapMapping<E> mapping, ConfigGroupKey configGroupKey) {
+        SmallRyeConfig config = mapping.buildConfig(mapping.configProperty2Key(configGroupKey), "user-val");
+        Map<String, E> map = mapping.getConfigGroupMap(config);
+
+        assertTrue(map.containsKey(configGroupKey.key));
+
+        E configGroup = map.get(configGroupKey.key);
+        assertNotNull(configGroup, "get(configured key) should not be null");
+        assertEquals(Optional.of("user-val"), mapping.configProperty2Value(configGroup));
+        if (mapping.hasConfigProperty1Default()) {
+            assertEquals("default-val", mapping.configProperty1Value(configGroup));
+        } else {
+            assertNull(mapping.configProperty1Value(configGroup));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("mapMappingsAndConfigGroupKeys")
+    <E> void noKeysConfigured(ConfigGroupMapMapping<E> mapping, ConfigGroupKey configGroupKey) {
+        SmallRyeConfig config = mapping.buildConfig();
+        Map<String, E> map = mapping.getConfigGroupMap(config);
+
+        // ISSUE: when @WithUnnamedKey is used and the config group has a config property with
+        // @WithDefault, the unnamed config group key materializes because @WithDefault generates
+        // defaults-source properties (e.g. "with-unnamed-key-only.map.config-property1=default-val")
+        // that match the unnamed key path (no key segment), causing the config group to materialize.
+        // This happens with @WithUnnamedKey alone — @WithDefaults on the map is not required.
+        assertFalse(map.containsKey(configGroupKey.key),
+                "containsKey should be false when nothing is configured");
+
+        E configGroup = map.get(configGroupKey.key);
+        if (mapping.hasWithDefaults()) {
+            assertNotNull(configGroup, "@WithDefaults should provide a default config group via get()");
+            assertEquals(Optional.empty(), mapping.configProperty2Value(configGroup));
+            if (mapping.hasConfigProperty1Default()) {
+                assertEquals("default-val", mapping.configProperty1Value(configGroup));
+            } else {
+                assertNull(mapping.configProperty1Value(configGroup));
+            }
+        } else {
+            assertNull(configGroup,
+                    "get should return null when nothing is configured and @WithDefaults is not used");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("mapMappingsAndConfigGroupKeys")
+    <E> void bothConfigGroupKeysConfigured(ConfigGroupMapMapping<E> mapping, ConfigGroupKey configGroupKey) {
+        assumeTrue(mapping.hasWithUnnamedKey(), "Only applicable to mappings with @WithUnnamedKey");
+
+        SmallRyeConfig config = mapping.buildConfig(
+                mapping.configProperty2Key(ConfigGroupKey.NAMED), "named-val",
+                mapping.configProperty2Key(ConfigGroupKey.UNNAMED), "unnamed-val");
+        Map<String, E> map = mapping.getConfigGroupMap(config);
+
+        String expectedOptVal = configGroupKey == ConfigGroupKey.NAMED ? "named-val" : "unnamed-val";
+
+        assertTrue(map.containsKey(configGroupKey.key));
+
+        E configGroup = map.get(configGroupKey.key);
+        assertNotNull(configGroup);
+        assertEquals(Optional.of(expectedOptVal), mapping.configProperty2Value(configGroup));
+    }
+
+    @ParameterizedTest
+    @MethodSource("mapMappingsAndConfigGroupKeys")
+    <E> void otherConfigGroupKeyConfigured(ConfigGroupMapMapping<E> mapping, ConfigGroupKey configGroupKey) {
+        assumeTrue(mapping.hasWithUnnamedKey(), "Only applicable to mappings with @WithUnnamedKey");
+
+        ConfigGroupKey otherKey = configGroupKey == ConfigGroupKey.NAMED
+                ? ConfigGroupKey.UNNAMED
+                : ConfigGroupKey.NAMED;
+        SmallRyeConfig config = mapping.buildConfig(mapping.configProperty2Key(otherKey), "other-val");
+        Map<String, E> map = mapping.getConfigGroupMap(config);
+
+        // ISSUE: same unnamed config group key materialization as in noKeysConfigured.
+        assertFalse(map.containsKey(configGroupKey.key),
+                "containsKey should be false for a config group key that was not configured");
+
+        E configGroup = map.get(configGroupKey.key);
+        if (mapping.hasWithDefaults()) {
+            assertNotNull(configGroup, "@WithDefaults should provide a default config group via get()");
+            assertEquals(Optional.empty(), mapping.configProperty2Value(configGroup));
+            if (mapping.hasConfigProperty1Default()) {
+                assertEquals("default-val", mapping.configProperty1Value(configGroup));
+            } else {
+                assertNull(mapping.configProperty1Value(configGroup));
+            }
+        } else {
+            assertNull(configGroup,
+                    "get should return null for a config group key that was not configured");
+        }
+    }
+
+    // ============================
+    // Infrastructure
+    // ============================
+
+    enum ConfigGroupKey {
+        NAMED("mykey"),
+        UNNAMED("<default>");
+
+        final String key;
+
+        ConfigGroupKey(String key) {
+            this.key = key;
+        }
+    }
+
+    // -- ConfigGroupMapMapping abstraction --
+
+    static abstract class ConfigGroupMapMapping<E> {
+        abstract String name();
+
+        abstract Class<?>[] mappingClasses();
+
+        abstract Map<String, E> getConfigGroupMap(SmallRyeConfig config);
+
+        abstract String namedKeyConfigProperty2Key();
+
+        abstract String unnamedKeyConfigProperty2Key();
+
+        String configProperty2Key(ConfigGroupKey configGroupKey) {
+            return configGroupKey == ConfigGroupKey.NAMED
+                    ? namedKeyConfigProperty2Key()
+                    : unnamedKeyConfigProperty2Key();
+        }
+
+        abstract boolean hasWithDefaults();
+
+        abstract boolean hasWithUnnamedKey();
+
+        abstract boolean hasConfigProperty1Default();
+
+        abstract Optional<String> configProperty2Value(E configGroup);
+
+        abstract String configProperty1Value(E configGroup);
+
+        SmallRyeConfig buildConfig(String... keyValues) {
+            SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+            for (Class<?> c : mappingClasses()) {
+                builder.withMapping(c);
+            }
+            if (keyValues.length > 0) {
+                builder.withSources(config(keyValues));
+            }
+            return builder.build();
+        }
+
+        @Override
+        public String toString() {
+            return name();
+        }
+    }
+
+    static abstract class PropertyDefaultsConfigGroupMapMapping extends ConfigGroupMapMapping<ConfigGroup> {
+        @Override
+        boolean hasConfigProperty1Default() {
+            return true;
+        }
+
+        @Override
+        Optional<String> configProperty2Value(ConfigGroup configGroup) {
+            return configGroup.configProperty2();
+        }
+
+        @Override
+        String configProperty1Value(ConfigGroup configGroup) {
+            return configGroup.configProperty1();
+        }
+    }
+
+    static abstract class NoPropertyDefaultsConfigGroupMapMapping
+            extends ConfigGroupMapMapping<ConfigGroupNoPropertyDefaults> {
+        @Override
+        boolean hasConfigProperty1Default() {
+            return false;
+        }
+
+        @Override
+        Optional<String> configProperty2Value(ConfigGroupNoPropertyDefaults configGroup) {
+            return configGroup.configProperty2();
+        }
+
+        @Override
+        String configProperty1Value(ConfigGroupNoPropertyDefaults configGroup) {
+            return configGroup.configProperty1().orElse(null);
+        }
+    }
+
+    // -- Method source --
+
+    static Stream<Arguments> mapMappingsAndConfigGroupKeys() {
+        return Stream.<ConfigGroupMapMapping<?>> of(
+                new PlainMapping(),
+                new WithDefaultsOnlyMapping(),
+                new WithUnnamedKeyOnlyMapping(),
+                new WithDefaultsAndUnnamedKeyMapping(),
+                new WithParentNameDefaultsAndUnnamedKeyMapping(),
+                new WithUnnamedKeyNoPropertyDefaultsMapping())
+                .flatMap(m -> {
+                    Stream.Builder<Arguments> b = Stream.builder();
+                    b.add(Arguments.of(m, ConfigGroupKey.NAMED));
+                    if (m.hasWithUnnamedKey()) {
+                        b.add(Arguments.of(m, ConfigGroupKey.UNNAMED));
+                    }
+                    return b.build();
+                });
+    }
+
+    // -- ConfigGroupMapMapping implementations --
+
+    static class PlainMapping extends PropertyDefaultsConfigGroupMapMapping {
+        @ConfigMapping(prefix = "plain-map")
+        interface Config {
+            Map<String, ConfigGroup> map();
+        }
+
+        @Override
+        String name() {
+            return "plain-map";
+        }
+
+        @Override
+        Map<String, ConfigGroup> getConfigGroupMap(SmallRyeConfig config) {
+            return config.getConfigMapping(Config.class).map();
+        }
+
+        @Override
+        Class<?>[] mappingClasses() {
+            return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty2Key() {
+            return "plain-map.map.mykey.config-property2";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty2Key() {
+            return null;
+        }
+
+        @Override
+        boolean hasWithDefaults() {
+            return false;
+        }
+
+        @Override
+        boolean hasWithUnnamedKey() {
+            return false;
+        }
+    }
+
+    static class WithDefaultsOnlyMapping extends PropertyDefaultsConfigGroupMapMapping {
+        @ConfigMapping(prefix = "with-defaults-only")
+        interface Config {
+            @WithDefaults
+            Map<String, ConfigGroup> map();
+        }
+
+        @Override
+        String name() {
+            return "with-defaults-only";
+        }
+
+        @Override
+        Map<String, ConfigGroup> getConfigGroupMap(SmallRyeConfig config) {
+            return config.getConfigMapping(Config.class).map();
+        }
+
+        @Override
+        Class<?>[] mappingClasses() {
+            return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty2Key() {
+            return "with-defaults-only.map.mykey.config-property2";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty2Key() {
+            return null;
+        }
+
+        @Override
+        boolean hasWithDefaults() {
+            return true;
+        }
+
+        @Override
+        boolean hasWithUnnamedKey() {
+            return false;
+        }
+    }
+
+    static class WithUnnamedKeyOnlyMapping extends PropertyDefaultsConfigGroupMapMapping {
+        @ConfigMapping(prefix = "with-unnamed-key-only")
+        interface Config {
+            @WithUnnamedKey("<default>")
+            Map<String, ConfigGroup> map();
+        }
+
+        @Override
+        String name() {
+            return "with-unnamed-key-only";
+        }
+
+        @Override
+        Map<String, ConfigGroup> getConfigGroupMap(SmallRyeConfig config) {
+            return config.getConfigMapping(Config.class).map();
+        }
+
+        @Override
+        Class<?>[] mappingClasses() {
+            return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty2Key() {
+            return "with-unnamed-key-only.map.mykey.config-property2";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty2Key() {
+            return "with-unnamed-key-only.map.config-property2";
+        }
+
+        @Override
+        boolean hasWithDefaults() {
+            return false;
+        }
+
+        @Override
+        boolean hasWithUnnamedKey() {
+            return true;
+        }
+    }
+
+    static class WithDefaultsAndUnnamedKeyMapping extends PropertyDefaultsConfigGroupMapMapping {
+        @ConfigMapping(prefix = "with-defaults-and-unnamed-key")
+        interface Config {
+            @WithDefaults
+            @WithUnnamedKey("<default>")
+            Map<String, ConfigGroup> map();
+        }
+
+        @Override
+        String name() {
+            return "with-defaults-and-unnamed-key";
+        }
+
+        @Override
+        Map<String, ConfigGroup> getConfigGroupMap(SmallRyeConfig config) {
+            return config.getConfigMapping(Config.class).map();
+        }
+
+        @Override
+        Class<?>[] mappingClasses() {
+            return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty2Key() {
+            return "with-defaults-and-unnamed-key.map.mykey.config-property2";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty2Key() {
+            return "with-defaults-and-unnamed-key.map.config-property2";
+        }
+
+        @Override
+        boolean hasWithDefaults() {
+            return true;
+        }
+
+        @Override
+        boolean hasWithUnnamedKey() {
+            return true;
+        }
+    }
+
+    static class WithParentNameDefaultsAndUnnamedKeyMapping extends PropertyDefaultsConfigGroupMapMapping {
+        @ConfigMapping(prefix = "with-parent-name-defaults-and-unnamed-key")
+        interface Config {
+            @WithParentName
+            @WithDefaults
+            @WithUnnamedKey("<default>")
+            Map<String, ConfigGroup> map();
+        }
+
+        @Override
+        String name() {
+            return "with-parent-name-defaults-and-unnamed-key";
+        }
+
+        @Override
+        Map<String, ConfigGroup> getConfigGroupMap(SmallRyeConfig config) {
+            return config.getConfigMapping(Config.class).map();
+        }
+
+        @Override
+        Class<?>[] mappingClasses() {
+            return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty2Key() {
+            return "with-parent-name-defaults-and-unnamed-key.mykey.config-property2";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty2Key() {
+            return "with-parent-name-defaults-and-unnamed-key.config-property2";
+        }
+
+        @Override
+        boolean hasWithDefaults() {
+            return true;
+        }
+
+        @Override
+        boolean hasWithUnnamedKey() {
+            return true;
+        }
+    }
+
+    static class WithUnnamedKeyNoPropertyDefaultsMapping extends NoPropertyDefaultsConfigGroupMapMapping {
+        @ConfigMapping(prefix = "with-unnamed-key-no-property-defaults")
+        interface Config {
+            @WithUnnamedKey("<default>")
+            Map<String, ConfigGroupNoPropertyDefaults> map();
+        }
+
+        @Override
+        String name() {
+            return "with-unnamed-key-no-property-defaults";
+        }
+
+        @Override
+        Map<String, ConfigGroupNoPropertyDefaults> getConfigGroupMap(SmallRyeConfig config) {
+            return config.getConfigMapping(Config.class).map();
+        }
+
+        @Override
+        Class<?>[] mappingClasses() {
+            return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty2Key() {
+            return "with-unnamed-key-no-property-defaults.map.mykey.config-property2";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty2Key() {
+            return "with-unnamed-key-no-property-defaults.map.config-property2";
+        }
+
+        @Override
+        boolean hasWithDefaults() {
+            return false;
+        }
+
+        @Override
+        boolean hasWithUnnamedKey() {
+            return true;
+        }
+    }
+}

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingMapDefaultsUnnamedKeyTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingMapDefaultsUnnamedKeyTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class ConfigMappingMapDefaultsUnnamedKeyTest {
 
-    // -- Config group interfaces (shared across multiple mappings) --
-
     interface ConfigGroup {
         @WithDefault("default-val")
         String configProperty1();
@@ -46,14 +44,10 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         Optional<String> configProperty2();
     }
 
-    // -- Non-map baseline config --
-
     @ConfigMapping(prefix = "non-map")
     interface NonMapConfig {
         ConfigGroup nested();
     }
-
-    // -- Non-map baseline tests --
 
     @Test
     void nonMap_configProperty2Configured() {
@@ -77,8 +71,6 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         assertEquals("default-val", nonMap.nested().configProperty1());
         assertEquals(Optional.empty(), nonMap.nested().configProperty2());
     }
-
-    // -- Map tests --
 
     @ParameterizedTest
     @MethodSource("mapMappingsAndConfigGroupKeys")
@@ -104,11 +96,6 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         SmallRyeConfig config = mapping.buildConfig();
         Map<String, E> map = mapping.getConfigGroupMap(config);
 
-        // ISSUE: when @WithUnnamedKey is used and the config group has a config property with
-        // @WithDefault, the unnamed config group key materializes because @WithDefault generates
-        // defaults-source properties (e.g. "with-unnamed-key-only.map.config-property1=default-val")
-        // that match the unnamed key path (no key segment), causing the config group to materialize.
-        // This happens with @WithUnnamedKey alone — @WithDefaults on the map is not required.
         assertFalse(map.containsKey(configGroupKey.key),
                 "containsKey should be false when nothing is configured");
 
@@ -157,7 +144,6 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         SmallRyeConfig config = mapping.buildConfig(mapping.configProperty2Key(otherKey), "other-val");
         Map<String, E> map = mapping.getConfigGroupMap(config);
 
-        // ISSUE: same unnamed config group key materialization as in noKeysConfigured.
         assertFalse(map.containsKey(configGroupKey.key),
                 "containsKey should be false for a config group key that was not configured");
 
@@ -176,9 +162,67 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         }
     }
 
-    // ============================
-    // Infrastructure
-    // ============================
+    @ParameterizedTest
+    @MethodSource("mapMappingsAndConfigGroupKeys")
+    <E> void unnamedKeyConfiguredWithSameValueAsDefault(ConfigGroupMapMapping<E> mapping, ConfigGroupKey configGroupKey) {
+        assumeTrue(mapping.hasWithUnnamedKey(), "Only applicable to mappings with @WithUnnamedKey");
+        assumeTrue(mapping.hasConfigProperty1Default(), "Only applicable to mappings with @WithDefault on configProperty1");
+        assumeTrue(configGroupKey == ConfigGroupKey.UNNAMED, "Only applicable to the unnamed key");
+
+        // Explicitly set the unnamed key's configProperty1 to the same value as the @WithDefault.
+        // Even though the value matches the default, it comes from a real config source,
+        // so the unnamed key should appear in the map.
+        String configProperty1Key = mapping.configProperty1Key(configGroupKey);
+        SmallRyeConfig config = mapping.buildConfig(configProperty1Key, "default-val");
+        Map<String, E> map = mapping.getConfigGroupMap(config);
+
+        assertTrue(map.containsKey(configGroupKey.key),
+                "containsKey should be true when the unnamed key is explicitly configured, even with the same value as @WithDefault");
+    }
+
+    @ConfigMapping(prefix = "case2")
+    interface Case2Config {
+        @WithDefaults
+        @WithUnnamedKey("<default>")
+        Map<String, ConfigGroup> map();
+    }
+
+    @Test
+    void leafPropertiesResolvedAllFromDefaults() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(Case2Config.class)
+                .build();
+
+        Map<String, ConfigGroup> map = config.getConfigMapping(Case2Config.class).map();
+
+        assertFalse(map.containsKey("<default>"),
+                "unnamed key should not appear when all leaf properties resolve from defaults only");
+
+        ConfigGroup group = map.get("<default>");
+        assertNotNull(group, "@WithDefaults should still provide a default via get()");
+        assertEquals("default-val", group.configProperty1());
+        assertEquals(Optional.empty(), group.configProperty2());
+    }
+
+    @ConfigMapping(prefix = "case3")
+    interface Case3Config {
+        @WithUnnamedKey("<default>")
+        Map<String, Map<String, String>> map();
+    }
+
+    @Test
+    void nestedMapNoLeafResolution() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(Case3Config.class)
+                .withSources(config(
+                        "case3.map.nested-key", "value"))
+                .build();
+
+        Map<String, Map<String, String>> map = config.getConfigMapping(Case3Config.class).map();
+
+        assertTrue(map.containsKey("<default>"),
+                "unnamed key should appear for nested maps when config is provided at the unnamed path");
+    }
 
     enum ConfigGroupKey {
         NAMED("mykey"),
@@ -191,14 +235,22 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         }
     }
 
-    // -- ConfigGroupMapMapping abstraction --
-
     static abstract class ConfigGroupMapMapping<E> {
         abstract String name();
 
         abstract Class<?>[] mappingClasses();
 
         abstract Map<String, E> getConfigGroupMap(SmallRyeConfig config);
+
+        abstract String namedKeyConfigProperty1Key();
+
+        abstract String unnamedKeyConfigProperty1Key();
+
+        String configProperty1Key(ConfigGroupKey configGroupKey) {
+            return configGroupKey == ConfigGroupKey.NAMED
+                    ? namedKeyConfigProperty1Key()
+                    : unnamedKeyConfigProperty1Key();
+        }
 
         abstract String namedKeyConfigProperty2Key();
 
@@ -272,10 +324,8 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         }
     }
 
-    // -- Method source --
-
     static Stream<Arguments> mapMappingsAndConfigGroupKeys() {
-        return Stream.<ConfigGroupMapMapping<?>> of(
+        return Stream.of(
                 new PlainMapping(),
                 new WithDefaultsOnlyMapping(),
                 new WithUnnamedKeyOnlyMapping(),
@@ -291,8 +341,6 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
                     return b.build();
                 });
     }
-
-    // -- ConfigGroupMapMapping implementations --
 
     static class PlainMapping extends PropertyDefaultsConfigGroupMapMapping {
         @ConfigMapping(prefix = "plain-map")
@@ -313,6 +361,16 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         @Override
         Class<?>[] mappingClasses() {
             return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty1Key() {
+            return "plain-map.map.mykey.config-property1";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty1Key() {
+            return null;
         }
 
         @Override
@@ -359,6 +417,16 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         }
 
         @Override
+        String namedKeyConfigProperty1Key() {
+            return "with-defaults-only.map.mykey.config-property1";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty1Key() {
+            return null;
+        }
+
+        @Override
         String namedKeyConfigProperty2Key() {
             return "with-defaults-only.map.mykey.config-property2";
         }
@@ -399,6 +467,16 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         @Override
         Class<?>[] mappingClasses() {
             return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty1Key() {
+            return "with-unnamed-key-only.map.mykey.config-property1";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty1Key() {
+            return "with-unnamed-key-only.map.config-property1";
         }
 
         @Override
@@ -443,6 +521,16 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         @Override
         Class<?>[] mappingClasses() {
             return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty1Key() {
+            return "with-defaults-and-unnamed-key.map.mykey.config-property1";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty1Key() {
+            return "with-defaults-and-unnamed-key.map.config-property1";
         }
 
         @Override
@@ -491,6 +579,16 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         }
 
         @Override
+        String namedKeyConfigProperty1Key() {
+            return "with-parent-name-defaults-and-unnamed-key.mykey.config-property1";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty1Key() {
+            return "with-parent-name-defaults-and-unnamed-key.config-property1";
+        }
+
+        @Override
         String namedKeyConfigProperty2Key() {
             return "with-parent-name-defaults-and-unnamed-key.mykey.config-property2";
         }
@@ -531,6 +629,16 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         @Override
         Class<?>[] mappingClasses() {
             return new Class<?>[] { Config.class };
+        }
+
+        @Override
+        String namedKeyConfigProperty1Key() {
+            return "with-unnamed-key-no-property-defaults.map.mykey.config-property1";
+        }
+
+        @Override
+        String unnamedKeyConfigProperty1Key() {
+            return "with-unnamed-key-no-property-defaults.map.config-property1";
         }
 
         @Override

--- a/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
@@ -423,7 +423,7 @@ public class ObjectCreatorTest {
                     .get();
 
             this.defaultsNested = context.new ObjectCreator<Map<String, Nested>>("defaults-nested")
-                    .map(String.class, null, null, null, nestedSupplier)
+                    .map(String.class, null, null, null, nestedSupplier, null)
                     .lazyGroup(Nested.class, nestedSupplier)
                     .get();
 


### PR DESCRIPTION
Creating for discussion following https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/.40WithUnnamedKey.20and.20keySet/with/603369236

Running the tests and reading the "ISSUE" comments is probably is the easiest way to grasp what is going on.

Test results:

<img width="832" height="912" alt="image" src="https://github.com/user-attachments/assets/f74c376c-5146-4003-a8f3-8f266124025a" />
