### PR TITLE
Use backslash escaping for property expressions

### DIFF
--- a/documentation/src/main/docs/config/expressions.md
+++ b/documentation/src/main/docs/config/expressions.md
@@ -20,9 +20,48 @@ Additionally, the Expression Expansion engine supports the following segments:
 
 If an expression cannot be expanded and no default is supplied a `NoSuchElementException` is thrown.
 
-Expression expansion may be selectively disabled with `io.smallrye.config.Expressions`:
+## Escaping
+
+A `$` that begins an expression segment can be escaped with a backslash to treat it as a literal character:
+
+```properties
+# value is: ${my.prop}
+expression=\${my.prop}
+```
+
+A backslash that immediately precedes a `$` can itself be escaped with another backslash:
+
+```properties
+# my.prop=value
+# value is: \value
+expression=\\${my.prop}
+```
+
+Escaping only applies to values that contain an expression segment. In a value that has no `${ ... }` segment,
+every backslash is treated as a literal character and nothing needs escaping (for example, a Windows path such as
+`C:\some\path` is used as-is).
+
+As soon as a value contains an expression segment, the whole value is processed for escapes and backslash becomes an
+escape character everywhere in it, not just before a `$`. Standard escape sequences are interpreted (`\n`, `\r`, `\t`,
+`\b`, `\f`) and a backslash before any other character is dropped. To keep a literal backslash in such a value, double
+it:
+
+```properties
+# value is: C:\some\path\value (my.prop=value)
+expression=C:\\some\\path\\${my.prop}
+```
+
+## Disabling Expansion
+
+Expression expansion may be selectively disabled for a block of code using `io.smallrye.config.Expressions.withoutExpansion()`.
+The raw (unexpanded) value is returned for any property looked up within the block:
+
+```properties
+callable.url=https://${remote.host}/
+```
 
 ```java
 Config config = Config.getOrCreate();
+// returns "https://${remote.host}/"
 String url = Expressions.withoutExpansion(() -> config.getValue("callable.url", String.class));
 ```

--- a/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/ExpressionConfigSourceInterceptor.java
@@ -1,7 +1,9 @@
 package io.smallrye.config;
 
 import static io.smallrye.common.expression.Expression.Flag.DOUBLE_COLON;
+import static io.smallrye.common.expression.Expression.Flag.ESCAPES;
 import static io.smallrye.common.expression.Expression.Flag.LENIENT_SYNTAX;
+import static io.smallrye.common.expression.Expression.Flag.NO_$$;
 import static io.smallrye.common.expression.Expression.Flag.NO_SMART_BRACES;
 import static io.smallrye.common.expression.Expression.Flag.NO_TRIM;
 import static io.smallrye.config._private.ConfigMessages.msg;
@@ -68,8 +70,8 @@ public class ExpressionConfigSourceInterceptor implements ConfigSourceIntercepto
         }
 
         ConfigValue.ConfigValueBuilder valueBuilder = configValue.from();
-        Expression expression = Expression.compile(escapeDollarIfExists(configValue.getValue()), LENIENT_SYNTAX, NO_TRIM,
-                NO_SMART_BRACES, DOUBLE_COLON);
+        Expression expression = Expression.compile(configValue.getValue(),
+                ESCAPES, LENIENT_SYNTAX, DOUBLE_COLON, NO_TRIM, NO_SMART_BRACES, NO_$$);
         String expanded = expression.evaluate(new BiConsumer<ResolveContext<RuntimeException>, StringBuilder>() {
             @Override
             public void accept(ResolveContext<RuntimeException> resolveContext, StringBuilder stringBuilder) {
@@ -93,35 +95,12 @@ public class ExpressionConfigSourceInterceptor implements ConfigSourceIntercepto
                 } else if (resolveContext.hasDefault()) {
                     resolveContext.expandDefault();
                 } else {
-                    valueBuilder.addProblem(new Problem(msg.expandingElementNotFound(key, configValue.getName())));
+                    valueBuilder.addProblem(new Problem(msg.expandingElementNotFound(key, name)));
                 }
             }
         });
 
         return valueBuilder.withValue(expanded).build();
-    }
-
-    /**
-     * MicroProfile Config defines the backslash escape for dollar to retrieve the raw expression. We don't want to
-     * turn {@link Expression.Flag#ESCAPES} on because it may break working configurations.
-     * <br>
-     * This will replace the expected escape in MicroProfile Config by the escape used in {@link Expression}, a double
-     * dollar.
-     */
-    private String escapeDollarIfExists(final String value) {
-        int index = value.indexOf("\\$");
-        if (index != -1) {
-            int start = 0;
-            StringBuilder builder = new StringBuilder();
-            while (index != -1) {
-                builder.append(value, start, index).append("$$");
-                start = index + 2;
-                index = value.indexOf("\\$", start);
-            }
-            builder.append(value.substring(start));
-            return builder.toString();
-        }
-        return value;
     }
 
     private SecretKeysHandler getHandler(final String handlerName, final ConfigSourceInterceptorContext context) {

--- a/implementation/src/test/java/io/smallrye/config/ExpressionConfigSourceInterceptorTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ExpressionConfigSourceInterceptorTest.java
@@ -120,18 +120,28 @@ class ExpressionConfigSourceInterceptorTest {
 
     @Test
     void escape() {
-        assertEquals("${my.prop}", buildConfig("expression", "$${my.prop}").getConfigValue("expression").getValue());
-        assertEquals("${my.prop}", buildConfig("expression", "\\${my.prop}").getConfigValue("expression").getValue());
+        // Test NO_$$
+        assertEquals("$1234",
+                buildConfig("expression", "$${my.prop}", "my.prop", "1234").getConfigValue("expression").getValue());
 
-        assertEquals("file:target/prices/?fileName=${date:now:yyyyMMddssSS}.txt&charset=utf-8",
-                buildConfig("camel.expression",
-                        "file:target/prices/?fileName=$${date:now:yyyyMMddssSS}.txt&charset=utf-8")
-                        .getConfigValue("camel.expression").getValue());
+        assertEquals("${my.prop}",
+                buildConfig("expression", "\\${my.prop}").getConfigValue("expression").getValue());
 
         assertEquals("file:target/prices/?fileName=${date:now:yyyyMMddssSS}.txt&charset=utf-8",
                 buildConfig("camel.expression",
                         "file:target/prices/?fileName=\\${date:now:yyyyMMddssSS}.txt&charset=utf-8")
                         .getConfigValue("camel.expression").getValue());
+
+        assertEquals("\\$\\{%s}",
+                buildConfig("key", "\\\\$\\\\{%s}").getConfigValue("key").getValue());
+
+        // Standard escape sequences are interpreted within an expression-bearing value.
+        assertEquals("a\tbvalue",
+                buildConfig("expression", "a\\tb${my.prop}", "my.prop", "value").getConfigValue("expression").getValue());
+
+        // A backslash before any other character is dropped within an expression-bearing value.
+        assertEquals("qwqvalue",
+                buildConfig("expression", "q\\wq${my.prop}", "my.prop", "value").getConfigValue("expression").getValue());
     }
 
     @Test
@@ -158,22 +168,22 @@ class ExpressionConfigSourceInterceptorTest {
 
         ConfigValue noExpression = config.getConfigValue("my.prop");
         assertNotNull(noExpression);
-        assertEquals(noExpression.getName(), "my.prop");
+        assertEquals("my.prop", noExpression.getName());
         assertNull(noExpression.getValue());
 
         ConfigValue noExpressionPartial = config.getConfigValue("my.prop.partial");
         assertNotNull(noExpressionPartial);
-        assertEquals(noExpressionPartial.getName(), "my.prop.partial");
+        assertEquals("my.prop.partial", noExpressionPartial.getName());
         assertNull(noExpressionPartial.getValue());
 
         ConfigValue noExpressionAnotherPartial = config.getConfigValue("my.prop.anotherPartial");
         assertNotNull(noExpressionAnotherPartial);
-        assertEquals(noExpressionAnotherPartial.getName(), "my.prop.anotherPartial");
+        assertEquals("my.prop.anotherPartial", noExpressionAnotherPartial.getName());
         assertNull(noExpressionAnotherPartial.getValue());
 
         ConfigValue noExpressionDependent = config.getConfigValue("my.prop.dependent");
         assertNotNull(noExpressionDependent);
-        assertEquals(noExpressionDependent.getName(), "my.prop.dependent");
+        assertEquals("my.prop.dependent", noExpressionDependent.getName());
         assertNull(noExpressionDependent.getValue());
 
         assertThrows(Exception.class, () -> config.getValue("my.prop", String.class));
@@ -184,10 +194,10 @@ class ExpressionConfigSourceInterceptorTest {
 
     @Test
     void arrayEscapes() {
-        SmallRyeConfig config = buildConfig("list", "cat,dog,${mouse},sea\\,turtle", "mouse", "mouse");
+        SmallRyeConfig config = buildConfig("list", "cat,dog,${mouse},sea\\\\,turtle", "mouse", "mouse");
         List<String> list = config.getValues("list", String.class, ArrayList::new);
         assertEquals(4, list.size());
-        assertEquals(list, Stream.of("cat", "dog", "mouse", "sea,turtle").collect(toList()));
+        assertEquals(Stream.of("cat", "dog", "mouse", "sea,turtle").toList(), list);
     }
 
     @Test
@@ -204,8 +214,15 @@ class ExpressionConfigSourceInterceptorTest {
 
     @Test
     void windowPath() {
-        SmallRyeConfig config = buildConfig("window.path", "C:\\Some\\Path");
-        assertEquals("C:\\Some\\Path", config.getConfigValue("window.path").getValue());
+        // A value with no expression segment keeps every backslash literal (no escaping applied).
+        assertEquals("C:\\Some\\Path",
+                buildConfig("window.path", "C:\\Some\\Path").getConfigValue("window.path").getValue());
+
+        // As soon as the value contains an expression, backslash becomes an escape character everywhere in it, so a
+        // literal backslash must be doubled
+        assertEquals("C:\\some\\path\\value",
+                buildConfig("window.path", "C:\\\\some\\\\path\\\\${my.prop}", "my.prop", "value").getConfigValue("window.path")
+                        .getValue());
     }
 
     @Test

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -54,10 +54,6 @@
           <dependenciesToScan>
             <dependency>org.eclipse.microprofile.config:microprofile-config-tck</dependency>
           </dependenciesToScan>
-          <!-- Require updates to MP TCK -->
-          <excludes>
-            <exclude>org.eclipse.microprofile.config.tck.ConverterTest</exclude>
-          </excludes>
         </configuration>
         <executions>
           <execution>
@@ -66,6 +62,10 @@
               <goal>test</goal>
             </goals>
             <configuration>
+              <!-- To be able to exclude specific methods; TestNG doesn't support excludesFile method exclusion -->
+              <suiteXmlFiles>
+                <suiteXmlFile>tck-suite.xml</suiteXmlFile>
+              </suiteXmlFiles>
               <classpathDependencyExcludes>
                 <exclude>org.apache.openwebbeans:openwebbeans-spi</exclude>
                 <exclude>org.apache.openwebbeans:openwebbeans-impl</exclude>
@@ -79,6 +79,9 @@
               <goal>test</goal>
             </goals>
             <configuration>
+              <suiteXmlFiles>
+                <suiteXmlFile>tck-suite-owb.xml</suiteXmlFile>
+              </suiteXmlFiles>
               <classpathDependencyExcludes>
                 <exclude>org.jboss.weld:weld-core-impl</exclude>
                 <exclude>org.jboss.arquillian.container:arquillian-weld-embedded</exclude>

--- a/testsuite/tck/tck-suite-owb.xml
+++ b/testsuite/tck/tck-suite-owb.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="microprofile-config-tck" verbose="2" configfailurepolicy="continue">
+  <test name="microprofile-config-tck">
+    <packages>
+      <package name="org.eclipse.microprofile.config.tck.*"/>
+    </packages>
+
+    <classes>
+      <class name="org.eclipse.microprofile.config.tck.PropertyExpressionsTest">
+        <methods>
+          <exclude name="arrayEscapes"/>
+        </methods>
+      </class>
+      <class name="org.eclipse.microprofile.config.tck.ConverterTest">
+        <methods>
+          <exclude name=".*"/>
+        </methods>
+      </class>
+    </classes>
+  </test>
+</suite>

--- a/testsuite/tck/tck-suite.xml
+++ b/testsuite/tck/tck-suite.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="microprofile-config-tck" verbose="2" configfailurepolicy="continue">
+    <test name="microprofile-config-tck">
+        <packages>
+            <package name="org.eclipse.microprofile.config.tck.*"/>
+        </packages>
+
+        <classes>
+            <class name="org.eclipse.microprofile.config.tck.PropertyExpressionsTest">
+                <methods>
+                    <exclude name="arrayEscapes"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Replace the internal `\$` to `$$` rewrite in `ExpressionConfigSourceInterceptor` with the `Expression` engine's `ESCAPES` and `NO_$$` flags, so backslash becomes the escape character and `$$` is no longer collapsed to a single `$`.

Behavior changes for values containing an expression segment:
- `\$` escapes a `$`, `\\` produces a literal backslash (double backslashes to keep a literal one)
- `$$` is preserved as `$$`; `$${expr}` yields `$` followed by the expansion.
- Standard escape sequences (`\n`, `\r`, `\t`, `\b`, `\f`) are interpreted.
- Values without an expression segment are unaffected (backslashes stay literal).

Current configuration values using expressions **MUST**:
- `$$` is no longer an escape sequence. It is now kept verbatim, so any value that relied on `$$` collapsing to a single `$` must drop one `$` (`a$$b` becomes `a$b`)
- To escape an expression, use `\$` instead of `$$` (e.g. `$${my.prop}` becomes `\${my.prop}`)
- Double-escape sequences if an expression is used in a comma-separated value for lists and arrays (`cat,dog,${mouse},sea\,turtle`, becomes `cat,dog,${mouse},sea\\,turtle`)

<br>

- Fixes #746
- Fixes #1056
- Fixes #1219