### PR TITLE
Make FileSystemConfigSource take into account Win line endings

### DIFF
--- a/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
+++ b/sources/file-system/src/main/java/io/smallrye/config/source/file/FileSystemConfigSource.java
@@ -99,7 +99,9 @@ public class FileSystemConfigSource extends MapBackedConfigSource {
     private static String readContent(Path file) {
         try {
             String content = Files.readString(file);
-            if (content.endsWith("\n")) {
+            if (content.endsWith("\r\n")) {
+                content = content.substring(0, content.length() - 2);
+            } else if (content.endsWith("\n") || content.endsWith("\r")) {
                 content = content.substring(0, content.length() - 1);
             }
             return content;

--- a/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceTest.java
+++ b/sources/file-system/src/test/java/io/smallrye/config/source/file/FileSystemConfigSourceTest.java
@@ -74,6 +74,13 @@ class FileSystemConfigSourceTest {
     }
 
     @Test
+    void testConfigOrdinalWithTrailingWindowsNewline(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("config_ordinal"), "500\r\n");
+        ConfigSource configSource = new FileSystemConfigSource(tempDir.toFile());
+        assertEquals(500, configSource.getOrdinal());
+    }
+
+    @Test
     void testMultilineNoTrailingNewline(@TempDir Path tempDir) throws IOException {
         Files.writeString(tempDir.resolve("key"), "line1\nline2\nline3");
         ConfigSource configSource = new FileSystemConfigSource(tempDir.toFile());


### PR DESCRIPTION
We found this regression here https://github.com/wildfly/wildfly/pull/20354#issuecomment-5585179334 in a test that has been working for years.

In our tests it creates the files with `Files.write(path, Collections.singletonList(value)).`, so that on Windows it gets the extra terminator. So assuming `\r\n` is allowed as a line ending in these files, this is a regression.