### PR TITLE
Remove deprecated methods

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
@@ -1,7 +1,6 @@
 package io.smallrye.config;
 
 import java.io.Serial;
-import java.util.Set;
 
 import jakarta.annotation.Priority;
 
@@ -26,14 +25,6 @@ public class SecretKeysConfigSourceInterceptor implements ConfigSourceIntercepto
 
     public SecretKeysConfigSourceInterceptor(final PropertyNamesMatcher<?> secrets) {
         this.secrets = secrets;
-    }
-
-    @Deprecated(forRemoval = true)
-    public SecretKeysConfigSourceInterceptor(final Set<PropertyName> secrets) {
-        this.secrets = new PropertyNamesMatcher<>();
-        for (PropertyName secret : secrets) {
-            this.secrets.add(secret.getName());
-        }
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -200,26 +200,6 @@ public class SmallRyeConfig implements Config, Serializable {
         }
     }
 
-    @Deprecated(forRemoval = true)
-    public <T, C extends Collection<T>> C getIndexedValues(String name, Converter<T> converter,
-            IntFunction<C> collectionFactory) {
-        List<String> indexedProperties = getIndexedProperties(name);
-        if (indexedProperties.isEmpty()) {
-            throw new NoSuchElementException(ConfigMessages.msg.propertyNotFound(name));
-        }
-        return getIndexedValues(indexedProperties, converter, collectionFactory);
-    }
-
-    @Deprecated(forRemoval = true)
-    private <T, C extends Collection<T>> C getIndexedValues(List<String> indexedProperties, Converter<T> converter,
-            IntFunction<C> collectionFactory) {
-        C collection = collectionFactory.apply(indexedProperties.size());
-        for (String indexedProperty : indexedProperties) {
-            collection.add(getValue(indexedProperty, converter));
-        }
-        return collection;
-    }
-
     public List<String> getIndexedProperties(final String property) {
         Map<Integer, String> indexedProperties = configSources.getPropertyNames().indexed().get(property);
         return indexedProperties == null ? Collections.emptyList() : indexedProperties.values().stream().toList();
@@ -533,23 +513,6 @@ public class SmallRyeConfig implements Config, Serializable {
         } else {
             return getOptionalValue(name, newCollectionConverter(converter, collectionFactory));
         }
-    }
-
-    @Deprecated(forRemoval = true)
-    public <T, C extends Collection<T>> Optional<C> getIndexedOptionalValues(String name, Converter<T> converter,
-            IntFunction<C> collectionFactory) {
-        List<String> indexedProperties = getIndexedProperties(name);
-        if (indexedProperties.isEmpty()) {
-            return Optional.empty();
-        }
-
-        C collection = collectionFactory.apply(indexedProperties.size());
-        for (String indexedProperty : indexedProperties) {
-            Optional<T> optionalValue = getOptionalValue(indexedProperty, converter);
-            optionalValue.ifPresent(collection::add);
-        }
-
-        return collection.isEmpty() ? Optional.empty() : Optional.of(collection);
     }
 
     @Override

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -630,11 +630,6 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         return defaults;
     }
 
-    @Deprecated(forRemoval = true)
-    public Map<String, String> getDefaultValues() {
-        return defaults.getProperties();
-    }
-
     public PropertyNamesMatcher<?> getSecretKeys() {
         return secretKeys;
     }

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -21,6 +21,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -181,8 +182,10 @@ class SmallRyeConfigTest {
                         "server.environments[2]", "prod"))
                 .build();
 
-        List<String> environments = config.getIndexedValues("server.environments", config.requireConverter(String.class),
-                ArrayList::new);
+        List<String> environments = config.getValues(
+                "server.environments",
+                config.requireConverter(String.class),
+                (IntFunction<List<String>>) value -> new ArrayList<>());
         assertEquals(3, environments.size());
         assertEquals("dev", environments.get(0));
         assertEquals("dev", config.getValue("server.environments[0]", String.class));
@@ -192,7 +195,10 @@ class SmallRyeConfigTest {
         assertEquals("prod", config.getValue("server.environments[2]", String.class));
 
         assertThrows(NoSuchElementException.class,
-                () -> config.getIndexedValues("not.found", config.requireConverter(String.class), ArrayList::new));
+                () -> config.getValues(
+                        "not.found",
+                        config.requireConverter(String.class),
+                        (IntFunction<List<String>>) value -> new ArrayList<>()));
     }
 
     @Test
@@ -298,9 +304,11 @@ class SmallRyeConfigTest {
                 .withSources(config("server.environments", ""))
                 .build();
 
-        assertFalse(
-                config.getIndexedOptionalValues("server.environments", config.requireConverter(String.class), ArrayList::new)
-                        .isPresent());
+        assertFalse(config.getOptionalValues(
+                "server.environments",
+                config.requireConverter(String.class),
+                (IntFunction<Collection<String>>) value -> new ArrayList<>())
+                .isPresent());
         assertFalse(config.getOptionalValues("server.environments", String.class).isPresent());
 
         SmallRyeConfig configIndexed = new SmallRyeConfigBuilder()
@@ -308,7 +316,10 @@ class SmallRyeConfigTest {
                 .build();
 
         assertFalse(configIndexed
-                .getIndexedOptionalValues("server.environments", config.requireConverter(String.class), ArrayList::new)
+                .getOptionalValues(
+                        "server.environments",
+                        config.requireConverter(String.class),
+                        (IntFunction<Collection<String>>) value -> new ArrayList<>())
                 .isPresent());
         assertFalse(configIndexed.getOptionalValues("server.environments", String.class).isPresent());
     }


### PR DESCRIPTION
Remove deprecated API methods:

- Removes the deprecated constructor from `SecretKeysConfigSourceInterceptor` that accepted a `Set<PropertyName>`
- Removes two deprecated methods from `SmallRyeConfig`: `getIndexedValues()` and `getIndexedOptionalValues()`
- Removes the deprecated `getDefaultValues()` method from `SmallRyeConfigBuilder`