### PR TITLE
Remove the generation of a comma separated value name for Collections in the YamlConfigSource

### DIFF
--- a/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSource.java
+++ b/sources/yaml/src/main/java/io/smallrye/config/source/yaml/YamlConfigSource.java
@@ -1,19 +1,15 @@
 package io.smallrye.config.source.yaml;
 
-import static java.util.Collections.singletonMap;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
 import java.io.UncheckedIOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -132,8 +128,7 @@ public class YamlConfigSource extends MapBackedConfigSource {
             } else if (value instanceof Map) {
                 flattenYaml(key, (Map<Object, Object>) value, target, false);
             } else if (value instanceof List) {
-                final List<Object> list = (List<Object>) value;
-                flattenList(key, list, target);
+                List<Object> list = (List<Object>) value;
                 for (int i = 0; i < list.size(); i++) {
                     flattenYaml(key, Collections.singletonMap("[" + i + "]", list.get(i)), target, true);
                 }
@@ -143,41 +138,6 @@ public class YamlConfigSource extends MapBackedConfigSource {
                 }
             }
         });
-    }
-
-    // Do not remove this, because Quarkus old ConfigRoots still rely on comma separated values calling Config#getValue and not Config#getValues.
-    private static void flattenList(String key, List<Object> source, Map<String, String> target) {
-        boolean mixed = false;
-        List<String> flatten = new ArrayList<>();
-        for (Object value : source) {
-            if (value instanceof String || value instanceof Boolean) {
-                flatten.add(value.toString());
-            } else if (value != null) {
-                mixed = true;
-                break;
-            }
-        }
-
-        if (!mixed) {
-            target.put(key, flatten.stream().map(value -> {
-                StringBuilder sb = new StringBuilder();
-                escapeCommas(sb, value, 1);
-                return sb.toString();
-            }).collect(Collectors.joining(",")));
-        }
-    }
-
-    private static void escapeCommas(StringBuilder b, String src, int escapeLevel) {
-        int cp;
-        for (int i = 0; i < src.length(); i += Character.charCount(cp)) {
-            cp = src.codePointAt(i);
-            if (cp == '\\' || cp == ',') {
-                for (int j = 0; j < escapeLevel; j++) {
-                    b.append('\\');
-                }
-            }
-            b.appendCodePoint(cp);
-        }
     }
 
     /**

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/test/ArrayTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/test/ArrayTest.java
@@ -46,7 +46,6 @@ class ArrayTest {
                         + "    - ~\n"))
                 .build();
 
-        assertEquals("something,1,true", config.getConfigValue("foo").getValue());
         assertEquals("something", config.getConfigValue("foo[0]").getValue());
         assertEquals("1", config.getConfigValue("foo[1]").getValue());
         assertEquals("true", config.getConfigValue("foo[2]").getValue());

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/test/BasicTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/test/BasicTest.java
@@ -43,7 +43,9 @@ class BasicTest {
 
         ConfigSource src = new YamlConfigSource("Yaml", yaml);
 
-        assertEquals("cat,dog,chicken", src.getValue("foo.bar"));
+        assertEquals("cat", src.getValue("foo.bar[0]"));
+        assertEquals("dog", src.getValue("foo.bar[1]"));
+        assertEquals("chicken", src.getValue("foo.bar[2]"));
     }
 
     @Test

--- a/sources/yaml/src/test/java/io/smallrye/config/source/yaml/test/YamlConfigSourceTest.java
+++ b/sources/yaml/src/test/java/io/smallrye/config/source/yaml/test/YamlConfigSourceTest.java
@@ -162,7 +162,6 @@ class YamlConfigSourceTest {
 
         assertTrue(propertyNames.contains("quarkus.http.port"));
         assertTrue(propertyNames.contains("quarkus.http.ssl-port"));
-        assertTrue(propertyNames.contains("quarkus.http.ssl.protocols"));
         assertTrue(propertyNames.contains("quarkus.http.ssl.protocols[0]"));
         assertNotNull(config.getConfigValue("quarkus.http.ssl.protocols[0]").getValue());
     }


### PR DESCRIPTION
This has been previously done in https://github.com/smallrye/smallrye-config/pull/1203 and reverted in https://github.com/smallrye/smallrye-config/pull/1257.

Now it should be fine, since Quarkus no longer uses the old `@ConfigRoot` implementations, which required YAML lists in comma-separated values.