### PR TITLE
Register profile names with SecretKeys

### DIFF
--- a/implementation/src/main/java/io/smallrye/config/PropertyName.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertyName.java
@@ -209,17 +209,4 @@ public class PropertyName {
     public static PropertyName name(final String name) {
         return new PropertyName(name);
     }
-
-    public static PropertyName unprofiled(final String name) {
-        if (!name.isEmpty() && name.charAt(0) == '%') {
-            int profilesEnd = name.indexOf('.', 1);
-            return new PropertyName(profilesEnd == -1 ? name : name.substring(profilesEnd + 1));
-        } else {
-            return new PropertyName(name);
-        }
-    }
-
-    public static boolean hasWildcardOrIndexed(final String name) {
-        return name.indexOf('*') != -1 || name.indexOf('[') != -1;
-    }
 }

--- a/implementation/src/main/java/io/smallrye/config/SecretKeys.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeys.java
@@ -2,6 +2,10 @@ package io.smallrye.config;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -100,6 +104,35 @@ public final class SecretKeys implements Serializable {
             }
         } else {
             return supplier.get();
+        }
+    }
+
+    public static class Secrets extends PropertyNamesMatcher<Void> {
+        private final Set<String> secrets = new HashSet<>();
+
+        public Set<String> getSecrets() {
+            return Collections.unmodifiableSet(secrets);
+        }
+
+        @Override
+        protected void add(String name, Void value) {
+            secrets.add(name);
+            super.add(name, null);
+        }
+
+        @Override
+        protected void put(String name, Void value) {
+            secrets.add(name);
+            super.put(name, null);
+        }
+
+        Secrets withProfiles(List<String> profiles) {
+            for (String secret : secrets) {
+                for (String profile : profiles) {
+                    super.add("%" + profile + "." + secret, null);
+                }
+            }
+            return this;
         }
     }
 }

--- a/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
+++ b/implementation/src/main/java/io/smallrye/config/SecretKeysConfigSourceInterceptor.java
@@ -30,7 +30,7 @@ public class SecretKeysConfigSourceInterceptor implements ConfigSourceIntercepto
     @Override
     public ConfigValue getValue(final ConfigSourceInterceptorContext context, final String name) {
         // separate empty check to avoid PropertyName alloc
-        if (SecretKeys.isLocked() && !secrets.isEmpty() && secrets.matches(PropertyName.unprofiled(name).getName())) {
+        if (SecretKeys.isLocked() && !secrets.isEmpty() && secrets.matches(name)) {
             throw ConfigMessages.msg.notAllowed(name);
         }
         return context.proceed(name);

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfig.java
@@ -797,7 +797,8 @@ public class SmallRyeConfig implements Config, Serializable {
             this.sources = configSources;
             this.defaultValues = defaultValues;
             this.interceptorChain = current;
-            this.propertyNames = new PropertyNames(current, builder.getSecretKeys(), builder.isCachePropertyNames());
+            this.propertyNames = new PropertyNames(current, builder.getSecretKeys().withProfiles(profiles),
+                    builder.isCachePropertyNames());
         }
 
         private static List<ConfigSource> buildSources(final SmallRyeConfigBuilder builder) {
@@ -1075,7 +1076,7 @@ public class SmallRyeConfig implements Config, Serializable {
                 while (namesIterator.hasNext()) {
                     String name = namesIterator.next();
                     // separate empty check to avoid PropertyName alloc
-                    if (!secretKeys.isEmpty() && secretKeys.matches(PropertyName.unprofiled(name).getName())) {
+                    if (!secretKeys.isEmpty() && secretKeys.matches(name)) {
                         secretNames.add(name);
                     } else {
                         names.add(name);

--- a/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
+++ b/implementation/src/main/java/io/smallrye/config/SmallRyeConfigBuilder.java
@@ -58,6 +58,7 @@ import io.smallrye.common.constraint.Assert;
 import io.smallrye.config.ConfigMappings.ConfigClass;
 import io.smallrye.config.Converters.ConverterWithPriority;
 import io.smallrye.config.DefaultValuesConfigSource.Defaults;
+import io.smallrye.config.SecretKeys.Secrets;
 import io.smallrye.config._private.ConfigMessages;
 
 /**
@@ -72,7 +73,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
     private final List<InterceptorWithPriority> interceptors = new ArrayList<>();
     private final List<String> profiles = new ArrayList<>();
     private final Defaults defaults = new Defaults();
-    private final PropertyNamesMatcher<?> secretKeys = new PropertyNamesMatcher<>();
+    private final Secrets secrets = new Secrets();
     private final List<SecretKeysHandlerWithName> secretKeysHandlers = new ArrayList<>();
     private ConfigValidator validator = ConfigValidator.EMPTY;
     private final MappingBuilder mappingsBuilder = new MappingBuilder();
@@ -408,7 +409,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         interceptors.add(new InterceptorWithPriority(new ConfigSourceInterceptorFactory() {
             @Override
             public ConfigSourceInterceptor getInterceptor(final ConfigSourceInterceptorContext context) {
-                return new SecretKeysConfigSourceInterceptor(SmallRyeConfigBuilder.this.secretKeys);
+                return new SecretKeysConfigSourceInterceptor(SmallRyeConfigBuilder.this.secrets);
             }
 
             @Override
@@ -513,7 +514,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
 
     public SmallRyeConfigBuilder withSecretKeys(String... keys) {
         for (String key : keys) {
-            secretKeys.add(key);
+            secrets.add(key);
         }
         return this;
     }
@@ -630,8 +631,8 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         return defaults;
     }
 
-    public PropertyNamesMatcher<?> getSecretKeys() {
-        return secretKeys;
+    public Secrets getSecretKeys() {
+        return secrets;
     }
 
     public MappingBuilder getMappingsBuilder() {
@@ -811,7 +812,7 @@ public class SmallRyeConfigBuilder implements ConfigBuilder {
         private void addDefaultsAndIgnores(ConfigClass configClass) {
             // Do not override defaults set by the builder directly, which have priority over mapping defaults
             defaults.add(configClass.getProperties());
-            secretKeys.add(configClass.getSecrets());
+            secrets.add(configClass.getSecrets());
             if (configClass.getHandler().ignoreUnmappedProperties()) {
                 ignores.add(configClass.getPrefix().isEmpty() ? "*" : configClass.getPrefix() + ".**");
             }

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingSecretsTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingSecretsTest.java
@@ -81,6 +81,7 @@ class ConfigMappingSecretsTest {
         SmallRyeConfig config = new SmallRyeConfigBuilder()
                 .addDefaultInterceptors()
                 .withMapping(MappingSecrets.class)
+                .withProfile("dev")
                 .withSources(config(
                         "%dev.secrets.secret", "secret",
                         "secrets.secret", "secret",


### PR DESCRIPTION
Mostly to avoid allocations of `PropertyName` on each lookup.