### PR TITLE
Support nested config classes in class-based mappings

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -96,9 +96,17 @@ public final class ConfigMappingContext {
     }
 
     <T> T constructGroup(Class<T> interfaceType) {
-        return constructGroup(() -> ConfigMappingLoader.configMappingObject(interfaceType, this));
+        // Save the current naming / style, because the nested / child element may override it
+        NamingStrategy namingStrategy = this.namingStrategy;
+        BeanStyleGetters beanStyleGetters = this.beanStyleGetters;
+        T mappingObject = ConfigMappingLoader.configMappingObject(interfaceType, this);
+        // restore the naming / style
+        applyNamingStrategy(namingStrategy);
+        applyBeanStyleGetters(beanStyleGetters);
+        return mappingObject;
     }
 
+    @SuppressWarnings("unchecked")
     <T> T constructGroup(Supplier<T> groupSupplier) {
         // Save the current naming / style, because the nested / child element may override it
         NamingStrategy namingStrategy = this.namingStrategy;
@@ -107,6 +115,10 @@ public final class ConfigMappingContext {
         // restore the naming / style
         applyNamingStrategy(namingStrategy);
         applyBeanStyleGetters(beanStyleGetters);
+        // Nested elements may have to be unwrapped
+        if (mappingObject instanceof ConfigMappingClassMapper) {
+            mappingObject = (T) ((ConfigMappingClassMapper) mappingObject).map();
+        }
         return mappingObject;
     }
 

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -910,6 +910,11 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
                 if (configurationInterface != null) {
                     return new CollectionProperty(rawType, new GroupProperty(method, propertyName, configurationInterface));
                 }
+                configurationInterface = ConfigMappingLoader.getConfigMapping(elementClass);
+                if (configurationInterface != null) {
+                    return new CollectionProperty(rawType,
+                            new GroupProperty(method, propertyName, configurationInterface));
+                }
 
                 Class<? extends Converter<?>> converter = getConverter(elementType, method);
                 if (converter != null) {
@@ -921,6 +926,10 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
             ConfigMappingInterface configurationInterface = getConfigurationInterface(rawType);
             if (configurationInterface != null) {
                 // it's a group
+                return new GroupProperty(method, propertyName, configurationInterface);
+            }
+            configurationInterface = ConfigMappingLoader.getConfigMapping(rawType);
+            if (configurationInterface != null) {
                 return new GroupProperty(method, propertyName, configurationInterface);
             }
             // fall out (leaf)

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingLoader.java
@@ -8,6 +8,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -280,10 +281,22 @@ public final class ConfigMappingLoader {
         private static ConfigMappingClass createConfigurationClass(final Class<?> classType) {
             if (classType.isInterface() && classType.getTypeParameters().length == 0 ||
                     Modifier.isAbstract(classType.getModifiers()) ||
-                    classType.isEnum()) {
+                    classType.isEnum() ||
+                    classType.isArray() ||
+                    classType.isPrimitive()) {
                 return null;
             }
-
+            if (classType.getName().startsWith("java")) {
+                return null;
+            }
+            if (Collection.class.isAssignableFrom(classType) || Map.class.isAssignableFrom(classType)) {
+                return null;
+            }
+            try {
+                classType.getDeclaredConstructor();
+            } catch (NoSuchMethodException e) {
+                return null;
+            }
             return new ConfigMappingClass(classType);
         }
 

--- a/microprofile/src/test/java/io/smallrye/config/microprofile/ConfigPropertiesMappingsTest.java
+++ b/microprofile/src/test/java/io/smallrye/config/microprofile/ConfigPropertiesMappingsTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -154,6 +155,77 @@ class ConfigPropertiesMappingsTest {
     }
 
     @Test
+    void nestedGroup() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerNested.class)
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.host", "localhost", "server.port", "8080",
+                        "server.log.enabled", "true"), "test"))
+                .build();
+
+        ServerNested server = config.getConfigMapping(ServerNested.class);
+        assertEquals("localhost", server.host);
+        assertEquals(8080, server.port);
+        assertTrue(server.log.enabled);
+    }
+
+    @Test
+    void nestedGroupList() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerNodes.class)
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.nodes[0].name", "main",
+                        "server.nodes[0].host", "localhost",
+                        "server.nodes[1].name", "backup",
+                        "server.nodes[1].host", "backup-host"), "test"))
+                .build();
+
+        ServerNodes server = config.getConfigMapping(ServerNodes.class);
+        assertEquals(2, server.nodes.size());
+        assertEquals("main", server.nodes.get(0).name);
+        assertEquals("localhost", server.nodes.get(0).host);
+        assertEquals("backup", server.nodes.get(1).name);
+        assertEquals("backup-host", server.nodes.get(1).host);
+    }
+
+    @Test
+    void nestedGroupMap() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(ServerEndpoints.class)
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "server.endpoints.api.path", "/api",
+                        "server.endpoints.api.port", "8080",
+                        "server.endpoints.admin.path", "/admin",
+                        "server.endpoints.admin.port", "9090"), "test"))
+                .build();
+
+        ServerEndpoints server = config.getConfigMapping(ServerEndpoints.class);
+        assertEquals(2, server.endpoints.size());
+        assertEquals("/api", server.endpoints.get("api").path);
+        assertEquals(8080, server.endpoints.get("api").port);
+        assertEquals("/admin", server.endpoints.get("admin").path);
+        assertEquals(9090, server.endpoints.get("admin").port);
+    }
+
+    @Test
+    void deeplyNestedGroup() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(AppDeepNested.class)
+                .withSources(new PropertiesConfigSource(Map.of(
+                        "app.name", "test",
+                        "app.database.host", "db-host",
+                        "app.database.pool.minSize", "5",
+                        "app.database.pool.maxSize", "20"), "test"))
+                .build();
+
+        AppDeepNested app = config.getConfigMapping(AppDeepNested.class);
+        assertEquals("test", app.name);
+        assertEquals("db-host", app.database.host);
+        assertEquals(5, app.database.pool.minSize);
+        assertEquals(20, app.database.pool.maxSize);
+    }
+
+    @Test
     void noArgsConstructorConfigProperties() {
         assertThrows(IllegalArgumentException.class,
                 () -> ConfigMappingLoader.ensureLoaded(ServerProperties.class));
@@ -202,6 +274,53 @@ class ConfigPropertiesMappingsTest {
         public String host;
         @ConfigProperty(defaultValue = "8080")
         public int port;
+    }
+
+    @ConfigProperties(prefix = "server")
+    public static class ServerNested {
+        public String host;
+        public int port;
+        public Log log;
+
+        public static class Log {
+            public boolean enabled;
+        }
+    }
+
+    @ConfigProperties(prefix = "server")
+    public static class ServerNodes {
+        public List<Node> nodes;
+
+        public static class Node {
+            public String name;
+            public String host;
+        }
+    }
+
+    @ConfigProperties(prefix = "server")
+    public static class ServerEndpoints {
+        public Map<String, Endpoint> endpoints;
+
+        public static class Endpoint {
+            public String path;
+            public int port;
+        }
+    }
+
+    @ConfigProperties(prefix = "app")
+    public static class AppDeepNested {
+        public String name;
+        public Database database;
+
+        public static class Database {
+            public String host;
+            public Pool pool;
+
+            public static class Pool {
+                public int minSize;
+                public int maxSize;
+            }
+        }
     }
 
     static class Version {


### PR DESCRIPTION
- `ConfigMappingInterface.getPropertyDef()` falls back to `ConfigMappingLoader.getConfigMapping()` for POJO field types, treating them as groups
- `ConfigMappingContext.constructGroup(Supplier)` calls `map()` on `ConfigMappingClassMapper` results to convert generated implementations back to POJO instances
- `ConfigMappingLoader.ConfigMappingClass.createConfigurationClass()` filters out JDK types, primitives, collections, and classes without no-arg constructors
- Supports nested groups, `List<NestedObject>`, and `Map<String, NestedObject>` in class-based mappings