### PR TITLE
@WithUnnamedKey#eager to control if default keys are present in the mapping Map

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingContext.java
@@ -291,13 +291,23 @@ public final class ConfigMappingContext {
                 final Class<? extends Converter<K>> keyConvertWith,
                 final String unnamedKey,
                 final Iterable<String> keys) {
-            return map(keyRawType, keyConvertWith, unnamedKey, keys, null, null);
+            return map(keyRawType, keyConvertWith, unnamedKey, true, keys, null, null);
         }
 
         public <K, V> ObjectCreator<T> map(
                 final Class<K> keyRawType,
                 final Class<? extends Converter<K>> keyConvertWith,
                 final String unnamedKey,
+                final Iterable<String> keys,
+                final Supplier<V> defaultValue) {
+            return map(keyRawType, keyConvertWith, unnamedKey, true, keys, defaultValue, null);
+        }
+
+        public <K, V> ObjectCreator<T> map(
+                final Class<K> keyRawType,
+                final Class<? extends Converter<K>> keyConvertWith,
+                final String unnamedKey,
+                final boolean unnamedEager,
                 final Iterable<String> keys,
                 final Supplier<V> defaultValue,
                 final Supplier<V> unnamedDefaultSupplier) {
@@ -318,30 +328,41 @@ public final class ConfigMappingContext {
                         Map<K, V> map = defaultInstance != null ? new MapWithDefault<>(defaultInstance) : new HashMap<>();
 
                         if (unnamedKey != null) {
-                            V unnamedDefault = defaultInstance;
-                            if (unnamedDefault == null && unnamedDefaultSupplier != null) {
-                                int problemsBefore = problems.size();
-                                int length = nameBuilder.length();
-                                nameBuilder.append(".*");
-                                unnamedDefault = constructGroup(unnamedDefaultSupplier);
-                                nameBuilder.setLength(length);
-                                if (problems.size() > problemsBefore) {
-                                    problems.subList(problemsBefore, problems.size()).clear();
-                                    unnamedDefault = null;
-                                }
-                            }
-                            final V unnamedDefaultInstance = unnamedDefault;
-                            nestedCreators.add(new Consumer<>() {
-                                @Override
-                                public void accept(Function<String, Object> get) {
-                                    resolvedNonDefault = false;
-                                    V value = (V) get.apply(path);
-                                    if (value != null
-                                            && (resolvedNonDefault || !value.equals(unnamedDefaultInstance))) {
-                                        map.put(unnamedKey.isEmpty() ? null : keyConverter.convert(unnamedKey), value);
+                            if (unnamedEager) {
+                                nestedCreators.add(new Consumer<>() {
+                                    @Override
+                                    public void accept(Function<String, Object> get) {
+                                        V value = (V) get.apply(path);
+                                        if (value != null) {
+                                            map.put(unnamedKey.isEmpty() ? null : keyConverter.convert(unnamedKey), value);
+                                        }
+                                    }
+                                });
+                            } else {
+                                V unnamedDefault = defaultInstance;
+                                if (unnamedDefault == null && unnamedDefaultSupplier != null) {
+                                    int problemsBefore = problems.size();
+                                    int length = nameBuilder.length();
+                                    nameBuilder.append(".*");
+                                    unnamedDefault = constructGroup(unnamedDefaultSupplier);
+                                    nameBuilder.setLength(length);
+                                    if (problems.size() > problemsBefore) {
+                                        problems.subList(problemsBefore, problems.size()).clear();
+                                        unnamedDefault = null;
                                     }
                                 }
-                            });
+                                final V unnamedDefaultInstance = unnamedDefault;
+                                nestedCreators.add(new Consumer<>() {
+                                    @Override
+                                    public void accept(Function<String, Object> get) {
+                                        resolvedNonDefault = false;
+                                        V value = (V) get.apply(path);
+                                        if (value != null && (resolvedNonDefault || !value.equals(unnamedDefaultInstance))) {
+                                            map.put(unnamedKey.isEmpty() ? null : keyConverter.convert(unnamedKey), value);
+                                        }
+                                    }
+                                });
+                            }
                         }
 
                         // single map key with the path plus the map key

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -588,13 +588,14 @@ public class ConfigMappingGenerator {
                 ctor.visitLdcInsn(getType(mapProperty.getKeyRawType()));
                 ctor.visitKeyConverter(mapProperty);
                 ctor.visitKeyUnnamed(mapProperty);
+                ctor.visitInsn(mapProperty.hasKeyUnnamed() && mapProperty.isKeyUnnamedEager() ? ICONST_1 : ICONST_0);
                 ctor.visitKeyProvider(mapProperty);
                 if (mapProperty.hasDefaultValue()) {
                     ctor.visitGroupSupplier(valueProperty.asGroup().getGroupType().getInterfaceType());
                 } else {
                     ctor.visitInsn(ACONST_NULL);
                 }
-                if (mapProperty.hasKeyUnnamed()) {
+                if (mapProperty.hasKeyUnnamed() && !mapProperty.isKeyUnnamedEager()) {
                     ctor.visitGroupSupplier(valueProperty.asGroup().getGroupType().getInterfaceType());
                 } else {
                     ctor.visitInsn(ACONST_NULL);
@@ -1359,7 +1360,7 @@ public class ConfigMappingGenerator {
 
     private enum ObjectCreatorMapGroupInvocation implements MethodInvocation {
         map(INVOKEVIRTUAL,
-                "(" + D_CLASS + D_CLASS + D_STRING + D_ITERABLE + D_SUPPLIER + D_SUPPLIER + ")" + D_OBJECT_CREATOR);
+                "(" + D_CLASS + D_CLASS + D_STRING + "Z" + D_ITERABLE + D_SUPPLIER + D_SUPPLIER + ")" + D_OBJECT_CREATOR);
 
         private final int opcode;
         private final String desc;

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -613,6 +613,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
     public static final class MapProperty extends Property {
         private final Type keyType;
         private final String keyUnnamed;
+        private final boolean keyUnnamedEager;
         private final Class<? extends Supplier<Iterable<String>>> keysProvider;
         private final Class<? extends Converter<?>> keyConvertWith;
         private final Property valueProperty;
@@ -624,6 +625,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
                 final String propertyName,
                 final Type keyType,
                 final String keyUnnamed,
+                final boolean keyUnnamedEager,
                 final Class<? extends Supplier<Iterable<String>>> keysProvider,
                 final Class<? extends Converter<?>> keyConvertWith,
                 final Property valueProperty,
@@ -633,6 +635,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
             super(method, propertyName);
             this.keyType = keyType;
             this.keyUnnamed = keyUnnamed;
+            this.keyUnnamedEager = keyUnnamedEager;
             this.keysProvider = keysProvider;
             this.keyConvertWith = keyConvertWith;
             this.valueProperty = valueProperty;
@@ -654,6 +657,10 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
 
         public boolean hasKeyUnnamed() {
             return keyUnnamed != null;
+        }
+
+        public boolean isKeyUnnamedEager() {
+            return keyUnnamedEager;
         }
 
         public Class<? extends Supplier<Iterable<String>>> getKeysProvider() {
@@ -889,6 +896,7 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
                 return new MapProperty(method,
                         propertyName, keyType.getType(),
                         getUnnamedKey(keyType, method),
+                        getUnnamedKeyEager(keyType, method),
                         getKeysProvider(keyType, method),
                         getConverter(keyType, method),
                         getPropertyDef(interfaceType, method, valueType),
@@ -996,6 +1004,14 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
             annotation = method.getAnnotation(WithUnnamedKey.class);
         }
         return annotation != null ? annotation.value() : null;
+    }
+
+    private static boolean getUnnamedKeyEager(final AnnotatedType type, final Method method) {
+        WithUnnamedKey annotation = type.getAnnotation(WithUnnamedKey.class);
+        if (annotation == null) {
+            annotation = method.getAnnotation(WithUnnamedKey.class);
+        }
+        return annotation == null || annotation.eager();
     }
 
     private static Class<? extends Supplier<Iterable<String>>> getKeysProvider(final AnnotatedType type, final Method method) {

--- a/implementation/src/main/java/io/smallrye/config/WithUnnamedKey.java
+++ b/implementation/src/main/java/io/smallrye/config/WithUnnamedKey.java
@@ -20,4 +20,12 @@ public @interface WithUnnamedKey {
      * @return the Map key
      */
     String value() default "";
+
+    /**
+     * Whether the unnamed key should be included in the {@link java.util.Map} when its values come only from defaults.
+     *
+     * @return {@code true} to always include the unnamed key, {@code false} to exclude it when only default values
+     *         are present
+     */
+    boolean eager() default true;
 }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingFullTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingFullTest.java
@@ -267,8 +267,7 @@ public class ConfigMappingFullTest {
                 .build();
 
         OrmConfig ormConfig = config.getConfigMapping(OrmConfig.class);
-        assertEquals(0, ormConfig.persistenceUnits().size());
-        assertFalse(ormConfig.persistenceUnits().get("<default>").database().globallyQuotedIdentifiers());
+        assertEquals(1, ormConfig.persistenceUnits().size());
         OrmRuntimeConfig ormRuntimeConfig = config.getConfigMapping(OrmRuntimeConfig.class);
         assertEquals(1, ormRuntimeConfig.persistenceUnits().size());
         assertEquals("drop-and-create",
@@ -339,7 +338,7 @@ public class ConfigMappingFullTest {
     @ConfigMapping(prefix = "smallrye.config-orm")
     interface OrmRuntimeConfig {
         @WithParentName
-        @WithUnnamedKey("<default>")
+        @WithUnnamedKey(value = "<default>", eager = false)
         @WithDefaults
         Map<String, OrmRuntimeConfigPersistenceUnit> persistenceUnits();
 

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingMapDefaultsUnnamedKeyTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingMapDefaultsUnnamedKeyTest.java
@@ -183,7 +183,7 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
     @ConfigMapping(prefix = "case2")
     interface Case2Config {
         @WithDefaults
-        @WithUnnamedKey("<default>")
+        @WithUnnamedKey(value = "<default>", eager = false)
         Map<String, ConfigGroup> map();
     }
 
@@ -206,7 +206,7 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
 
     @ConfigMapping(prefix = "case3")
     interface Case3Config {
-        @WithUnnamedKey("<default>")
+        @WithUnnamedKey(value = "<default>", eager = false)
         Map<String, Map<String, String>> map();
     }
 
@@ -222,6 +222,30 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
 
         assertTrue(map.containsKey("<default>"),
                 "unnamed key should appear for nested maps when config is provided at the unnamed path");
+    }
+
+    @ConfigMapping(prefix = "builder-default")
+    interface BuilderDefaultConfig {
+        @WithUnnamedKey(value = "<default>", eager = false)
+        Map<String, BuilderDefaultGroup> map();
+
+        interface BuilderDefaultGroup {
+            @WithDefault("mapping-default")
+            String value();
+        }
+    }
+
+    @Test
+    void builderDefaultValueWithEagerFalse() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withDefaultValue("builder-default.map.value", "mapping-default")
+                .withMapping(BuilderDefaultConfig.class)
+                .build();
+
+        Map<String, BuilderDefaultConfig.BuilderDefaultGroup> map = config.getConfigMapping(BuilderDefaultConfig.class).map();
+
+        assertFalse(map.containsKey("<default>"),
+                "unnamed key should not appear when value comes from withDefaultValue (same ordinal as mapping defaults)");
     }
 
     enum ConfigGroupKey {
@@ -450,7 +474,7 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
     static class WithUnnamedKeyOnlyMapping extends PropertyDefaultsConfigGroupMapMapping {
         @ConfigMapping(prefix = "with-unnamed-key-only")
         interface Config {
-            @WithUnnamedKey("<default>")
+            @WithUnnamedKey(value = "<default>", eager = false)
             Map<String, ConfigGroup> map();
         }
 
@@ -504,7 +528,7 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         @ConfigMapping(prefix = "with-defaults-and-unnamed-key")
         interface Config {
             @WithDefaults
-            @WithUnnamedKey("<default>")
+            @WithUnnamedKey(value = "<default>", eager = false)
             Map<String, ConfigGroup> map();
         }
 
@@ -559,7 +583,7 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
         interface Config {
             @WithParentName
             @WithDefaults
-            @WithUnnamedKey("<default>")
+            @WithUnnamedKey(value = "<default>", eager = false)
             Map<String, ConfigGroup> map();
         }
 
@@ -612,7 +636,7 @@ public class ConfigMappingMapDefaultsUnnamedKeyTest {
     static class WithUnnamedKeyNoPropertyDefaultsMapping extends NoPropertyDefaultsConfigGroupMapMapping {
         @ConfigMapping(prefix = "with-unnamed-key-no-property-defaults")
         interface Config {
-            @WithUnnamedKey("<default>")
+            @WithUnnamedKey(value = "<default>", eager = false)
             Map<String, ConfigGroupNoPropertyDefaults> map();
         }
 

--- a/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ObjectCreatorTest.java
@@ -423,7 +423,7 @@ public class ObjectCreatorTest {
                     .get();
 
             this.defaultsNested = context.new ObjectCreator<Map<String, Nested>>("defaults-nested")
-                    .map(String.class, null, null, null, nestedSupplier, null)
+                    .map(String.class, null, null, true, null, nestedSupplier, null)
                     .lazyGroup(Nested.class, nestedSupplier)
                     .get();
 


### PR DESCRIPTION
With https://github.com/smallrye/smallrye-config/pull/1534, we changed the behavior globally to not include the default key in a mapping `Map` if the configuration values were coming from the defaults. This can cause problems for existing integrations, so this behavior can now be controlled with `@WithUnnamedKey#eager` (the default is the original behavior). 