### PR TITLE
Simplify CDI injection of Collections and Maps

### DIFF
--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigInjectionBean.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigInjectionBean.java
@@ -16,46 +16,30 @@
 package io.smallrye.config.inject;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.spi.Annotated;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.PassivationCapable;
 import jakarta.enterprise.util.AnnotationLiteral;
-import jakarta.inject.Provider;
 
-import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.Config;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
 public class ConfigInjectionBean<T> implements Bean<T>, PassivationCapable {
-
-    private static final Set<Annotation> QUALIFIERS = new HashSet<>();
-    static {
-        QUALIFIERS.add(new ConfigPropertyLiteral());
-    }
+    private static final Set<Annotation> QUALIFIERS = Set.of(new ConfigPropertyLiteral());
 
     private final BeanManager bm;
     private final Class<?> clazz;
-
-    /**
-     * only access via {@link #getConfig()}
-     */
-    private Config _config;
 
     public ConfigInjectionBean(BeanManager bm, Class<?> clazz) {
         this.bm = bm;
@@ -73,45 +57,9 @@ public class ConfigInjectionBean<T> implements Bean<T>, PassivationCapable {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public T create(CreationalContext<T> context) {
         InjectionPoint ip = (InjectionPoint) bm.getInjectableReference(new MetadataInjectionPoint(), context);
-        Annotated annotated = ip.getAnnotated();
-        ConfigProperty configProperty = annotated.getAnnotation(ConfigProperty.class);
-        String key = ConfigProducerUtil.getConfigKey(ip, configProperty);
-        String defaultValue = configProperty.defaultValue();
-
-        if (annotated.getBaseType() instanceof ParameterizedType) {
-            ParameterizedType paramType = (ParameterizedType) annotated.getBaseType();
-            Type rawType = paramType.getRawType();
-
-            // handle Provider<T> and Instance<T>
-            if (rawType instanceof Class
-                    && (((Class<?>) rawType).isAssignableFrom(Provider.class)
-                            || ((Class<?>) rawType).isAssignableFrom(Instance.class))
-                    && paramType.getActualTypeArguments().length == 1) {
-                Class<?> paramTypeClass = (Class<?>) paramType.getActualTypeArguments()[0];
-                return (T) getConfig().getValue(key, paramTypeClass);
-            }
-        } else {
-            Class<?> annotatedTypeClass = (Class<?>) annotated.getBaseType();
-            if (defaultValue.isEmpty()) {
-                return (T) getConfig().getValue(key, annotatedTypeClass);
-            } else {
-                Optional<T> optionalValue = (Optional<T>) getConfig().getOptionalValue(key, annotatedTypeClass);
-                return optionalValue.orElseGet(
-                        () -> (T) getConfig().unwrap(SmallRyeConfig.class).convert(defaultValue, annotatedTypeClass));
-            }
-        }
-
-        throw InjectionMessages.msg.unhandledConfigProperty();
-    }
-
-    public Config getConfig() {
-        if (_config == null) {
-            _config = io.smallrye.config.Config.get();
-        }
-        return _config;
+        return ConfigProducerUtil.getValue(ip, Config.get());
     }
 
     @Override

--- a/cdi/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
+++ b/cdi/src/main/java/io/smallrye/config/inject/ConfigProducerUtil.java
@@ -1,10 +1,10 @@
 package io.smallrye.config.inject;
 
+import static io.smallrye.config.Converters.createCollectionFactory;
 import static io.smallrye.config.Converters.newCollectionConverter;
 import static io.smallrye.config.Converters.newMapConverter;
 import static io.smallrye.config.Converters.newOptionalConverter;
 
-import java.io.Serial;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
@@ -35,8 +34,6 @@ import org.eclipse.microprofile.config.spi.Converter;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SecretKeys;
 import io.smallrye.config.SmallRyeConfig;
-import io.smallrye.config.common.AbstractConverter;
-import io.smallrye.config.common.AbstractDelegatingConverter;
 
 /**
  * Actual implementations for producer method in CDI producer {@link ConfigProducer}.
@@ -63,8 +60,7 @@ public final class ConfigProducerUtil {
 
     private static Type getType(InjectionPoint injectionPoint) {
         Type type = injectionPoint.getType();
-        if (type instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) type;
+        if (type instanceof ParameterizedType parameterizedType) {
             if (parameterizedType.getRawType().equals(Provider.class)
                     || parameterizedType.getRawType().equals(Instance.class)) {
                 return parameterizedType.getActualTypeArguments()[0];
@@ -89,68 +85,84 @@ public final class ConfigProducerUtil {
         }
 
         SmallRyeConfig smallRyeConfig = config.unwrap(SmallRyeConfig.class);
-        ConfigValue configValue = getConfigValue(name, smallRyeConfig);
-        ConfigValue configValueWithDefault = configValue.withValue(resolveDefault(configValue.getValue(), defaultValue));
+        // Injected values are allowed to read secret keys, so the whole resolution runs unlocked.
+        return SecretKeys.doUnlocked(() -> resolveValue(name, type, defaultValue, smallRyeConfig));
+    }
+
+    private static <T> T resolveValue(final String name, final Type type, final String defaultValue,
+            final SmallRyeConfig config) {
+        if (isType(type, Supplier.class)) {
+            return resolveValue(name, ((ParameterizedType) type).getActualTypeArguments()[0], defaultValue, config);
+        }
 
         if (hasCollection(type)) {
-            return convertValues(configValueWithDefault, type, smallRyeConfig);
+            return convertCollection(name, type, defaultValue, config);
         } else if (hasMap(type)) {
-            return convertMapValues(configValueWithDefault, type, smallRyeConfig);
+            return convertMap(name, type, defaultValue, config);
         }
 
-        return smallRyeConfig.convertValue(configValueWithDefault, resolveConverter(type, smallRyeConfig));
+        ConfigValue configValue = config.getConfigValue(name);
+        configValue = configValue.withValue(resolveDefault(configValue.getValue(), defaultValue));
+        return config.convertValue(configValue, resolveConverter(type, config));
     }
 
-    private static <T> T convertValues(ConfigValue configValue, Type type, SmallRyeConfig config) {
-        List<String> indexedProperties = config.getIndexedProperties(configValue.getName());
-        if (indexedProperties.isEmpty()) {
-            return config.convertValue(configValue, resolveConverter(type, config));
+    @SuppressWarnings("unchecked")
+    private static <T> T convertCollection(final String name, final Type type, final String defaultValue,
+            final SmallRyeConfig config) {
+        boolean optional = isType(type, Optional.class);
+        ParameterizedType collectionType = (ParameterizedType) (optional
+                ? ((ParameterizedType) type).getActualTypeArguments()[0]
+                : type);
+
+        ConfigValue configValue = config.getConfigValue(name);
+        if (defaultValue != null && configValue.getValue() == null && config.getIndexedProperties(name).isEmpty()) {
+            return config.convertValue(configValue.withValue(defaultValue), resolveConverter(type, config));
         }
 
-        // Check ordinality of indexed
-        int indexedOrdinality = Integer.MIN_VALUE;
-        List<ConfigValue> indexedValues = new ArrayList<>(indexedProperties.size());
-        for (String indexedProperty : indexedProperties) {
-            ConfigValue indexedValue = getConfigValue(indexedProperty, config);
-            if (indexedValue.getConfigSourceOrdinal() >= indexedOrdinality) {
-                indexedOrdinality = indexedValue.getConfigSourceOrdinal();
-            }
-            indexedValues.add(indexedValue);
-        }
-
-        BiFunction<Converter<T>, IntFunction<Collection<T>>, Collection<T>> indexedConverter = (itemConverter,
-                collectionFactory) -> {
-            Collection<T> collection = collectionFactory.apply(indexedValues.size());
-            for (ConfigValue indexedValue : indexedValues) {
-                collection.add(config.convertValue(indexedValue, itemConverter));
-            }
-            return collection;
-        };
-
-        // Use indexed if comma separated empty or higher in ordinality
-        if (configValue.getValue() == null || indexedOrdinality >= configValue.getConfigSourceOrdinal()) {
-            return resolveConverterForIndexed(type, config, indexedConverter).convert(" ");
-        } else {
-            return config.convertValue(configValue, resolveConverter(type, config));
-        }
+        Converter<Object> itemConverter = resolveConverter(collectionType.getActualTypeArguments()[0], config);
+        IntFunction<? extends Collection<Object>> collectionFactory = createCollectionFactory(rawTypeOf(collectionType));
+        return optional
+                ? (T) config.getOptionalValues(name, itemConverter, collectionFactory)
+                : (T) config.getValues(name, itemConverter, collectionFactory);
     }
 
-    private static <T> T convertMapValues(ConfigValue configValue, Type type, SmallRyeConfig config) {
-        Map<String, String> mapKeys = config.getMapKeys(configValue.getName());
-        if (configValue.getRawValue() != null || mapKeys.isEmpty()) {
-            return config.convertValue(configValue, resolveConverter(type, config));
+    @SuppressWarnings("unchecked")
+    private static <T> T convertMap(final String name, final Type type, final String defaultValue,
+            final SmallRyeConfig config) {
+        boolean optional = isType(type, Optional.class);
+        ParameterizedType mapType = (ParameterizedType) (optional ? ((ParameterizedType) type).getActualTypeArguments()[0]
+                : type);
+        Type valueType = mapType.getActualTypeArguments()[1];
+
+        if (isType(valueType, List.class) || isType(valueType, Set.class)) {
+            ConfigValue configValue = config.getConfigValue(name);
+            if (defaultValue != null && configValue.getValue() == null && config.getMapIndexedKeys(name).isEmpty()) {
+                return config.convertValue(configValue.withValue(defaultValue), resolveConverter(type, config));
+            }
+
+            Converter<Object> keyConverter = resolveConverter(mapType.getActualTypeArguments()[0], config);
+            ParameterizedType collectionType = (ParameterizedType) valueType;
+            Converter<Object> valueConverter = resolveConverter(collectionType.getActualTypeArguments()[0], config);
+            IntFunction<? extends Collection<Object>> collectionFactory = createCollectionFactory(rawTypeOf(collectionType));
+            return optional
+                    ? (T) config.getOptionalValues(name, keyConverter, valueConverter, HashMap::new, collectionFactory)
+                    : (T) config.getValues(name, keyConverter, valueConverter, HashMap::new, collectionFactory);
         }
 
-        BiFunction<Converter<?>, Converter<?>, Map<?, ?>> mapConverter = (keyConverter, valueConverter) -> {
-            Map<Object, Object> map = new HashMap<>(mapKeys.size());
-            for (Map.Entry<String, String> entry : mapKeys.entrySet()) {
-                map.put(keyConverter.convert(entry.getKey()),
-                        config.convertValue(getConfigValue(entry.getValue(), config), valueConverter));
-            }
-            return map;
-        };
+        ConfigValue configValue = config.getConfigValue(name);
+        if (defaultValue != null && configValue.getValue() == null && config.getMapKeys(name).isEmpty()) {
+            return config.convertValue(configValue.withValue(defaultValue), resolveConverter(type, config));
+        }
 
-        return ConfigProducerUtil.<T> resolveConverterForMap(type, config, mapConverter).convert(" ");
+        Converter<Object> keyConverter = resolveConverter(mapType.getActualTypeArguments()[0], config);
+        Converter<Object> valueConverter = resolveConverter(valueType, config);
+        return optional
+                ? (T) config.getOptionalValues(name, keyConverter, valueConverter, HashMap::new)
+                : (T) config.getValues(name, keyConverter, valueConverter, HashMap::new);
+    }
+
+    private static boolean isType(final Type type, final Class<?> rawType) {
+        return type instanceof ParameterizedType && ((ParameterizedType) type).getRawType().equals(rawType);
     }
 
     static ConfigValue getConfigValue(InjectionPoint injectionPoint, SmallRyeConfig config) {
@@ -178,8 +190,7 @@ public final class ConfigProducerUtil {
     @SuppressWarnings("unchecked")
     private static <T> Converter<T> resolveConverter(final Type type, final SmallRyeConfig config) {
         Class<T> rawType = rawTypeOf(type);
-        if (type instanceof ParameterizedType) {
-            ParameterizedType paramType = (ParameterizedType) type;
+        if (type instanceof ParameterizedType paramType) {
             Type[] typeArgs = paramType.getActualTypeArguments();
             if (rawType == List.class) {
                 return (Converter<T>) newCollectionConverter(resolveConverter(typeArgs[0], config), ArrayList::new);
@@ -196,64 +207,6 @@ public final class ConfigProducerUtil {
         }
         // just try the raw type
         return config.getConverter(rawType).orElseThrow(() -> InjectionMessages.msg.noRegisteredConverter(rawType));
-    }
-
-    /**
-     * We need to handle indexed properties in a special way, since a Collection may be wrapped in other converters.
-     * The issue is that in the original code the value was retrieved by calling the first converter that will delegate
-     * to all the wrapped types until it finally gets the result. For indexed properties, because it requires
-     * additional key lookups, a special converter is added to perform the work. This is mostly a workaround, since
-     * converters do not have the proper API, and probably should not have to handle this type of logic.
-     *
-     * @see IndexedCollectionConverter
-     */
-    @SuppressWarnings("unchecked")
-    private static <T> Converter<T> resolveConverterForIndexed(
-            final Type type,
-            final SmallRyeConfig config,
-            final BiFunction<Converter<T>, IntFunction<Collection<T>>, Collection<T>> indexedConverter) {
-
-        Class<T> rawType = rawTypeOf(type);
-        if (type instanceof ParameterizedType) {
-            ParameterizedType paramType = (ParameterizedType) type;
-            Type[] typeArgs = paramType.getActualTypeArguments();
-            if (rawType == List.class) {
-                return (Converter<T>) new IndexedCollectionConverter<>(resolveConverter(typeArgs[0], config), ArrayList::new,
-                        indexedConverter);
-            } else if (rawType == Set.class) {
-                return (Converter<T>) new IndexedCollectionConverter<>(resolveConverter(typeArgs[0], config), HashSet::new,
-                        indexedConverter);
-            } else if (rawType == Optional.class) {
-                return (Converter<T>) newOptionalConverter(resolveConverterForIndexed(typeArgs[0], config, indexedConverter));
-            } else if (rawType == Supplier.class) {
-                return resolveConverterForIndexed(typeArgs[0], config, indexedConverter);
-            }
-        }
-
-        throw new IllegalArgumentException();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> Converter<T> resolveConverterForMap(
-            final Type type,
-            final SmallRyeConfig config,
-            final BiFunction<Converter<?>, Converter<?>, Map<?, ?>> mapConverter) {
-
-        Class<T> rawType = rawTypeOf(type);
-        if (type instanceof ParameterizedType) {
-            ParameterizedType paramType = (ParameterizedType) type;
-            Type[] typeArgs = paramType.getActualTypeArguments();
-            if (rawType == Map.class) {
-                return (Converter<T>) new MapKeyConverter<>(resolveConverter(typeArgs[0], config),
-                        resolveConverter(typeArgs[1], config), mapConverter);
-            } else if (rawType == Optional.class) {
-                return (Converter<T>) newOptionalConverter(resolveConverterForMap(typeArgs[0], config, mapConverter));
-            } else if (rawType == Supplier.class) {
-                return resolveConverterForMap(typeArgs[0], config, mapConverter);
-            }
-        }
-
-        throw new IllegalArgumentException();
     }
 
     @SuppressWarnings("unchecked")
@@ -281,8 +234,7 @@ public final class ConfigProducerUtil {
 
     private static <T> boolean hasCollection(final Type type) {
         Class<T> rawType = rawTypeOf(type);
-        if (type instanceof ParameterizedType) {
-            ParameterizedType paramType = (ParameterizedType) type;
+        if (type instanceof ParameterizedType paramType) {
             Type[] typeArgs = paramType.getActualTypeArguments();
             if (rawType == List.class) {
                 return true;
@@ -333,8 +285,7 @@ public final class ConfigProducerUtil {
         if (!key.trim().isEmpty()) {
             return key;
         }
-        if (ip.getAnnotated() instanceof AnnotatedMember) {
-            AnnotatedMember<?> member = (AnnotatedMember<?>) ip.getAnnotated();
+        if (ip.getAnnotated() instanceof AnnotatedMember<?> member) {
             AnnotatedType<?> declaringType = member.getDeclaringType();
             if (declaringType != null) {
                 String[] parts = declaringType.getJavaClass().getCanonicalName().split("\\.");
@@ -347,52 +298,5 @@ public final class ConfigProducerUtil {
             }
         }
         throw InjectionMessages.msg.noConfigPropertyDefaultName(ip);
-    }
-
-    static final class IndexedCollectionConverter<T, C extends Collection<T>> extends AbstractDelegatingConverter<T, C> {
-        @Serial
-        private static final long serialVersionUID = 5186940408317652618L;
-
-        private final IntFunction<Collection<T>> collectionFactory;
-        private final BiFunction<Converter<T>, IntFunction<Collection<T>>, Collection<T>> indexedConverter;
-
-        public IndexedCollectionConverter(
-                final Converter<T> resolveConverter,
-                final IntFunction<Collection<T>> collectionFactory,
-                final BiFunction<Converter<T>, IntFunction<Collection<T>>, Collection<T>> indexedConverter) {
-            super(resolveConverter);
-
-            this.collectionFactory = collectionFactory;
-            this.indexedConverter = indexedConverter;
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public C convert(final String value) throws IllegalArgumentException, NullPointerException {
-            return (C) indexedConverter.apply((Converter<T>) getDelegate(), collectionFactory);
-        }
-    }
-
-    static final class MapKeyConverter<K, V> extends AbstractConverter<Map<? extends K, ? extends V>> {
-        @Serial
-        private static final long serialVersionUID = -2920578756435265533L;
-
-        private final Converter<? extends K> keyConverter;
-        private final Converter<? extends V> valueConverter;
-        private final BiFunction<Converter<? extends K>, Converter<? extends V>, Map<? extends K, ? extends V>> mapConverter;
-
-        public MapKeyConverter(
-                final Converter<? extends K> keyConverter,
-                final Converter<? extends V> valueConverter,
-                final BiFunction<Converter<? extends K>, Converter<? extends V>, Map<? extends K, ? extends V>> mapConverter) {
-            this.keyConverter = keyConverter;
-            this.valueConverter = valueConverter;
-            this.mapConverter = mapConverter;
-        }
-
-        @Override
-        public Map<? extends K, ? extends V> convert(final String value) throws IllegalArgumentException, NullPointerException {
-            return mapConverter.apply(keyConverter, valueConverter);
-        }
     }
 }

--- a/cdi/src/test/java/io/smallrye/config/inject/MapInjectionTest.java
+++ b/cdi/src/test/java/io/smallrye/config/inject/MapInjectionTest.java
@@ -55,6 +55,14 @@ public class MapInjectionTest {
         assertEquals("value", mapBean.getDefaults().get("default"));
     }
 
+    @Test
+    void keysOverInline() {
+        Map<String, String> keysOverInline = mapBean.getKeysOverInline();
+        assertEquals(1, keysOverInline.size());
+        assertEquals("value", keysOverInline.get("key"));
+        assertFalse(keysOverInline.containsKey("raw"));
+    }
+
     @ApplicationScoped
     static class MapBean {
         @Inject
@@ -72,6 +80,9 @@ public class MapInjectionTest {
         @Inject
         @ConfigProperty(name = "optionals.defaults", defaultValue = "default=value")
         Optional<Map<String, String>> optionalDefaults;
+        @Inject
+        @ConfigProperty(name = "keys-over-inline")
+        Map<String, String> keysOverInline;
 
         Map<String, String> getMap() {
             return map;
@@ -92,6 +103,10 @@ public class MapInjectionTest {
         Optional<Map<String, String>> getOptionalDefaults() {
             return optionalDefaults;
         }
+
+        Map<String, String> getKeysOverInline() {
+            return keysOverInline;
+        }
     }
 
     @BeforeAll
@@ -99,6 +114,7 @@ public class MapInjectionTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .withSources(config("map.key", "value", "map.key.nested", "value", "map.\"key.quoted\"", "value"))
                 .withSources(config("converted.key", "value"))
+                .withSources(config("keys-over-inline", "raw=value", "keys-over-inline.key", "value"))
                 .build();
         ConfigProviderResolver.instance().registerConfig(config, Thread.currentThread().getContextClassLoader());
     }

--- a/implementation/src/main/java/io/smallrye/config/Converters.java
+++ b/implementation/src/main/java/io/smallrye/config/Converters.java
@@ -523,7 +523,19 @@ public final class Converters {
         }
     }
 
-    static <T, C extends Collection<T>> IntFunction<? extends Collection<T>> createCollectionFactory(final Class<C> type) {
+    /**
+     * Create a collection factory for a supported {@link Collection} type. The returned {@link IntFunction} accepts
+     * the expected number of elements and produces an empty collection of the requested type, suitable for use with
+     * {@link #newCollectionConverter(Converter, IntFunction)} and the {@code SmallRyeConfig} collection lookups.
+     *
+     * @param type the collection type; only {@link List} and {@link Set} are supported (must not be {@code null})
+     * @param <T> the item type
+     * @param <C> the collection type
+     * @return a factory producing {@link ArrayList} for {@link List} or {@link HashSet} for {@link Set} (not {@code null})
+     * @throws IllegalArgumentException if {@code type} is neither {@link List} nor {@link Set}
+     */
+    public static <T, C extends Collection<T>> IntFunction<? extends Collection<T>> createCollectionFactory(
+            final Class<C> type) {
         if (type.equals(List.class)) {
             return ArrayList::new;
         }

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -661,11 +661,6 @@ public class SmallRyeConfig implements Config, Serializable {
         return configSources.defaultValues;
     }
 
-    @Deprecated
-    public <T> T convert(String value, Class<T> asType) {
-        return value != null ? requireConverter(asType).convert(value) : null;
-    }
-
     private <T> Converter<Optional<T>> getOptionalConverter(Class<T> asType) {
         Converter<Optional<T>> converter = recast(optionalConverters.get(asType));
         if (converter == null) {

--- a/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SmallRyeConfigTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,14 +78,6 @@ class SmallRyeConfigTest {
                 (IntFunction<List<Integer>>) value -> new ArrayList<>());
         assertTrue(values.isPresent());
         assertEquals(Arrays.asList(1, 2, 3, 4), values.get());
-    }
-
-    @Test
-    void convert() {
-        SmallRyeConfig config = new SmallRyeConfigBuilder().build();
-
-        assertEquals(1234, config.convert("1234", Integer.class).intValue());
-        assertNull(config.convert(null, Integer.class));
     }
 
     @Test


### PR DESCRIPTION
- Replace the duplicated code used in the CDI module with direct calls to the `SmallRyeConfig` APIs