### PR TITLE
Fix HOCON property name rendering

### DIFF
--- a/sources/hocon/src/main/java/io/smallrye/config/source/hocon/HoconConfigSource.java
+++ b/sources/hocon/src/main/java/io/smallrye/config/source/hocon/HoconConfigSource.java
@@ -7,8 +7,9 @@ import java.io.Reader;
 import java.io.Serial;
 import java.io.UncheckedIOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import com.typesafe.config.Config;
@@ -56,32 +57,65 @@ public class HoconConfigSource extends MapBackedConfigSource {
 
     private static Map<String, String> configToMap(Config config) {
         final Map<String, String> properties = new TreeMap<>();
-        final Set<Map.Entry<String, ConfigValue>> entries = config.entrySet();
-        for (Map.Entry<String, ConfigValue> entry : entries) {
-            flatten(entry.getKey(), entry.getValue(), properties);
-        }
+        flattenObject(List.of(), config.root(), properties);
         return properties;
     }
 
-    private static void flatten(String path, ConfigValue value, Map<String, String> target) {
+    private static void flatten(List<String> path, ConfigValue value, Map<String, String> target) {
         if (value instanceof ConfigObject) {
             flattenObject(path, (ConfigObject) value, target);
         } else if (value instanceof ConfigList) {
             flattenList(path, (ConfigList) value, target);
         } else {
-            target.put(path, value.unwrapped().toString());
+            target.put(toPropertyName(path), value.unwrapped().toString());
         }
     }
 
-    private static void flattenObject(String path, ConfigObject value, Map<String, String> target) {
+    private static void flattenObject(List<String> path, ConfigObject value, Map<String, String> target) {
         for (Map.Entry<String, ConfigValue> entry : value.entrySet()) {
-            flatten(path + "." + entry.getKey(), entry.getValue(), target);
+            List<String> entryPath = new ArrayList<>(path);
+            entryPath.add(entry.getKey());
+            flatten(entryPath, entry.getValue(), target);
         }
     }
 
-    private static void flattenList(String path, ConfigList value, Map<String, String> target) {
+    private static void flattenList(List<String> path, ConfigList value, Map<String, String> target) {
         for (int i = 0, valueSize = value.size(); i < valueSize; i++) {
-            flatten(path + "[" + i + "]", value.get(i), target);
+            List<String> indexedPath = new ArrayList<>(path);
+            int last = indexedPath.size() - 1;
+            indexedPath.set(last, indexedPath.get(last) + "[" + i + "]");
+            flatten(indexedPath, value.get(i), target);
         }
+    }
+
+    private static String toPropertyName(List<String> path) {
+        StringBuilder propertyName = new StringBuilder();
+        for (String segment : path) {
+            if (!propertyName.isEmpty()) {
+                propertyName.append('.');
+            }
+            propertyName.append(renderSegment(segment));
+        }
+        return propertyName.toString();
+    }
+
+    private static String renderSegment(String segment) {
+        if (!needsQuotes(segment)) {
+            return segment;
+        }
+        return '"' + segment + '"';
+    }
+
+    private static boolean needsQuotes(String segment) {
+        if (segment.isEmpty()) {
+            return true;
+        }
+        for (int i = 0; i < segment.length(); i++) {
+            char c = segment.charAt(i);
+            if (c == '.' || c == '"' || Character.isWhitespace(c)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/sources/hocon/src/test/java/io/smallrye/config/source/hocon/HoconConfigSourceTest.java
+++ b/sources/hocon/src/test/java/io/smallrye/config/source/hocon/HoconConfigSourceTest.java
@@ -80,6 +80,20 @@ class HoconConfigSourceTest {
         assertEquals("Fiji", mapping.countries().get(0).name());
     }
 
+    @Test
+    void renderedPropertyNamesUseSmallRyeConfigSyntax() throws Exception {
+        HoconConfigSource source = new HoconConfigSource(HoconConfigSource.class.getResource("/rendered-properties.conf"));
+
+        assertEquals("1", source.getValue("%dev.some.property"));
+        assertEquals("6", source.getValue("org.acme.CoffeeResource/coffees/Retry/maxRetries"));
+        assertEquals("dog", source.getValue("my.indexed.collection[0]"));
+        assertEquals("2", source.getValue("foo.\"bar.baz\""));
+
+        assertFalse(source.getPropertyNames().contains("\"%dev\".some.property"));
+        assertFalse(source.getPropertyNames().contains("org.acme.\"CoffeeResource/coffees/Retry/maxRetries\""));
+        assertFalse(source.getPropertyNames().contains("my.indexed.\"collection[0]\""));
+    }
+
     @ConfigMapping(prefix = "countries")
     public interface Countries {
         @WithParentName

--- a/sources/hocon/src/test/resources/rendered-properties.conf
+++ b/sources/hocon/src/test/resources/rendered-properties.conf
@@ -1,0 +1,4 @@
+%dev.some.property=1
+org.acme.CoffeeResource/coffees/Retry/maxRetries=6
+my.indexed."collection[0]"=dog
+foo."bar.baz"=2


### PR DESCRIPTION
Fixes #1225

## Summary
- flatten HOCON objects by raw path segments instead of using Typesafe Config rendered paths
- render property names with SmallRye Config syntax so profile prefixes, slash-containing keys, and indexed property names remain usable
- preserve quoted segments when a segment contains dots

## Testing
- `mvn -pl sources/hocon -am -Dtest=HoconConfigSourceTest#renderedPropertyNamesUseSmallRyeConfigSyntax -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl sources/hocon -am -Dtest=HoconConfigSourceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl sources/hocon -am test`
