### PR TITLE
Rewrite PropertyName equals to a segment by segment matching engine and cover missing cases

### DIFF
--- a/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
+++ b/common/src/main/java/io/smallrye/config/common/utils/StringUtil.java
@@ -397,6 +397,15 @@ public class StringUtil {
         }
 
         if (name.charAt(begin) == '"' && name.charAt(end - 1) == '"') {
+            // both quotes must be the matching pair of a single segment, or they are part of the name
+            for (int i = begin + 1; i < end - 1; i++) {
+                char c = name.charAt(i);
+                if (c == '\\') {
+                    i++;
+                } else if (c == '"') {
+                    return name.substring(begin, end);
+                }
+            }
             return name.substring(begin + 1, end - 1);
         } else {
             return name.substring(begin, end);

--- a/common/src/test/java/io/smallrye/config/common/utils/StringUtilTest.java
+++ b/common/src/test/java/io/smallrye/config/common/utils/StringUtilTest.java
@@ -232,6 +232,24 @@ class StringUtilTest {
         assertEquals("my.\"unquoted\"", StringUtil.unquoted("my.\"unquoted\""));
         assertEquals("unquoted", StringUtil.unquoted("my.\"unquoted\"", 3, 13));
         assertEquals("unquoted", StringUtil.unquoted("my.unquoted", 3, 11));
+
+        // the quotes wrap a single segment, so they are stripped
+        assertEquals("bar", StringUtil.unquoted("map.\"bar\"", 4));
+        assertEquals("bar.baz", StringUtil.unquoted("map.\"bar.baz\"", 4));
+        assertEquals("bar[0]", StringUtil.unquoted("map.\"bar[0]\"", 4));
+
+        // the region spans multiple segments, so the quotes are part of the name and are kept
+        assertEquals("\"bar\"[0]", StringUtil.unquoted("map.\"bar\"[0]", 4));
+        assertEquals("\"bar\".baz", StringUtil.unquoted("map.\"bar\".baz", 4));
+        assertEquals("bar.\"baz\"", StringUtil.unquoted("map.bar.\"baz\"", 4));
+
+        // the region starts and ends with a quote, but the quotes belong to different segments
+        assertEquals("\"bar\".\"baz\"", StringUtil.unquoted("map.\"bar\".\"baz\"", 4));
+        assertEquals("\"bar.baz\".\"qux\"", StringUtil.unquoted("map.\"bar.baz\".\"qux\"", 4));
+        assertEquals("\"bar\".\"baz.qux\"", StringUtil.unquoted("map.\"bar\".\"baz.qux\"", 4));
+
+        // an escaped quote is part of the segment, so it does not break the matching pair
+        assertEquals("bar\\\"baz", StringUtil.unquoted("map.\"bar\\\"baz\"", 4));
     }
 
     @Test

--- a/implementation/src/main/java/io/smallrye/config/PropertyName.java
+++ b/implementation/src/main/java/io/smallrye/config/PropertyName.java
@@ -14,20 +14,14 @@ import static io.smallrye.config.common.utils.StringUtil.isNumericEquals;
  * <li><code>foo.bar.baz</code> matches <code>foo.*.baz</code></li>
  * <li><code>foo."bar.baz"</code> matches <code>foo.*</code></li>
  * <li><code>foo.bar[0]</code> matches <code>foo.bar[*]</code></li>
+ * <li><code>foo."bar[0]"</code> does not match <code>foo.bar[0]</code></li>
+ * <li><code>foo."bar[0]"</code> does not match <code>foo."bar[*]"</code></li>
  * </ul>
+ * <p>
+ * Due to the equality rules and hashing function, {@link PropertyName} is <code>NOT</code> suitable for use in
+ * structures that require an even distribution of keys.
  */
-public class PropertyName {
-    private final String name;
-    private final int hashCode;
-
-    public PropertyName(final String name) {
-        this.name = name;
-        this.hashCode = hashCode(name);
-    }
-
-    public String getName() {
-        return name;
-    }
+public record PropertyName(String name) {
 
     @Override
     public boolean equals(final Object o) {
@@ -46,12 +40,12 @@ public class PropertyName {
      *
      * @param name a String with a configuration name.
      * @param other a String with another configuration name.
-     * @return <code>true</code> if both arguments match the {@link PropertyName} semantics, <code>false</code>
+     * @return <code>true</code> if both arguments match the {@link PropertyName} semantics,
+     *         <code>false</code>
      *         otherwise.
      */
     public static boolean equals(final String name, final String other) {
-        return equalsInternal(name, 0, name.length(), other, 0, other.length())
-                || equalsInternal(other, 0, other.length(), name, 0, name.length());
+        return equals(name, 0, name.length(), other, 0, other.length());
     }
 
     /**
@@ -66,104 +60,448 @@ public class PropertyName {
      * @return <code>true</code> if both arguments match the {@link PropertyName} semantics, <code>false</code>
      *         otherwise.
      */
-    public static boolean equals(final String name, final int offset, final int len, final String other, final int ooffset,
-            final int olen) {
-        return equalsInternal(name, offset, len, other, ooffset, olen)
-                || equalsInternal(other, ooffset, olen, name, offset, len);
-    }
-
     @SuppressWarnings("squid:S4973")
-    private static boolean equalsInternal(final String name, final int offset, final int len, final String other,
-            final int ooffset, final int olen) {
+    public static boolean equals(
+            final String name, final int offset, final int len,
+            final String other, final int ooffset, final int olen) {
+
         //noinspection StringEquality
-        if (name == other) {
+        if (name == other && offset == ooffset && len == olen) {
             return true;
         }
-
-        if (name.equals("*") && (other.isEmpty() || other.equals("\"\""))) {
+        if (len == olen && name.regionMatches(offset, other, ooffset, len)) {
+            return true;
+        }
+        // fast path, names that share a long prefix are the common case, so if the last character is different we
+        // know there is no match.
+        if (len != 0 && olen != 0) {
+            char last = name.charAt(offset + len - 1);
+            char olast = other.charAt(ooffset + olen - 1);
+            if (last != olast && isPlain(last) && isPlain(olast)) {
+                return false;
+            }
+        }
+        // a wildcard stands for any segment, empty ones included, so "map.*" matches "map.\"\"", but it does not
+        // stand for a leading empty segment, so "*" matches neither "" nor ".foo"
+        if (startsEmpty(name, offset, offset + len) != startsEmpty(other, ooffset, ooffset + olen)) {
             return false;
         }
 
-        char n;
-        char o;
+        if (matches(name, offset, offset + len, other, ooffset, ooffset + olen)) {
+            return true;
+        }
+        // matching is symmetric, except for the greedy trailing star, so the other direction is only required
+        // when it is the other name that ends in one
+        if (other.indexOf('*', ooffset) == -1) {
+            return false;
+        }
+        int last = lastSegmentStart(other, ooffset, ooffset + olen);
+        if (!isStar(other, last, nameEnd(other, last, ooffset + olen))) {
+            return false;
+        }
+        return matches(other, ooffset, ooffset + olen, name, offset, offset + len);
+    }
 
-        int matchPosition = offset + len - 1;
-        for (int i = ooffset + olen - 1; i >= ooffset; i--) {
-            if (matchPosition == -1) {
+    /**
+     * Checks if the character only stands for itself, so it neither ends the segment nor carries any meaning.
+     */
+    private static boolean isPlain(final char c) {
+        return c != '.' && c != '"' && c != '*' && c != '[' && c != ']' && c != '\\';
+    }
+
+    /**
+     * Checks if the first segment of the region is empty, which only a leading dot or a leading quote can make it.
+     */
+    private static boolean startsEmpty(final String name, final int start, final int end) {
+        if (start == end) {
+            return true;
+        }
+        char c = name.charAt(start);
+        if (c == '.') {
+            return true;
+        }
+        // only a run of quotes can be an empty segment, so a single one, or one that a name follows, cannot
+        if (c != '"' || start + 1 == end || name.charAt(start + 1) != '"') {
+            return false;
+        }
+        return isEmpty(name, start, segmentEnd(name, start, end));
+    }
+
+    /**
+     * Matches the segments of <code>name</code> against the segments of <code>other</code>, in order. A star segment
+     * in <code>name</code> stands for any non empty segment in <code>other</code>, and a trailing star segment is
+     * greedy, so it stands for every remaining segment.
+     */
+    private static boolean matches(
+            final String name, final int start, final int end,
+            final String other, final int ostart, final int oend) {
+
+        int s = start;
+        int os = ostart;
+        segments: for (;;) {
+            for (int i = s, o = os; i < end && o < oend;) {
+                char c = name.charAt(i);
+                char d = other.charAt(o);
+                if (c == '.' && d == '.') {
+                    // everything before matched and both segments end here
+                    s = i + 1;
+                    os = o + 1;
+                    continue segments;
+                } else if (c == '"' && !isQuoteRequired(name, start, end, i)) {
+                    // a quote that carries no meaning only shifts the name being compared
+                    i++;
+                } else if (d == '"' && !isQuoteRequired(other, ostart, oend, o)) {
+                    o++;
+                } else if (c == '"' && isPlain(d) || d == '"' && isPlain(c)) {
+                    // the quote that remains is one the segment requires, so it is a plain character that only
+                    // another quote matches, and a segment holding one is never a wildcard
+                    return false;
+                } else if (!isPlain(c) || !isPlain(d)) {
+                    break;
+                } else if (c != d) {
+                    // nothing later in either segment can realign what already differs
+                    return false;
+                } else {
+                    i++;
+                    o++;
+                }
+            }
+
+            int e = segmentEnd(name, s, end);
+            int oe = segmentEnd(other, os, oend);
+
+            // greedy map - a trailing star segment consumes every remaining segment
+            if (e == end && oe != oend && isStar(name, s, nameEnd(name, s, e))) {
+                int last = lastSegmentStart(other, os, oend);
+                if (hasWildcard(other, ostart, oend) || hasIndex(other, os, last)) {
+                    return false;
+                }
+                return segmentMatches(name, s, e, other, last, oend);
+            }
+
+            if (!segmentMatches(name, s, e, other, os, oe)) {
                 return false;
             }
 
-            o = other.charAt(i);
-            n = name.charAt(matchPosition);
+            if (e == end || oe == oend) {
+                return e == end && oe == oend;
+            }
 
-            if (n == '*') {
-                if (o == ']') {
-                    return false;
-                } else if (o == '"') {
-                    int beginQuote = other.lastIndexOf('"', i - 1);
-                    if (beginQuote != -1) {
-                        i = beginQuote;
-                    }
-                } else {
-                    int previousDot = other.lastIndexOf('.', i);
-                    if (previousDot != -1) {
-                        i = previousDot + 1;
-                    } else {
-                        i = 0;
-                    }
-                    // greedy map - match any ending segments if a last segment is a *
-                    if (matchPosition + 1 == len) {
-                        // try to match by removing the * and the last segment
-                        if (equalsInternal(name, offset, matchPosition, other, ooffset, olen - (ooffset + olen - i))) {
+            s = e + 1;
+            os = oe + 1;
+        }
+    }
+
+    /**
+     * Matches a single segment. Quotes that the segment does not require carry no meaning, so <code>"bar"</code>
+     * matches <code>bar</code> and <code>"*"</code> is still the wildcard <code>*</code>. Quotes that the segment
+     * does require are part of the name, so <code>"bar.baz"</code> is a single opaque segment, in which the star and
+     * the brackets are plain characters.
+     */
+    private static boolean segmentMatches(
+            final String name, final int start, final int end,
+            final String other, final int ostart, final int oend) {
+        int index = indexStart(name, start, end);
+        int oindex = indexStart(other, ostart, oend);
+        if ((index == -1) != (oindex == -1)) {
+            return false;
+        }
+        if (index != -1 && !indexMatches(name, index + 1, end - 1, other, oindex + 1, oend - 1)) {
+            return false;
+        }
+
+        int e = index == -1 ? end : index;
+        int oe = oindex == -1 ? oend : oindex;
+        if (isStar(name, start, e) || isStar(other, ostart, oe)) {
+            return true;
+        }
+        return unquotedEquals(name, start, e, other, ostart, oe);
+    }
+
+    /**
+     * Matches the contents of two indexes, where the star matches any index.
+     */
+    private static boolean indexMatches(
+            final String name, final int start, final int end,
+            final String other, final int ostart, final int oend) {
+
+        boolean star = isStar(name, start, end);
+        boolean ostar = isStar(other, ostart, oend);
+        if (star && ostar) {
+            return true;
+        } else if (star) {
+            return isNumeric(other, ostart, oend - ostart);
+        } else if (ostar) {
+            return isNumeric(name, start, end - start);
+        }
+        return isNumericEquals(name, start, end - start, other, ostart, oend - ostart);
+    }
+
+    /**
+     * The end position of the segment that starts in <code>start</code>, which is the next dot that no quote holds,
+     * or the end of the region.
+     */
+    private static int segmentEnd(final String name, final int start, final int end) {
+        boolean quoted = false;
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '\\') {
+                i++;
+            } else if (c == '"') {
+                quoted = !quoted;
+            } else if (c == '.' && !quoted) {
+                return i;
+            }
+        }
+        return end;
+    }
+
+    private static int lastSegmentStart(final String name, final int start, final int end) {
+        int last = start;
+        for (int s = start; s < end;) {
+            int e = segmentEnd(name, s, end);
+            if (e == end) {
+                break;
+            }
+            s = e + 1;
+            last = s;
+        }
+        return last;
+    }
+
+    /**
+     * The end position of the name part of a segment, which is the position of its index, if it has one.
+     */
+    private static int nameEnd(final String name, final int start, final int end) {
+        int index = indexStart(name, start, end);
+        return index == -1 ? end : index;
+    }
+
+    /**
+     * The position of the opening bracket of the index that ends the segment, or <code>-1</code> if the segment has
+     * no index. Brackets that a quoted segment holds are plain characters, so <code>"bar[0]"</code> has no index,
+     * while <code>bar[0]</code> and <code>"bar"[0]</code> both have one.
+     */
+    private static int indexStart(final String name, final int start, final int end) {
+        // an index always closes the segment, so a segment that does not end in a bracket cannot hold one
+        if (end - start < 3 || name.charAt(end - 1) != ']') {
+            return -1;
+        }
+
+        int quote = name.indexOf('"', start);
+        if (quote == -1 || quote >= end) {
+            // without a quote to turn them into plain characters, the last opening bracket starts the index
+            int open = name.lastIndexOf('[', end - 2);
+            return open >= start ? open : -1;
+        }
+
+        boolean quoted = false;
+        int open = -1;
+        int close = -1;
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '\\') {
+                i++;
+            } else if (c == '"') {
+                quoted = !quoted;
+            } else if (!quoted && c == '[') {
+                open = i;
+            } else if (!quoted && c == ']') {
+                close = i;
+            }
+        }
+        return close == end - 1 && open != -1 && open < close ? open : -1;
+    }
+
+    /**
+     * Checks if the region holds a star that is a wildcard, which a greedy star cannot stand for. A star that a
+     * quoted segment requiring its quotes holds is a plain character, so it is not a wildcard.
+     */
+    private static boolean hasWildcard(final String name, final int start, final int end) {
+        int star = name.indexOf('*', start);
+        if (star == -1 || star >= end) {
+            return false;
+        }
+        for (int s = start; s < end;) {
+            int e = segmentEnd(name, s, end);
+            if (segmentContainsWildcard(name, s, e)) {
+                return true;
+            }
+            if (e == end) {
+                return false;
+            }
+            s = e + 1;
+        }
+        return false;
+    }
+
+    private static boolean segmentContainsWildcard(final String name, final int start, final int end) {
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '\\') {
+                i++;
+            } else if (c == '"') {
+                int close = closingQuote(name, i, end);
+                if (!hasRequiredQuotes(name, i + 1, close)) {
+                    for (int k = i + 1; k < close; k++) {
+                        if (name.charAt(k) == '\\') {
+                            k++;
+                        } else if (name.charAt(k) == '*') {
                             return true;
                         }
-                        // try to match by keeping the original * and removing the last segment,
-                        // but only if the remaining other does not contain a *
-                        int newOlen = olen - (ooffset + olen - i) - 1;
-                        for (int j = ooffset; j < ooffset + newOlen; j++) {
-                            if (other.charAt(j) == '*') {
-                                return false;
-                            }
-                        }
-                        return equalsInternal(name, offset, len, other, ooffset, newOlen);
                     }
                 }
-            } else if (o == ']' && n == ']') {
-                int otherBeginIndexed = other.lastIndexOf('[', i);
-                int nameBeginIndexed = name.lastIndexOf('[', matchPosition);
-                if (otherBeginIndexed != -1 && nameBeginIndexed != -1) {
-                    if (other.charAt(otherBeginIndexed + 1) == '*' && name.charAt(nameBeginIndexed + 1) == '*') {
-                        i = i - 2;
-                        matchPosition = matchPosition - 3;
-                    } else if (name.charAt(nameBeginIndexed + 1) == '*'
-                            && isNumeric(other, otherBeginIndexed + 1, i - otherBeginIndexed - 1)) {
-                        i = otherBeginIndexed;
-                        matchPosition = matchPosition - 3;
-                        // greedy map - match any ending segments if a last segment is a *[*]
-                        if (matchPosition + 4 == len) {
-                            // try to match by removing the * and the last segment
-                            if (equalsInternal(name, offset, matchPosition + 1,
-                                    other, ooffset, olen - (ooffset + olen - i)))
-                                return true;
-                            // try to match by keeping the original * and removing the last segment plus the brackets
-                            return equalsInternal(name, offset, nameBeginIndexed, other,
-                                    ooffset, olen - (ooffset + olen - otherBeginIndexed));
-                        }
-                    } else if (isNumericEquals(name, nameBeginIndexed + 1, matchPosition - nameBeginIndexed - 1, other,
-                            otherBeginIndexed + 1, i - otherBeginIndexed - 1)) {
-                        i = otherBeginIndexed;
-                        matchPosition = nameBeginIndexed - 1;
-                    } else {
-                        return false;
-                    }
-                    continue;
-                }
-            } else if (o != n) {
+                i = close;
+            } else if (c == '*') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int closingQuote(final String name, final int quote, final int end) {
+        for (int i = quote + 1; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '\\') {
+                i++;
+            } else if (c == '"') {
+                return i;
+            }
+        }
+        return end;
+    }
+
+    /**
+     * Checks if a quoted run requires its quotes, which is the case when it holds a segment boundary.
+     */
+    private static boolean hasRequiredQuotes(final String name, final int start, final int end) {
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '\\') {
+                i++;
+            } else if (c == '.' || c == '[' || c == ']') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the region is a single star, once the quotes that carry no meaning are removed, so both
+     * <code>*</code> and <code>"*"</code> are a wildcard, while <code>"a.*"</code> is a plain name.
+     */
+    private static boolean isStar(final String name, final int start, final int end) {
+        boolean star = false;
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '"' && !isQuoteRequired(name, start, end, i)) {
+                // do nothing
+            } else if (c == '*' && !star) {
+                star = true;
+            } else {
                 return false;
             }
-            matchPosition--;
         }
-        return matchPosition < offset;
+        return star;
+    }
+
+    /**
+     * Checks if the region holds nothing but quotes that carry no meaning, so it is an empty segment, which a
+     * wildcard does not match.
+     */
+    private static boolean isEmpty(final String name, final int start, final int end) {
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '\\') {
+                return false;
+            } else if (c != '"' || isQuoteRequired(name, start, end, i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks if any segment that starts before <code>end</code> holds an index. A greedy star cannot swallow such a
+     * segment, because the index it holds has nothing to match it.
+     */
+    private static boolean hasIndex(final String name, final int start, final int end) {
+        int bracket = name.indexOf('[', start);
+        if (bracket == -1 || bracket >= end) {
+            return false;
+        }
+        for (int s = start; s < end;) {
+            int e = segmentEnd(name, s, end);
+            if (indexStart(name, s, e) != -1) {
+                return true;
+            }
+            s = e + 1;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the character in the given position is a quote that the segment requires, which is the case when the
+     * quoted run holds a segment boundary. Such quotes are part of the comparison, so <code>"bar]"</code> does not
+     * match <code>bar]</code>. A quote that the segment does not require carries no meaning and is not part of the
+     * comparison, so <code>"bar"</code> matches <code>bar</code>. A quote that no other quote closes is required as
+     * well, because {@link #segmentEnd} lets such a run swallow every dot that follows it, and both have to agree on
+     * where the segment ends.
+     */
+    private static boolean isQuoteRequired(final String name, final int start, final int end, final int quote) {
+        // if another quote precedes this one before a segment boundary, this is an inner quote of the run
+        for (int i = quote - 1; i >= start; i--) {
+            char c = name.charAt(i);
+            if (c == '"') {
+                return false;
+            } else if (c == '.' || c == '[' || c == ']') {
+                break;
+            }
+        }
+        // a quote that closes the run before any segment boundary makes it one the segment does not require
+        for (int i = quote + 1; i < end; i++) {
+            char c = name.charAt(i);
+            if (c == '"') {
+                return false;
+            } else if (c == '.' || c == '[' || c == ']') {
+                break;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Compares two segments, skipping the quotes that carry no meaning. An escaped character is compared as it is,
+     * so the escaped quote in <code>"bar\"baz"</code> is part of the name and does not delimit anything.
+     */
+    private static boolean unquotedEquals(final String name, final int start, final int end, final String other,
+            final int ostart, final int oend) {
+        int i = start;
+        int o = ostart;
+        for (;;) {
+            while (i < end && name.charAt(i) == '"' && !isQuoteRequired(name, start, end, i)) {
+                i++;
+            }
+            while (o < oend && other.charAt(o) == '"' && !isQuoteRequired(other, ostart, oend, o)) {
+                o++;
+            }
+            if (i == end || o == oend) {
+                return i == end && o == oend;
+            }
+            char c = name.charAt(i++);
+            if (c != other.charAt(o++)) {
+                return false;
+            }
+            if (c == '\\') {
+                // the escaped character is part of the name, even when it is a quote
+                if (i == end || o == oend) {
+                    return i == end && o == oend;
+                }
+                if (name.charAt(i++) != other.charAt(o++)) {
+                    return false;
+                }
+            }
+        }
     }
 
     /**
@@ -176,15 +514,15 @@ public class PropertyName {
      */
     @Override
     public int hashCode() {
-        return hashCode;
-    }
-
-    private static int hashCode(final String name) {
         int h = 0;
         int length = name.length();
         boolean quotesOpen = false;
         for (int i = 0; i < length; i++) {
             char c = name.charAt(i);
+            if (c == '\\') {
+                i++;
+                continue;
+            }
             if (quotesOpen) {
                 if (c == '"') {
                     quotesOpen = false;

--- a/implementation/src/test/java/io/smallrye/config/ConfigMappingInterfaceTest.java
+++ b/implementation/src/test/java/io/smallrye/config/ConfigMappingInterfaceTest.java
@@ -2265,6 +2265,26 @@ class ConfigMappingInterfaceTest {
         assertEquals("another", mapping.nested().get("quoted").another());
     }
 
+    @Test
+    void mapKeyQuotesMultipleSegments() {
+        SmallRyeConfig config = new SmallRyeConfigBuilder()
+                .withValidateUnknown(false)
+                .withMapping(MapKeyQuotes.class)
+                .withSources(config(
+                        "map.values.\"one.two\"", "1234",
+                        "map.values.\"three.four\".five", "1234",
+                        "map.values.\"six.seven\".\"eight\"", "1234"))
+                .build();
+
+        MapKeyQuotes mapping = config.getConfigMapping(MapKeyQuotes.class);
+
+        // the quotes wrap the whole key, so the key is the quoted segment
+        assertEquals("1234", mapping.values().get("one.two"));
+        // the key spans multiple segments, so the quotes are part of the key
+        assertEquals("1234", mapping.values().get("\"three.four\".five"));
+        assertEquals("1234", mapping.values().get("\"six.seven\".\"eight\""));
+    }
+
     @ConfigMapping(prefix = "map")
     interface MapKeyQuotes {
         Map<String, String> values();

--- a/implementation/src/test/java/io/smallrye/config/PropertyNameTest.java
+++ b/implementation/src/test/java/io/smallrye/config/PropertyNameTest.java
@@ -6,9 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("StringOperationCanBeSimplified")
+@SuppressWarnings({ "StringOperationCanBeSimplified", "EqualsWithItself" })
 class PropertyNameTest {
     @Test
     void propertyNameEquals() {
@@ -70,6 +73,82 @@ class PropertyNameTest {
     void propertyNameEqualsRegions() {
         assertTrue(PropertyName.equals("foo.bar", 4, 3, "bar", 0, 3));
         assertTrue(PropertyName.equals("foo.\"bar\".baz", 4, 5, "*", 0, 1));
+        assertTrue(PropertyName.equals("foo.\"bar\".baz", 4, 5, new String("\"bar\""), 0, 5));
+        assertTrue(PropertyName.equals("foo.\"bar.baz\".qux", 4, 9, new String("\"bar.baz\""), 0, 9));
+        assertTrue(PropertyName.equals("foo.\"bar.baz\".\"qux\"", 14, 5, new String("qux"), 0, 3));
+        assertFalse(PropertyName.equals("foo.\"bar.baz\".qux", 4, 9, new String("bar.baz"), 0, 7));
+    }
+
+    @Test
+    void propertyNameEqualsRegionsQuoteOutsideRegion() {
+        // a quote that falls outside the region is not part of the comparison, so the quote that remains is one
+        // the segment requires and it opens a run that the region never closes. The region below is "a.b".c cut
+        // after the opening quote, which is the two segments a and b".c
+
+        assertTrue(PropertyName.equals("a.*", 0, 3, "foo.\"a.b\".c", 5, 6));
+        assertTrue(PropertyName.equals("foo.\"a.b\".c", 5, 6, "a.*", 0, 3));
+        assertTrue(PropertyName.equals("*.*", 0, 3, "foo.\"a.b\".c", 5, 4));
+        assertTrue(PropertyName.equals("foo.\"a.b\".c", 5, 4, "*.*", 0, 3));
+
+        assertFalse(PropertyName.equals("*.c", 0, 3, "foo.\"a.b\".c", 5, 6));
+        assertFalse(PropertyName.equals("foo.\"a.b\".c", 5, 6, "*.c", 0, 3));
+
+        // the unclosed quote holds the dot, so b".c is a single segment that the star stands for
+        assertTrue(PropertyName.equals("*", 0, 1, "foo.\"a.b\".c", 7, 4));
+        assertTrue(PropertyName.equals("foo.\"a.b\".c", 7, 4, "*", 0, 1));
+
+        assertFalse(PropertyName.equals("*.map.*", 0, 7, "greedy.\"a.b\".map.k", 8, 10));
+        assertFalse(PropertyName.equals("greedy.\"a.b\".map.k", 8, 10, "*.map.*", 0, 7));
+
+        // the same regions, compared as standalone names
+        assertTrue(PropertyName.equals(new String("a.*"), new String("a.b\".c")));
+        assertTrue(PropertyName.equals(new String("*.*"), new String("a.b\"")));
+        assertFalse(PropertyName.equals(new String("*.c"), new String("a.b\".c")));
+        assertTrue(PropertyName.equals(new String("*"), new String("b\".c")));
+        assertFalse(PropertyName.equals(new String("*.map.*"), new String("a.b\".map.k")));
+    }
+
+    @Test
+    void propertyNameEqualsRegionsBracketOutsideRegion() {
+        // an opening bracket that falls outside the region is not part of the comparison, so the region does not
+        // hold an indexed segment and the remaining index digits are plain characters
+        assertFalse(PropertyName.equals("[0]", 0, 3, "foo[0].bar", 4, 2));
+        assertFalse(PropertyName.equals("foo[0].bar", 4, 2, "[0]", 0, 3));
+        assertFalse(PropertyName.equals("[*]", 0, 3, "foo[0].bar", 4, 2));
+        assertFalse(PropertyName.equals("foo[0].bar", 4, 2, "[*]", 0, 3));
+        assertFalse(PropertyName.equals("[0]", 0, 3, "foo[0].bar", 5, 1));
+        assertFalse(PropertyName.equals("foo[0].bar", 5, 1, "[0]", 0, 3));
+        assertFalse(PropertyName.equals("[*]", 0, 3, "x[12].y[3]", 3, 2));
+        assertFalse(PropertyName.equals("x[12].y[3]", 3, 2, "[*]", 0, 3));
+        assertFalse(PropertyName.equals("[*]", 0, 3, "list[*].nested[*]", 16, 1));
+        assertFalse(PropertyName.equals("list[*].nested[*]", 16, 1, "[*]", 0, 3));
+
+        // the bracket may also fall outside the region of the name being matched, which leaves a star that a
+        // plain character follows. A star only stands for a whole segment, so it does not match a part of one
+        assertFalse(PropertyName.equals("list[*].nested[*]", 15, 2, "nested[1]", 0, 9));
+        assertFalse(PropertyName.equals("nested[1]", 0, 9, "list[*].nested[*]", 15, 2));
+
+        // the same regions, compared as standalone names
+        assertFalse(PropertyName.equals(new String("[0]"), new String("0]")));
+        assertFalse(PropertyName.equals(new String("[*]"), new String("0]")));
+        assertFalse(PropertyName.equals(new String("[0]"), new String("]")));
+        assertFalse(PropertyName.equals(new String("[*]"), new String("2]")));
+        assertFalse(PropertyName.equals(new String("[*]"), new String("]")));
+        assertFalse(PropertyName.equals(new String("*]"), new String("nested[1]")));
+    }
+
+    @Test
+    void propertyNameEqualsSameInstanceRegions() {
+        // the regions are compared, even when both sides are the same instance
+        assertTrue(PropertyName.equals("foo.bar.foo", 0, 3, "foo.bar.foo", 8, 3));
+        assertTrue(PropertyName.equals("foo.bar.foo", 0, 11, "foo.bar.foo", 0, 11));
+
+        assertFalse(PropertyName.equals("foo.bar.foo", 0, 3, "foo.bar.foo", 4, 3));
+        assertFalse(PropertyName.equals("foo.bar.foo", 0, 3, "foo.bar.foo", 0, 7));
+        assertFalse(PropertyName.equals("foo.bar.foo", 0, 0, "foo.bar.foo", 0, 1));
+
+        assertTrue(PropertyName.equals("*.foo", 0, 1, "*.foo", 2, 3));
+        assertFalse(PropertyName.equals("*.foo", 0, 1, "*.foo", 1, 4));
     }
 
     @Test
@@ -134,6 +213,315 @@ class PropertyNameTest {
         assertEquals(name("greedy.*.map-list.*[*]").hashCode(), name(("greedy.one.two.map-list.key[0]")).hashCode());
         assertEquals(name("greedy.*.map-list.*[*]").hashCode(), name(("greedy.one.two.map-list.one.two[0]")).hashCode());
 
+        // a greedy star matches ending segments, but it does not match a star, wherever the star is: neither in the
+        // segments that remain nor in the ending segments that the greedy star would match
         assertNotEquals(name("greedy.*"), name(("greedy.*.name")));
+        assertNotEquals(name("greedy.*.name"), name(("greedy.*")));
+        assertNotEquals(name("greedy.*"), name(("greedy.one.*")));
+        assertNotEquals(name("greedy.one.*"), name(("greedy.*")));
+        assertNotEquals(name("greedy.*"), name(("greedy.one.two.*")));
+        assertNotEquals(name("greedy.*"), name(("greedy.\"a.b\".*")));
+        assertNotEquals(name("greedy.\"a.b\".*"), name(("greedy.*")));
+        assertNotEquals(name("foo.*"), name(("foo.bar.*")));
+        assertNotEquals(name("foo.bar.*"), name(("foo.*")));
+        assertNotEquals(name("*"), name(("foo.*")));
+        assertNotEquals(name("foo.*"), name(("*")));
+        assertNotEquals(name("*"), name(("foo.bar.*")));
+        assertNotEquals(name("greedy.*.map.*"), name(("greedy.key.map.one.*")));
+        assertNotEquals(name("greedy.key.map.one.*"), name(("greedy.*.map.*")));
+
+        // a star that the other name matches by position is not swallowed, so it still matches
+        assertEquals(name("greedy.*"), name(new String("greedy.*")));
+        assertEquals(name("greedy.*.map.*"), name(new String("greedy.key.map.*")));
+        assertEquals(name("greedy.key.map.*"), name(new String("greedy.*.map.*")));
+        assertEquals(name("greedy.*.map.*"), name(new String("greedy.*.map.*")));
+    }
+
+    @Test
+    void greedyMapRegions() {
+        // a greedy star matches the ending segments, no matter where the regions start
+        assertTrue(PropertyName.equals("x.greedy.*", 2, 8, "greedy.one.two", 0, 14));
+        assertTrue(PropertyName.equals("greedy.*", 0, 8, "x.greedy.one.two", 2, 14));
+        assertTrue(PropertyName.equals("x.greedy.*", 2, 8, "x.greedy.one.two", 2, 14));
+        assertTrue(PropertyName.equals("p.greedy.*.map.*", 2, 14, "greedy.key.map.one.two", 0, 22));
+        assertTrue(PropertyName.equals("p.g.*.m.*[*]", 2, 10, "g.k.m.one.two[0]", 0, 16));
+
+        assertFalse(PropertyName.equals("p.greedy.*.map.*", 2, 14, "greedy.one.two.map.key", 0, 22));
+        assertFalse(PropertyName.equals("p.greedy.*", 2, 8, "greedy.*.name", 0, 13));
+        assertFalse(PropertyName.equals("p.*", 2, 1, "", 0, 0));
+
+        // the ending segments may require the quotes
+        assertTrue(PropertyName.equals("x.greedy.*", 2, 8, "greedy.one.\"c.d\"", 0, 16));
+        assertTrue(PropertyName.equals("greedy.*", 0, 8, "x.greedy.one.\"c.d\"", 2, 16));
+        assertTrue(PropertyName.equals("x.foo.*", 2, 5, "z.foo.\"a.b\".two", 2, 13));
+        assertTrue(PropertyName.equals("x.foo.*", 2, 5, "z.foo.\"a.b\".\"c.d\"", 2, 15));
+        assertTrue(PropertyName.equals("p.greedy.*.map.*", 2, 14, "greedy.key.map.one.\"c.d\"", 0, 24));
+
+        assertFalse(PropertyName.equals("p.greedy.*.map.*", 2, 14, "greedy.one.two.map.\"c.d\"", 0, 24));
+    }
+
+    @Test
+    void quotedSegment() {
+        // single-segment quote equals the unquoted form
+        assertEquals(name("foo.\"bar\""), name("foo.bar"));
+        assertEquals(name("foo.bar"), name("foo.\"bar\""));
+        assertEquals(name("\"foo\""), name("foo"));
+        assertEquals(name("foo"), name("\"foo\""));
+        assertEquals(name("foo.\"bar\".baz"), name("foo.bar.baz"));
+        assertEquals(name("foo.bar.baz"), name("foo.\"bar\".baz"));
+
+        // multi-segment quote does NOT equal the dot-split form
+        assertNotEquals(name("foo.\"bar.baz\""), name("foo.bar.baz"));
+        assertNotEquals(name("foo.bar.baz"), name("foo.\"bar.baz\""));
+        assertNotEquals(name("foo.\"bar.baz\".qux"), name("foo.bar.baz.qux"));
+        assertNotEquals(name("foo.bar.baz.qux"), name("foo.\"bar.baz\".qux"));
+
+        // wildcard still matches quoted segments regardless of dots inside
+        assertEquals(name("foo.*"), name("foo.\"bar\""));
+        assertEquals(name("foo.*"), name("foo.\"bar.baz\""));
+        assertEquals(name("foo.\"bar\""), name("foo.*"));
+        assertEquals(name("foo.\"bar.baz\""), name("foo.*"));
+    }
+
+    @Test
+    void quotedSegmentEqualsItself() {
+        assertEquals(name(new String("\"foo\"")), name(new String("\"foo\"")));
+        assertEquals(name(new String("foo.\"bar\"")), name(new String("foo.\"bar\"")));
+        assertEquals(name(new String("foo.\"bar\".baz")), name(new String("foo.\"bar\".baz")));
+        assertEquals(name(new String("foo.\"bar\"[0]")), name(new String("foo.\"bar\"[0]")));
+        assertEquals(name(new String("foo.\"bar\".\"baz\"")), name(new String("foo.\"bar\".\"baz\"")));
+
+        assertEquals(name(new String("\"foo.bar\"")), name(new String("\"foo.bar\"")));
+        assertEquals(name(new String("foo.\"bar.baz\"")), name(new String("foo.\"bar.baz\"")));
+        assertEquals(name(new String("foo.\"bar.baz\".qux")), name(new String("foo.\"bar.baz\".qux")));
+        assertEquals(name(new String("foo.\"bar.baz\"[0]")), name(new String("foo.\"bar.baz\"[0]")));
+        assertEquals(name(new String("foo.\"bar.baz\".\"qux.quz\"")), name(new String("foo.\"bar.baz\".\"qux.quz\"")));
+
+        assertNotEquals(name(new String("foo.\"bar\"")), name(new String("foo.\"baz\"")));
+        assertNotEquals(name(new String("foo.\"bar.baz\"")), name(new String("foo.\"bar.qux\"")));
+    }
+
+    @Test
+    void quotedSegmentMixed() {
+        // a quoted single segment is transparent, even when preceded by an opaque quoted segment
+        assertEquals(name("foo.\"bar.baz\".\"qux\""), name("foo.\"bar.baz\".qux"));
+        assertEquals(name("foo.\"bar.baz\".qux"), name("foo.\"bar.baz\".\"qux\""));
+        assertEquals(name("\"foo\".\"bar.baz\".\"qux\""), name("foo.\"bar.baz\".qux"));
+        assertEquals(name("foo.\"bar.baz\".qux"), name("\"foo\".\"bar.baz\".\"qux\""));
+        assertEquals(name("foo.\"bar\"[0]"), name("foo.bar[0]"));
+        assertEquals(name("foo.bar[0]"), name("foo.\"bar\"[0]"));
+
+        assertNotEquals(name("foo.\"bar.baz\".\"qux\""), name("foo.\"bar.qux\".qux"));
+        assertNotEquals(name("foo.\"bar.baz\".qux"), name("foo.bar.baz.\"qux\""));
+
+        // wildcards still match either form
+        assertEquals(name("foo.*.qux"), name("foo.\"bar.baz\".\"qux\""));
+        assertEquals(name("foo.\"bar.baz\".\"qux\""), name("foo.*.qux"));
+        assertEquals(name("foo.\"bar.baz\".*"), name("foo.\"bar.baz\".qux"));
+        assertEquals(name("foo.\"bar.baz\".qux"), name("foo.\"bar.baz\".*"));
+
+        // a greedy star matches the ending segments, quoted or not
+        assertEquals(name("foo.*"), name("foo.one.\"two\""));
+        assertEquals(name("foo.one.\"two\""), name("foo.*"));
+        assertEquals(name("foo.*"), name("foo.\"one\".\"two\""));
+        assertEquals(name("greedy.*.map.*"), name("greedy.key.map.one.\"two\""));
+        assertEquals(name("greedy.key.map.one.\"two\""), name("greedy.*.map.*"));
+
+        // a greedy star also matches ending segments that require the quotes
+        assertEquals(name("foo.*"), name("foo.one.\"c.d\""));
+        assertEquals(name("foo.one.\"c.d\""), name("foo.*"));
+        assertEquals(name("foo.*"), name("foo.\"a.b\".two"));
+        assertEquals(name("foo.\"a.b\".two"), name("foo.*"));
+        assertEquals(name("foo.*"), name("foo.\"a.b\".\"c.d\""));
+        assertEquals(name("foo.\"a.b\".\"c.d\""), name("foo.*"));
+        assertEquals(name("foo.*"), name("foo.one.two.\"c.d\""));
+        assertEquals(name("foo.one.two.\"c.d\""), name("foo.*"));
+        assertEquals(name("*"), name("one.\"c.d\""));
+        assertEquals(name("one.\"c.d\""), name("*"));
+        assertEquals(name("greedy.*.map.*"), name("greedy.key.map.one.\"c.d\""));
+        assertEquals(name("greedy.key.map.one.\"c.d\""), name("greedy.*.map.*"));
+        assertEquals(name("greedy.*.map.*"), name("greedy.\"a.b\".map.one.\"c.d\""));
+        assertEquals(name("greedy.\"a.b\".map.one.\"c.d\""), name("greedy.*.map.*"));
+        assertEquals(name("foo.\"a.b\".*"), name("foo.\"a.b\".one.\"c.d\""));
+        assertEquals(name("foo.\"a.b\".one.\"c.d\""), name("foo.\"a.b\".*"));
+
+        // the segments before the greedy star must still match
+        assertNotEquals(name("greedy.*.map.*"), name("greedy.one.two.map.\"c.d\""));
+        assertNotEquals(name("greedy.one.two.map.\"c.d\""), name("greedy.*.map.*"));
+        assertNotEquals(name("greedy.*.map.*"), name("greedy.one.\"a.b\".map.key"));
+        assertNotEquals(name("greedy.one.\"a.b\".map.key"), name("greedy.*.map.*"));
+        assertNotEquals(name("greedy.*"), name("greedy.*.\"a.b\""));
+
+        // equal names hash the same
+        assertEquals(name("foo.*").hashCode(), name("foo.one.\"c.d\"").hashCode());
+        assertEquals(name("foo.*").hashCode(), name("foo.\"a.b\".\"c.d\"").hashCode());
+        assertEquals(name("greedy.*.map.*").hashCode(), name("greedy.key.map.one.\"c.d\"").hashCode());
+
+        // an empty segment is empty, quoted or not, and a star does not match it
+        assertNotEquals(name("*"), name("\"\""));
+        assertNotEquals(name("\"\""), name("*"));
+        assertNotEquals(name("*.foo"), name("\"\".foo"));
+        assertNotEquals(name("\"\".foo"), name("*.foo"));
+        assertEquals(name("\"\".foo"), name(new String(".foo")));
+    }
+
+    @Test
+    void quotedSegmentIndexed() {
+        // a quote around a bracket is required, so it is not transparent
+        assertNotEquals(name("foo.\"bar[0]\""), name("foo.bar[0]"));
+        assertNotEquals(name("foo.bar[0]"), name("foo.\"bar[0]\""));
+        assertNotEquals(name("foo.\"bar]\""), name("foo.bar]"));
+        assertNotEquals(name("foo.\"bar[\""), name("foo.bar["));
+
+        // a quote outside the brackets is still transparent
+        assertEquals(name("foo.\"bar\"[0]"), name("foo.bar[0]"));
+        assertEquals(name("foo.\"bar\"[*]"), name("foo.bar[0]"));
+
+        // a wildcard matches a quoted segment, brackets or not
+        assertEquals(name("foo.*"), name("foo.\"bar[0]\""));
+        assertEquals(name("foo.\"bar[0]\""), name("foo.*"));
+        assertEquals(name("foo.*"), name("foo.\"a.b[0]\""));
+
+        // equal names hash the same
+        assertNotEquals(name("foo.\"bar[0]\"").hashCode(), name("foo.bar[0]").hashCode());
+        assertEquals(name("foo.\"bar\"[0]").hashCode(), name("foo.bar[0]").hashCode());
+    }
+
+    @Test
+    void quotedSegmentIndexedWildcard() {
+        // the brackets are inside the quotes, so they do not delimit an index and the star is not an index
+        // wildcard, which makes the quoted segment a plain name that only matches the very same name
+        assertNotEquals(name("foo.\"bar[*]\""), name("foo.\"bar[0]\""));
+        assertNotEquals(name("foo.\"bar[0]\""), name("foo.\"bar[*]\""));
+        assertNotEquals(name("\"bar[*]\""), name("\"bar[0]\""));
+        assertNotEquals(name("\"bar[0]\""), name("\"bar[*]\""));
+        assertNotEquals(name("\"[*]\""), name("\"[0]\""));
+        assertNotEquals(name("\"[0]\""), name("\"[*]\""));
+        assertNotEquals(name("foo.\"bar[*]\".baz"), name("foo.\"bar[0]\".baz"));
+        assertNotEquals(name("foo.\"bar[0]\".baz"), name("foo.\"bar[*]\".baz"));
+        assertNotEquals(name("foo.\"a.b[*]\""), name("foo.\"a.b[0]\""));
+        assertNotEquals(name("foo.\"a.b[0]\""), name("foo.\"a.b[*]\""));
+        assertNotEquals(name("foo.\"bar[*]\""), name("foo.\"bar[99]\""));
+        assertNotEquals(name("foo.\"bar[*]\""), name("foo.\"bar[x]\""));
+
+        // a quoted index does not match an unquoted index either, in either direction
+        assertNotEquals(name("foo.\"bar[*]\""), name("foo.bar[0]"));
+        assertNotEquals(name("foo.bar[0]"), name("foo.\"bar[*]\""));
+        assertNotEquals(name("foo.\"bar[*]\""), name("foo.bar[*]"));
+        assertNotEquals(name("foo.bar[*]"), name("foo.\"bar[*]\""));
+        assertNotEquals(name("foo.\"bar[0]\""), name("foo.bar[*]"));
+        assertNotEquals(name("foo.bar[*]"), name("foo.\"bar[0]\""));
+        assertNotEquals(name("foo.\"bar[*]\""), name("foo.*[*]"));
+        assertNotEquals(name("foo.*[*]"), name("foo.\"bar[*]\""));
+
+        // a quoted index still equals the very same quoted index
+        assertEquals(name(new String("foo.\"bar[*]\"")), name(new String("foo.\"bar[*]\"")));
+        assertEquals(name(new String("foo.\"[*]\"")), name(new String("foo.\"[*]\"")));
+        assertEquals(name(new String("foo.\"a.b[*]\"")), name(new String("foo.\"a.b[*]\"")));
+        assertEquals(name(new String("foo.\"bar[*]\".baz")), name(new String("foo.\"bar[*]\".baz")));
+        assertEquals(name(new String("\"bar[*]\"")), name(new String("\"bar[*]\"")));
+
+        // a quote the segment does not require is still transparent, so the index is still an index
+        assertEquals(name("foo.\"bar\"[*]"), name("foo.bar[0]"));
+        assertEquals(name("foo.bar[0]"), name("foo.\"bar\"[*]"));
+        assertEquals(name("foo.\"bar\"[*]"), name("foo.\"bar\"[0]"));
+        assertEquals(name("foo.\"bar\"[0]"), name("foo.\"bar\"[*]"));
+
+        // a wildcard segment still matches the whole quoted segment, index wildcard or not
+        assertEquals(name("foo.*"), name("foo.\"bar[*]\""));
+        assertEquals(name("foo.\"bar[*]\""), name("foo.*"));
+        assertEquals(name("*"), name("foo.\"bar[*]\""));
+
+        // a literal bracket inside the quotes equals itself, even after an unquoted index
+        assertEquals(name(new String("bar[0].\"bar]\"")), name(new String("bar[0].\"bar]\"")));
+        assertEquals(name("bar[*].\"bar]\""), name("bar[0].\"bar]\""));
+        assertEquals(name("bar[0].\"bar]\""), name("bar[*].\"bar]\""));
+
+        // equal names hash the same
+        assertEquals(name("foo.*").hashCode(), name("foo.\"bar[*]\"").hashCode());
+        assertEquals(name("bar[*].\"bar]\"").hashCode(), name("bar[0].\"bar]\"").hashCode());
+        assertEquals(name("foo.\"bar\"[*]").hashCode(), name("foo.bar[0]").hashCode());
+    }
+
+    @Test
+    void quotedSegmentStar() {
+        // a star inside a quote the segment requires is a plain character, not a wildcard
+        assertNotEquals(name("foo.\"a.*\""), name("foo.\"a.b\""));
+        assertNotEquals(name("foo.\"a.b\""), name("foo.\"a.*\""));
+        assertNotEquals(name("foo.\"a.*\""), name("foo.\"a.b*c\""));
+        assertNotEquals(name("foo.\"a.b*c\""), name("foo.\"a.*\""));
+        assertNotEquals(name("\"*.b\""), name("\"a.b\""));
+        assertNotEquals(name("\"a.b\""), name("\"*.b\""));
+        assertNotEquals(name("\"[*]\""), name("\"[9]\""));
+
+        // which makes it equal to the very same name
+        assertEquals(name(new String("foo.\"a.*\"")), name(new String("foo.\"a.*\"")));
+        assertEquals(name(new String("foo.\"a.b*c\"")), name(new String("foo.\"a.b*c\"")));
+        assertEquals(name(new String("\"a.b*\"")), name(new String("\"a.b*\"")));
+        assertEquals(name(new String("\"*.b\"")), name(new String("\"*.b\"")));
+
+        // a quote the segment does not require carries no meaning, so the star is still a wildcard
+        assertEquals(name("foo.\"*\""), name("foo.bar"));
+        assertEquals(name("foo.bar"), name("foo.\"*\""));
+        assertEquals(name("\"*\""), name("foo"));
+        assertEquals(name("foo.\"*\""), name("foo.*"));
+        assertEquals(name("foo.\"*\".baz"), name("foo.bar.baz"));
+
+        // a wildcard segment still matches a quoted segment that holds a star
+        assertEquals(name("foo.*"), name("foo.\"a.*\""));
+        assertEquals(name("foo.\"a.*\""), name("foo.*"));
+        assertEquals(name("foo.*"), name("foo.\"a.b*c\""));
+
+        // a greedy star swallows ending segments that hold a star, because that star is a plain character
+        assertEquals(name("greedy.*"), name("greedy.one.\"a.*\""));
+        assertEquals(name("greedy.one.\"a.*\""), name("greedy.*"));
+        assertEquals(name("greedy.*"), name("greedy.\"a.*\".one"));
+        assertEquals(name("greedy.*.map.*"), name("greedy.k.map.one.\"a.*\""));
+
+        // but it still refuses to swallow a wildcard, including one that a redundant quote holds
+        assertNotEquals(name("greedy.*"), name("greedy.one.*"));
+        assertNotEquals(name("greedy.*"), name("greedy.\"a.b\".*"));
+        assertNotEquals(name("greedy.*"), name("greedy.one.\"*\""));
+
+        // equal names hash the same
+        assertEquals(name("foo.\"*\"").hashCode(), name("foo.bar").hashCode());
+        assertEquals(name("foo.*").hashCode(), name("foo.\"a.*\"").hashCode());
+        assertEquals(name("greedy.*").hashCode(), name("greedy.one.\"a.*\"").hashCode());
+    }
+
+    @Test
+    void unbalancedQuote() {
+        // a quote that no other quote closes opens a run that swallows every dot that follows it, so the tail is a
+        // single opaque segment and the quote itself is a plain character that only another quote matches
+        assertNotEquals(name("foo"), name("\"foo"));
+        assertNotEquals(name("foo"), name("foo\""));
+        assertNotEquals(name("foo.bar"), name("\"foo.bar"));
+        assertNotEquals(name("foo.bar"), name("foo\".bar"));
+        assertNotEquals(name("foo.*"), name("foo\".*"));
+        assertNotEquals(name("b\".*"), name("b\".."));
+
+        // and a wildcard stands for that one segment, whatever it holds
+        assertEquals(name("*"), name("b\".c"));
+        assertEquals(name("foo.*"), name("foo.b\".c"));
+
+        // segmentEnd and the quoting rules have to agree on where a segment ends, or matching one name against the
+        // other splits them into a different number of segments and equals stops being symmetric
+        String[] segments = { "foo", "*", "\"foo\"", "bar[0]", "", "\"foo", "foo\"", "b\"" };
+        List<String> names = new ArrayList<>();
+        for (String one : segments) {
+            names.add(one);
+            for (String two : segments) {
+                names.add(one + "." + two);
+                for (String three : segments) {
+                    names.add(one + "." + two + "." + three);
+                }
+            }
+        }
+        for (String left : names) {
+            for (String right : names) {
+                assertEquals(PropertyName.equals(left, right), PropertyName.equals(right, left),
+                        "asymmetric: " + left + " / " + right);
+            }
+        }
     }
 }

--- a/implementation/src/test/java/io/smallrye/config/PropertyNamesMatcherTest.java
+++ b/implementation/src/test/java/io/smallrye/config/PropertyNamesMatcherTest.java
@@ -128,6 +128,30 @@ class PropertyNamesMatcherTest {
         assertTrue(matcher.matches("name.one"));
     }
 
+    @Test
+    void quotedSegments() {
+        PropertyNamesMatcher<String> matcher = new PropertyNamesMatcher<>();
+        matcher.add("map.*.\"one\"", "one");
+        matcher.add("map.*.\"one.two\"", "two");
+        matcher.add("map.*.three", "three");
+
+        assertTrue(matcher.matches("map.key.\"one\""));
+        assertTrue(matcher.matches("map.key.one"));
+        assertTrue(matcher.matches("map.key.\"one.two\""));
+        assertTrue(matcher.matches("map.key.three"));
+        assertTrue(matcher.matches("map.key.\"three\""));
+        assertFalse(matcher.matches("map.key.one.two"));
+
+        assertEquals("one", matcher.get("map.key.\"one\""));
+        assertEquals("one", matcher.get("map.key.one"));
+        assertEquals("two", matcher.get("map.key.\"one.two\""));
+        assertEquals("three", matcher.get("map.key.three"));
+        assertEquals("three", matcher.get("map.key.\"three\""));
+
+        assertTrue(matcher.matches("map.\"key.one\".\"one.two\""));
+        assertTrue(matcher.matches("map.\"key\".three"));
+    }
+
     @ConfigMapping
     interface Conflicts {
         Map<String, Nested> map();

--- a/implementation/src/test/java/io/smallrye/config/SecretKeysTest.java
+++ b/implementation/src/test/java/io/smallrye/config/SecretKeysTest.java
@@ -86,7 +86,7 @@ class SecretKeysTest {
 
         MappingSecret mapping = config.getConfigMapping(MappingSecret.class);
         assertEquals("secret", mapping.secret());
-        assertThrows(SecurityException.class, () -> config.getConfigValue("mapping.secret").getValue(),
+        assertThrows(SecurityException.class, () -> config.getConfigValue("mapping.secret"),
                 "Not allowed to access secret key mapping.secret");
     }
 


### PR DESCRIPTION
  The rewrite addresses several cases the old algorithm handled incorrectly:

- Brackets inside quotes are plain characters — `foo."bar[0]"` no longer matches `foo.bar[0]` or `foo."bar[*]"`.
- Transparent vs. required quotes — `"bar"` matches `bar` (quotes are not needed), but `"bar.baz"` does not match `bar.baz` (the dot requires the quotes). The new engine distinguishes these consistently across all call paths (same as `NameIterator`).
- Greedy trailing star — `foo.*` correctly consumes multiple trailing segments but does not consume segments that contain a wildcard or an index, which it has nothing to match against.
- Empty segments — `*` no longer matches `""` or a leading-dot name; a wildcard stands for a non-structural segment, not an empty one.
- `hashCode` escape handling — a backslash in the name was previously not skipped, causing the character after it to contribute to the hash independently. It is now correctly treated as an escape prefix.
