### PR TITLE
Ignore @WithDefault on Map and Collection with nested group values

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingGenerator.java
@@ -1022,6 +1022,10 @@ public class ConfigMappingGenerator {
             return false;
         }
 
+        if (ConfigMappingLoader.ConfigMappingClass.getConfigurationClass(klass) != null) {
+            return false;
+        }
+
         return !klass.isPrimitive() || !(value instanceof Character) || !value.equals(0);
     }
 

--- a/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
+++ b/implementation/src/main/java/io/smallrye/config/ConfigMappingInterface.java
@@ -893,13 +893,17 @@ public final class ConfigMappingInterface implements ConfigMappingMetadata {
                 AnnotatedType keyType = typeOfParameter(type, 0);
                 AnnotatedType valueType = typeOfParameter(type, 1);
                 String defaultValue = getDefaultValue(method);
+                Property valueProperty = getPropertyDef(interfaceType, method, valueType);
+                if (valueProperty.isGroup()) {
+                    defaultValue = null;
+                }
                 return new MapProperty(method,
                         propertyName, keyType.getType(),
                         getUnnamedKey(keyType, method),
                         getUnnamedKeyEager(keyType, method),
                         getKeysProvider(keyType, method),
                         getConverter(keyType, method),
-                        getPropertyDef(interfaceType, method, valueType),
+                        valueProperty,
                         defaultValue != null || hasDefaults(method),
                         defaultValue);
             }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingClassTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -241,6 +243,29 @@ class ConfigMappingClassTest {
 
     static class Empty {
 
+    }
+
+    @Test
+    void mapNestedWithFieldInitializerIgnored() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(MapNestedClass.class, "map")
+                .withDefaultValue("map.servers.one.host", "localhost")
+                .withDefaultValue("map.servers.one.port", "8080")
+                .build();
+
+        MapNestedClass mapping = config.getConfigMapping(MapNestedClass.class, "map");
+        assertEquals(1, mapping.servers.size());
+        assertEquals("localhost", mapping.servers.get("one").host);
+        assertEquals(8080, mapping.servers.get("one").port);
+    }
+
+    static class MapNestedClass {
+        Map<String, ServerEntry> servers = new HashMap<>();
+
+        static class ServerEntry {
+            String host;
+            int port;
+        }
     }
 
     static class ServerCamelCase {

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingCollectionsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingCollectionsTest.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1082,5 +1083,22 @@ public class ConfigMappingCollectionsTest {
     @ConfigMapping(prefix = "map")
     interface MapWithOptionalValues {
         Map<String, Optional<String>> values();
+    }
+
+    @Test
+    void mapNestedWithDefaultIgnored() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withMapping(MapNestedWithDefaultIgnored.class)
+                .build();
+        assertNotNull(config.getConfigMapping(MapNestedWithDefaultIgnored.class));
+    }
+
+    interface MapNestedWithDefaultIgnored {
+        @WithDefault("something")
+        Map<String, Nested> map();
+
+        interface Nested {
+            String value();
+        }
     }
 }


### PR DESCRIPTION
`@WithDefault` on a `Map` or `Collection` whose values are nested group types (interfaces or classes) has no meaningful semantics; the default value string cannot be decomposed into the nested type's fields. For class-based mappings, field initializers like `new HashMap<>()` produce `@WithDefault("{}")` on the generated interface. This causes SmallRye to attempt to resolve a default group entry with a `*` wildcard key, failing with `NoSuchElementException` on the nested type's required properties.

This PR, ignore the case.