### PR TITLE
Configure Surefire to display parameterized test names in reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,31 @@
   </modules>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <!-- Use JUnit 5 display names (e.g. @ParameterizedTest names) in reports and console output -->
+            <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+              <usePhrasedFileName>true</usePhrasedFileName>
+              <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+              <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+              <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+            </statelessTestsetReporter>
+            <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+              <usePhrasedFileName>true</usePhrasedFileName>
+            </consoleOutputReporter>
+            <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+              <usePhrasedFileName>true</usePhrasedFileName>
+              <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+              <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+            </statelessTestsetInfoReporter>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>io.sundr</groupId>


### PR DESCRIPTION
Configure JUnit 5 reporter extensions for `maven-surefire-plugin` so that `@ParameterizedTest` (and `@DisplayName`) values appear in Surefire XML reports instead of bare indices.

## XML reports (`target/surefire-reports/*.xml`) — fixed

Before:

```xml
<testcase name="leadingSpace(Class, Object, String)[1]" …/>
<testcase name="leadingSpace(Class, Object, String)[2]" …/>
<testcase name="leadingSpace(Class, Object, String)[3]" …/>
```

After:

```xml
<testcase name="leadingSpace(Class, Object, String) class java.lang.Boolean - true" …/>
<testcase name="leadingSpace(Class, Object, String) class java.lang.Boolean - NO" …/>
<testcase name="leadingSpace(Class, Object, String) class java.lang.Double - 1.0" …/>
```

These are the reports consumed by CI test-report actions (e.g. `dorny/test-reporter`, `mikepenz/action-junit-report`).

## Maven log (console) — unchanged

The inline `[ERROR]` lines Surefire prints for individual test failures still show the invocation index instead of parameters:

```
[ERROR] …ConfigMappingMapDefaultsUnnamedKeyTest.noKeysConfigured(…)[4]
[ERROR] …ConfigMappingMapDefaultsUnnamedKeyTest.noKeysConfigured(…)[6]
```

`JUnit5StatelessTestsetInfoReporter` only exposes class-level phrasing options (`usePhrasedClassNameInRunning`,
`usePhrasedClassNameInTestCaseSummary`); the method-level equivalent `usePhrasedTestCaseMethodName` only exists on
`JUnit5Xml30StatelessReporter` (XML reports).

Displaying parameterized test names in the console is tracked upstream as [SUREFIRE-2152](https://github.com/apache/maven-surefire/issues/2798), open since Feb 2023 with no fix version.

Third-party tree reporters (`me.fabriciorby:maven-surefire-junit5-tree-reporter`, `io.github.neewrobert:junit5-tree-reporter`) used to work around this, but broke with Surefire 3.5.4
([#3203](https://github.com/apache/maven-surefire/issues/3203)).

## Reference

Same approach used in Hibernate Search:
https://github.com/hibernate/hibernate-search/blob/main/pom.xml#L756-L781

Assisted-By: Claude Code <noreply@anthropic.com>